### PR TITLE
Protocol refactoring

### DIFF
--- a/lib/bno080/BNO080.cpp
+++ b/lib/bno080/BNO080.cpp
@@ -354,6 +354,7 @@ uint16_t BNO080::parseInputReport(void)
 		shtpData[5] == SENSOR_REPORTID_AR_VR_STABILIZED_ROTATION_VECTOR ||
 		shtpData[5] == SENSOR_REPORTID_AR_VR_STABILIZED_GAME_ROTATION_VECTOR)
 	{
+		hasNewQuaternion = true;
 		quatAccuracy = status;
 		rawQuatI = data1;
 		rawQuatJ = data2;
@@ -363,10 +364,29 @@ uint16_t BNO080::parseInputReport(void)
 		//Only available on rotation vector and ar/vr stabilized rotation vector,
 		// not game rot vector and not ar/vr stabilized rotation vector
 		rawQuatRadianAccuracy = data5;
+
+		if(shtpData[5] == SENSOR_REPORTID_ROTATION_VECTOR || shtpData[5] == SENSOR_REPORTID_AR_VR_STABILIZED_ROTATION_VECTOR) {
+			hasNewMagQuaternion = true;
+			quatMagAccuracy = status;
+			rawMagQuatI = data1;
+			rawMagQuatJ = data2;
+			rawMagQuatK = data3;
+			rawMagQuatReal = data4;
+			rawMagQuatRadianAccuracy = data5;
+		}
+		if(shtpData[5] == SENSOR_REPORTID_GAME_ROTATION_VECTOR || shtpData[5] == SENSOR_REPORTID_AR_VR_STABILIZED_GAME_ROTATION_VECTOR) {
+			hasNewGameQuaternion = true;
+			quatGameAccuracy = status;
+			rawGameQuatI = data1;
+			rawGameQuatJ = data2;
+			rawGameQuatK = data3;
+			rawGameQuatReal = data4;
+		}
 	}
 	else if (shtpData[5] == SENSOR_REPORTID_TAP_DETECTOR)
 	{
 		tapDetector = shtpData[5 + 4]; //Byte 4 only
+		hasNewTap = false;
 	}
 	else if (shtpData[5] == SENSOR_REPORTID_STEP_COUNTER)
 	{
@@ -517,6 +537,40 @@ void BNO080::getQuat(float &i, float &j, float &k, float &real, float &radAccura
 	real = qToFloat(rawQuatReal, rotationVector_Q1);
 	radAccuracy = qToFloat(rawQuatRadianAccuracy, rotationVector_Q1);
 	accuracy = quatAccuracy;
+	hasNewQuaternion = false;
+}
+
+void BNO080::getGameQuat(float &i, float &j, float &k, float &real, uint8_t &accuracy)
+{
+	i = qToFloat(rawGameQuatI, rotationVector_Q1);
+	j = qToFloat(rawGameQuatJ, rotationVector_Q1);
+	k = qToFloat(rawGameQuatK, rotationVector_Q1);
+	real = qToFloat(rawGameQuatReal, rotationVector_Q1);
+	accuracy = quatGameAccuracy;
+	hasNewGameQuaternion = false;
+}
+
+void BNO080::getMagQuat(float &i, float &j, float &k, float &real, float &radAccuracy, uint8_t &accuracy)
+{
+	i = qToFloat(rawMagQuatI, rotationVector_Q1);
+	j = qToFloat(rawMagQuatJ, rotationVector_Q1);
+	k = qToFloat(rawMagQuatK, rotationVector_Q1);
+	real = qToFloat(rawMagQuatReal, rotationVector_Q1);
+	radAccuracy = qToFloat(rawMagQuatRadianAccuracy, rotationVector_Q1);
+	accuracy = quatMagAccuracy;
+	hasNewMagQuaternion = false;
+}
+
+bool BNO080::hasNewQuat() {
+	return hasNewQuaternion;
+}
+
+bool BNO080::hasNewGameQuat() {
+	return hasNewGameQuaternion;
+}
+
+bool BNO080::hasNewMagQuat() {
+	return hasNewMagQuaternion;
 }
 
 //Return the rotation vector quaternion I
@@ -746,6 +800,10 @@ uint8_t BNO080::getTapDetector()
 	uint8_t previousTapDetector = tapDetector;
 	tapDetector = 0; //Reset so user code sees exactly one tap
 	return (previousTapDetector);
+}
+
+bool BNO080::getTapDetected() {
+	return hasNewTap;
 }
 
 //Return the step count
@@ -1341,6 +1399,7 @@ void BNO080::saveCalibration()
 //Returns false if failed
 boolean BNO080::waitForI2C()
 {
+	i2cTimedOut = false;
 	for (uint8_t counter = 0; counter < 100; counter++) //Don't got more than 255
 	{
 		if (_i2cPort->available() > 0)
@@ -1350,7 +1409,13 @@ boolean BNO080::waitForI2C()
 
 	if (_printDebug == true)
 		_debugPort->println(F("I2C timeout"));
+	i2cTimedOut = true;
 	return (false);
+}
+
+boolean BNO080::I2CTimedOut()
+{
+	return i2cTimedOut;
 }
 
 //Blocking wait for BNO080 to assert (pull low) the INT pin

--- a/lib/bno080/BNO080.cpp
+++ b/lib/bno080/BNO080.cpp
@@ -386,7 +386,7 @@ uint16_t BNO080::parseInputReport(void)
 	else if (shtpData[5] == SENSOR_REPORTID_TAP_DETECTOR)
 	{
 		tapDetector = shtpData[5 + 4]; //Byte 4 only
-		hasNewTap = false;
+		hasNewTap = true;
 	}
 	else if (shtpData[5] == SENSOR_REPORTID_STEP_COUNTER)
 	{
@@ -799,6 +799,7 @@ uint8_t BNO080::getTapDetector()
 {
 	uint8_t previousTapDetector = tapDetector;
 	tapDetector = 0; //Reset so user code sees exactly one tap
+	hasNewTap = false;
 	return (previousTapDetector);
 }
 

--- a/lib/bno080/BNO080.h
+++ b/lib/bno080/BNO080.h
@@ -155,6 +155,7 @@ public:
 	float qToFloat(int16_t fixedPointValue, uint8_t qPoint); //Given a Q value, converts fixed point floating to regular floating point number
 
 	boolean waitForI2C(); //Delay based polling for I2C traffic
+	boolean I2CTimedOut(); // Check if last time I2C timed out
 	boolean waitForSPI(); //Delay based polling for INT pin to go low
 	boolean receivePacket(void);
 	boolean getData(uint16_t bytesRemaining); //Given a number of bytes, send the requests in I2C_BUFFER_LENGTH chunks
@@ -184,7 +185,12 @@ public:
 	uint16_t parseInputReport(void);   //Parse sensor readings out of report
 	uint16_t parseCommandReport(void); //Parse command responses out of report
 
+	bool hasNewQuat();
+	bool hasNewGameQuat();
+	bool hasNewMagQuat();
 	void getQuat(float &i, float &j, float &k, float &real, float &radAccuracy, uint8_t &accuracy);
+	void getGameQuat(float &i, float &j, float &k, float &real, uint8_t &accuracy);
+	void getMagQuat(float &i, float &j, float &k, float &real, float &radAccuracy, uint8_t &accuracy);
 	float getQuatI();
 	float getQuatJ();
 	float getQuatK();
@@ -232,6 +238,7 @@ public:
 	boolean calibrationComplete();   //Checks ME Cal response for byte 5, R0 - Status
 
 	uint8_t getTapDetector();
+	bool getTapDetected();
 	uint32_t getTimeStamp();
 	uint16_t getStepCount();
 	uint8_t getStabilityClassifier();
@@ -286,6 +293,7 @@ private:
 	//Variables
 	TwoWire *_i2cPort;		//The generic connection to user's chosen I2C hardware
 	uint8_t _deviceAddress; //Keeps track of I2C address. setI2CAddress changes this.
+	bool i2cTimedOut = false;
 
 	Stream *_debugPort;			 //The stream to send debug messages to if enabled. Usually Serial.
 	boolean _printDebug = false; //Flag to print debugging variables
@@ -303,8 +311,12 @@ private:
 	uint16_t rawGyroX, rawGyroY, rawGyroZ, gyroAccuracy;
 	uint16_t rawMagX, rawMagY, rawMagZ, magAccuracy;
 	uint16_t rawQuatI, rawQuatJ, rawQuatK, rawQuatReal, rawQuatRadianAccuracy, quatAccuracy;
+	uint16_t rawGameQuatI, rawGameQuatJ, rawGameQuatK, rawGameQuatReal, quatGameAccuracy;
+	uint16_t rawMagQuatI, rawMagQuatJ, rawMagQuatK, rawMagQuatReal, rawMagQuatRadianAccuracy, quatMagAccuracy;
+	bool hasNewQuaternion, hasNewGameQuaternion, hasNewMagQuaternion;
 	uint16_t rawFastGyroX, rawFastGyroY, rawFastGyroZ;
 	uint8_t tapDetector;
+	bool hasNewTap;
 	uint16_t stepCount;
 	uint32_t timeStamp;
 	uint8_t stabilityClassifier;

--- a/lib/math/quat.cpp
+++ b/lib/math/quat.cpp
@@ -36,20 +36,20 @@
 // and similar for other axes.
 // This implementation uses XYZ convention (Z is the first rotation).
 void Quat::set_euler_xyz(const Vector3& p_euler) {
-	double half_a1 = p_euler.x * 0.5;
-	double half_a2 = p_euler.y * 0.5;
-	double half_a3 = p_euler.z * 0.5;
+	float half_a1 = p_euler.x * 0.5;
+	float half_a2 = p_euler.y * 0.5;
+	float half_a3 = p_euler.z * 0.5;
 
 	// R = X(a1).Y(a2).Z(a3) convention for Euler angles.
 	// Conversion to quaternion as listed in https://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/19770024290.pdf (page A-2)
 	// a3 is the angle of the first rotation, following the notation in this reference.
 
-	double cos_a1 = std::cos(half_a1);
-	double sin_a1 = std::sin(half_a1);
-	double cos_a2 = std::cos(half_a2);
-	double sin_a2 = std::sin(half_a2);
-	double cos_a3 = std::cos(half_a3);
-	double sin_a3 = std::sin(half_a3);
+	float cos_a1 = std::cos(half_a1);
+	float sin_a1 = std::sin(half_a1);
+	float cos_a2 = std::cos(half_a2);
+	float sin_a2 = std::sin(half_a2);
+	float cos_a3 = std::cos(half_a3);
+	float sin_a3 = std::sin(half_a3);
 
 	set(sin_a1 * cos_a2 * cos_a3 + sin_a2 * sin_a3 * cos_a1,
 		-sin_a1 * sin_a3 * cos_a2 + sin_a2 * cos_a1 * cos_a3,
@@ -71,20 +71,20 @@ Vector3 Quat::get_euler_xyz() const {
 // and similar for other axes.
 // This implementation uses YXZ convention (Z is the first rotation).
 void Quat::set_euler_yxz(const Vector3& p_euler) {
-	double half_a1 = p_euler.y * 0.5;
-	double half_a2 = p_euler.x * 0.5;
-	double half_a3 = p_euler.z * 0.5;
+	float half_a1 = p_euler.y * 0.5;
+	float half_a2 = p_euler.x * 0.5;
+	float half_a3 = p_euler.z * 0.5;
 
 	// R = Y(a1).X(a2).Z(a3) convention for Euler angles.
 	// Conversion to quaternion as listed in https://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/19770024290.pdf (page A-6)
 	// a3 is the angle of the first rotation, following the notation in this reference.
 
-	double cos_a1 = std::cos(half_a1);
-	double sin_a1 = std::sin(half_a1);
-	double cos_a2 = std::cos(half_a2);
-	double sin_a2 = std::sin(half_a2);
-	double cos_a3 = std::cos(half_a3);
-	double sin_a3 = std::sin(half_a3);
+	float cos_a1 = std::cos(half_a1);
+	float sin_a1 = std::sin(half_a1);
+	float cos_a2 = std::cos(half_a2);
+	float sin_a2 = std::sin(half_a2);
+	float cos_a3 = std::cos(half_a3);
+	float sin_a3 = std::sin(half_a3);
 
 	set(sin_a1 * cos_a2 * sin_a3 + cos_a1 * sin_a2 * cos_a3,
 		sin_a1 * cos_a2 * cos_a3 - cos_a1 * sin_a2 * sin_a3,
@@ -121,7 +121,7 @@ bool Quat::is_equal_approx(const Quat& p_quat) const {
 	return Math::is_equal_approx(x, p_quat.x) && Math::is_equal_approx(y, p_quat.y) && Math::is_equal_approx(z, p_quat.z) && Math::is_equal_approx(w, p_quat.w);
 }
 
-double Quat::length() const {
+float Quat::length() const {
 	return std::sqrt(length_squared());
 }
 
@@ -144,13 +144,13 @@ Quat Quat::inverse() const {
 	return Quat(-x, -y, -z, w);
 }
 
-Quat Quat::slerp(const Quat& q, const double& t) const {
+Quat Quat::slerp(const Quat& q, const float& t) const {
 #ifdef MATH_CHECKS
 	ERR_FAIL_COND_V_MSG(!is_normalized(), Quat(), "The start quaternion must be normalized.");
 	ERR_FAIL_COND_V_MSG(!q.is_normalized(), Quat(), "The end quaternion must be normalized.");
 #endif
 	Quat to1;
-	double omega, cosom, sinom, scale0, scale1;
+	float omega, cosom, sinom, scale0, scale1;
 
 	// calc cosine
 	cosom = dot(q);
@@ -193,20 +193,20 @@ Quat Quat::slerp(const Quat& q, const double& t) const {
 		scale0 * w + scale1 * to1.w);
 }
 
-Quat Quat::slerpni(const Quat& q, const double& t) const {
+Quat Quat::slerpni(const Quat& q, const float& t) const {
 #ifdef MATH_CHECKS
 	ERR_FAIL_COND_V_MSG(!is_normalized(), Quat(), "The start quaternion must be normalized.");
 	ERR_FAIL_COND_V_MSG(!q.is_normalized(), Quat(), "The end quaternion must be normalized.");
 #endif
 	const Quat& from = *this;
 
-	double dot = from.dot(q);
+	float dot = from.dot(q);
 
 	if (std::abs(dot) > 0.9999) {
 		return from;
 	}
 
-	double theta = std::acos(dot),
+	float theta = std::acos(dot),
 		sinT = 1.0 / std::sin(theta),
 		newFactor = std::sin(t * theta) * sinT,
 		invFactor = std::sin((1.0 - t) * theta) * sinT;
@@ -217,30 +217,30 @@ Quat Quat::slerpni(const Quat& q, const double& t) const {
 		invFactor * from.w + newFactor * q.w);
 }
 
-Quat Quat::cubic_slerp(const Quat& q, const Quat& prep, const Quat& postq, const double& t) const {
+Quat Quat::cubic_slerp(const Quat& q, const Quat& prep, const Quat& postq, const float& t) const {
 #ifdef MATH_CHECKS
 	ERR_FAIL_COND_V_MSG(!is_normalized(), Quat(), "The start quaternion must be normalized.");
 	ERR_FAIL_COND_V_MSG(!q.is_normalized(), Quat(), "The end quaternion must be normalized.");
 #endif
 	//the only way to do slerp :|
-	double t2 = (1.0 - t) * t * 2;
+	float t2 = (1.0 - t) * t * 2;
 	Quat sp = this->slerp(q, t);
 	Quat sq = prep.slerpni(postq, t);
 	return sp.slerpni(sq, t2);
 }
 
-void Quat::set_axis_angle(const Vector3& axis, const double& angle) {
+void Quat::set_axis_angle(const Vector3& axis, const float& angle) {
 #ifdef MATH_CHECKS
 	ERR_FAIL_COND_MSG(!axis.is_normalized(), "The axis Vector3 must be normalized.");
 #endif
-	double d = axis.length();
+	float d = axis.length();
 	if (d == 0) {
 		set(0, 0, 0, 0);
 	}
 	else {
-		double sin_angle = std::sin(angle * 0.5);
-		double cos_angle = std::cos(angle * 0.5);
-		double s = sin_angle / d;
+		float sin_angle = std::sin(angle * 0.5);
+		float cos_angle = std::cos(angle * 0.5);
+		float s = sin_angle / d;
 		set(axis.x * s, axis.y * s, axis.z * s,
 			cos_angle);
 	}

--- a/lib/math/quat.h
+++ b/lib/math/quat.h
@@ -43,28 +43,28 @@ class Quat {
 public:
 	union {
 		struct {
-			double x;
-			double y;
-			double z;
-			double w;
+			float x;
+			float y;
+			float z;
+			float w;
 		};
-		double components[4] = { 0, 0, 0, 1.0 };
+		float components[4] = { 0, 0, 0, 1.0 };
 	};
 
-	inline double& operator[](int idx) {
+	inline float& operator[](int idx) {
 		return components[idx];
 	}
-	inline const double& operator[](int idx) const {
+	inline const float& operator[](int idx) const {
 		return components[idx];
 	}
-	inline double length_squared() const;
+	inline float length_squared() const;
 	bool is_equal_approx(const Quat& p_quat) const;
-	double length() const;
+	float length() const;
 	void normalize();
 	Quat normalized() const;
 	bool is_normalized() const;
 	Quat inverse() const;
-	inline double dot(const Quat& q) const;
+	inline float dot(const Quat& q) const;
 
 	void set_euler_xyz(const Vector3& p_euler);
 	Vector3 get_euler_xyz() const;
@@ -74,11 +74,11 @@ public:
 	void set_euler(const Vector3& p_euler) { set_euler_yxz(p_euler); };
 	Vector3 get_euler() const { return get_euler_yxz(); };
 
-	Quat slerp(const Quat& q, const double& t) const;
-	Quat slerpni(const Quat& q, const double& t) const;
-	Quat cubic_slerp(const Quat& q, const Quat& prep, const Quat& postq, const double& t) const;
+	Quat slerp(const Quat& q, const float& t) const;
+	Quat slerpni(const Quat& q, const float& t) const;
+	Quat cubic_slerp(const Quat& q, const Quat& prep, const Quat& postq, const float& t) const;
 
-	void set_axis_angle(const Vector3& axis, const double& angle);
+	void set_axis_angle(const Vector3& axis, const float& angle);
 	inline void get_axis_angle(Vector3& r_axis, double& r_angle) const {
 		r_angle = 2 * std::acos(w);
 		double r = ((double)1) / std::sqrt(1 - w * w);
@@ -103,7 +103,7 @@ public:
 #endif
 		Vector3 u(x, y, z);
 		Vector3 uv = u.cross(v);
-		return v + ((uv * w) + u.cross(uv)) * ((double)2);
+		return v + ((uv * w) + u.cross(uv)) * ((float)2);
 	}
 
 	inline Vector3 xform_inv(const Vector3& v) const {
@@ -112,18 +112,18 @@ public:
 
 	inline void operator+=(const Quat& q);
 	inline void operator-=(const Quat& q);
-	inline void operator*=(const double& s);
-	inline void operator/=(const double& s);
+	inline void operator*=(const float& s);
+	inline void operator/=(const float& s);
 	inline Quat operator+(const Quat& q2) const;
 	inline Quat operator-(const Quat& q2) const;
 	inline Quat operator-() const;
-	inline Quat operator*(const double& s) const;
-	inline Quat operator/(const double& s) const;
+	inline Quat operator*(const float& s) const;
+	inline Quat operator/(const float& s) const;
 
 	inline bool operator==(const Quat& p_quat) const;
 	inline bool operator!=(const Quat& p_quat) const;
 
-	inline void set(double p_x, double p_y, double p_z, double p_w) {
+	inline void set(float p_x, float p_y, float p_z, float p_w) {
 		x = p_x;
 		y = p_y;
 		z = p_z;
@@ -131,13 +131,13 @@ public:
 	}
 
 	inline Quat() {}
-	inline Quat(double p_x, double p_y, double p_z, double p_w) :
+	inline Quat(float p_x, float p_y, float p_z, float p_w) :
 		x(p_x),
 		y(p_y),
 		z(p_z),
 		w(p_w) {
 	}
-	Quat(const Vector3& axis, const double& angle) { set_axis_angle(axis, angle); }
+	Quat(const Vector3& axis, const float& angle) { set_axis_angle(axis, angle); }
 
 	Quat(const Vector3& euler) { set_euler(euler); }
 	Quat(const Quat& q) :
@@ -158,7 +158,7 @@ public:
 	Quat(const Vector3& v0, const Vector3& v1) // shortest arc
 	{
 		Vector3 c = v0.cross(v1);
-		double d = v0.dot(v1);
+		float d = v0.dot(v1);
 
 		if (d < -1.0 + CMP_EPSILON) {
 			x = 0;
@@ -167,8 +167,8 @@ public:
 			w = 0;
 		}
 		else {
-			double s = std::sqrt((1.0 + d) * 2.0);
-			double rs = 1.0 / s;
+			float s = std::sqrt((1.0 + d) * 2.0);
+			float rs = 1.0 / s;
 
 			x = c.x * rs;
 			y = c.y * rs;
@@ -178,11 +178,11 @@ public:
 	}
 };
 
-double Quat::dot(const Quat& q) const {
+float Quat::dot(const Quat& q) const {
 	return x * q.x + y * q.y + z * q.z + w * q.w;
 }
 
-double Quat::length_squared() const {
+float Quat::length_squared() const {
 	return dot(*this);
 }
 
@@ -200,14 +200,14 @@ void Quat::operator-=(const Quat& q) {
 	w -= q.w;
 }
 
-void Quat::operator*=(const double& s) {
+void Quat::operator*=(const float& s) {
 	x *= s;
 	y *= s;
 	z *= s;
 	w *= s;
 }
 
-void Quat::operator/=(const double& s) {
+void Quat::operator/=(const float& s) {
 	*this *= 1.0 / s;
 }
 
@@ -226,11 +226,11 @@ Quat Quat::operator-() const {
 	return Quat(-q2.x, -q2.y, -q2.z, -q2.w);
 }
 
-Quat Quat::operator*(const double& s) const {
+Quat Quat::operator*(const float& s) const {
 	return Quat(x * s, y * s, z * s, w * s);
 }
 
-Quat Quat::operator/(const double& s) const {
+Quat Quat::operator/(const float& s) const {
 	return *this * (1.0 / s);
 }
 
@@ -242,7 +242,7 @@ bool Quat::operator!=(const Quat& p_quat) const {
 	return x != p_quat.x || y != p_quat.y || z != p_quat.z || w != p_quat.w;
 }
 
-inline Quat operator*(const double& p_real, const Quat& p_quat) {
+inline Quat operator*(const float& p_real, const Quat& p_quat) {
 	return p_quat * p_real;
 }
 

--- a/lib/math/vector3.h
+++ b/lib/math/vector3.h
@@ -44,30 +44,30 @@ struct Vector3 {
 
 	union {
 		struct {
-			double x;
-			double y;
-			double z;
+			float x;
+			float y;
+			float z;
 		};
 
-		double coord[3] = { 0 };
+		float coord[3] = { 0 };
 	};
 
-	inline const double& operator[](int p_axis) const {
+	inline const float& operator[](int p_axis) const {
 		return coord[p_axis];
 	}
 
-	inline double& operator[](int p_axis) {
+	inline float& operator[](int p_axis) {
 		return coord[p_axis];
 	}
 
-	void set_axis(int p_axis, double p_value);
-	double get_axis(int p_axis) const;
+	void set_axis(int p_axis, float p_value);
+	float get_axis(int p_axis) const;
 
 	int min_axis() const;
 	int max_axis() const;
 
-	inline double length() const;
-	inline double length_squared() const;
+	inline float length() const;
+	inline float length_squared() const;
 
 	inline void normalize();
 	inline Vector3 normalized() const;
@@ -79,19 +79,19 @@ struct Vector3 {
 	// void snap(Vector3 p_val);
 	// Vector3 snapped(Vector3 p_val) const;
 
-	void rotate(const Vector3& p_axis, double p_phi);
-	Vector3 rotated(const Vector3& p_axis, double p_phi) const;
+	void rotate(const Vector3& p_axis, float p_phi);
+	Vector3 rotated(const Vector3& p_axis, float p_phi) const;
 
 	/* Static Methods between 2 vector3s */
 
-	inline Vector3 lerp(const Vector3& p_b, double p_t) const;
-	inline Vector3 slerp(const Vector3& p_b, double p_t) const;
-	Vector3 cubic_interpolate(const Vector3& p_b, const Vector3& p_pre_a, const Vector3& p_post_b, double p_t) const;
-	Vector3 cubic_interpolaten(const Vector3& p_b, const Vector3& p_pre_a, const Vector3& p_post_b, double p_t) const;
-	Vector3 move_toward(const Vector3& p_to, const double p_delta) const;
+	inline Vector3 lerp(const Vector3& p_b, float p_t) const;
+	inline Vector3 slerp(const Vector3& p_b, float p_t) const;
+	Vector3 cubic_interpolate(const Vector3& p_b, const Vector3& p_pre_a, const Vector3& p_post_b, float p_t) const;
+	Vector3 cubic_interpolaten(const Vector3& p_b, const Vector3& p_pre_a, const Vector3& p_post_b, float p_t) const;
+	Vector3 move_toward(const Vector3& p_to, const float p_delta) const;
 
 	inline Vector3 cross(const Vector3& p_b) const;
-	inline double dot(const Vector3& p_b) const;
+	inline float dot(const Vector3& p_b) const;
 	Basis outer(const Vector3& p_b) const;
 	Basis to_diagonal_matrix() const;
 
@@ -100,14 +100,14 @@ struct Vector3 {
 	inline Vector3 sign() const;
 	inline Vector3 ceil() const;
 
-	inline double distance_to(const Vector3& p_b) const;
-	inline double distance_squared_to(const Vector3& p_b) const;
+	inline float distance_to(const Vector3& p_b) const;
+	inline float distance_squared_to(const Vector3& p_b) const;
 
-	inline Vector3 posmod(const double p_mod) const;
+	inline Vector3 posmod(const float p_mod) const;
 	inline Vector3 posmodv(const Vector3& p_modv) const;
 	inline Vector3 project(const Vector3& p_b) const;
 
-	inline double angle_to(const Vector3& p_b) const;
+	inline float angle_to(const Vector3& p_b) const;
 	inline Vector3 direction_to(const Vector3& p_b) const;
 
 	inline Vector3 slide(const Vector3& p_normal) const;
@@ -127,10 +127,10 @@ struct Vector3 {
 	inline Vector3& operator/=(const Vector3& p_v);
 	inline Vector3 operator/(const Vector3& p_v) const;
 
-	inline Vector3& operator*=(double p_scalar);
-	inline Vector3 operator*(double p_scalar) const;
-	inline Vector3& operator/=(double p_scalar);
-	inline Vector3 operator/(double p_scalar) const;
+	inline Vector3& operator*=(float p_scalar);
+	inline Vector3 operator*(float p_scalar) const;
+	inline Vector3& operator/=(float p_scalar);
+	inline Vector3 operator/(float p_scalar) const;
 
 	inline Vector3 operator-() const;
 
@@ -142,7 +142,7 @@ struct Vector3 {
 	inline bool operator>=(const Vector3& p_v) const;
 
 	inline Vector3() {}
-	inline Vector3(double p_x, double p_y, double p_z) {
+	inline Vector3(float p_x, float p_y, float p_z) {
 		x = p_x;
 		y = p_y;
 		z = p_z;
@@ -158,7 +158,7 @@ Vector3 Vector3::cross(const Vector3& p_b) const {
 	return ret;
 }
 
-double Vector3::dot(const Vector3& p_b) const {
+float Vector3::dot(const Vector3& p_b) const {
 	return x * p_b.x + y * p_b.y + z * p_b.z;
 }
 
@@ -178,27 +178,27 @@ Vector3 Vector3::ceil() const {
 	return Vector3(std::ceil(x), std::ceil(y), std::ceil(z));
 }
 
-Vector3 Vector3::lerp(const Vector3& p_b, double p_t) const {
+Vector3 Vector3::lerp(const Vector3& p_b, float p_t) const {
 	return Vector3(
 		x + (p_t * (p_b.x - x)),
 		y + (p_t * (p_b.y - y)),
 		z + (p_t * (p_b.z - z)));
 }
 
-Vector3 Vector3::slerp(const Vector3& p_b, double p_t) const {
-	double theta = angle_to(p_b);
+Vector3 Vector3::slerp(const Vector3& p_b, float p_t) const {
+	float theta = angle_to(p_b);
 	return rotated(cross(p_b).normalized(), theta * p_t);
 }
 
-double Vector3::distance_to(const Vector3& p_b) const {
+float Vector3::distance_to(const Vector3& p_b) const {
 	return (p_b - *this).length();
 }
 
-double Vector3::distance_squared_to(const Vector3& p_b) const {
+float Vector3::distance_squared_to(const Vector3& p_b) const {
 	return (p_b - *this).length_squared();
 }
 
-Vector3 Vector3::posmod(const double p_mod) const {
+Vector3 Vector3::posmod(const float p_mod) const {
 	return Vector3(Math::fposmod(x, p_mod), Math::fposmod(y, p_mod), Math::fposmod(z, p_mod));
 }
 
@@ -210,7 +210,7 @@ Vector3 Vector3::project(const Vector3& p_b) const {
 	return p_b * (dot(p_b) / p_b.length_squared());
 }
 
-double Vector3::angle_to(const Vector3& p_b) const {
+float Vector3::angle_to(const Vector3& p_b) const {
 	return std::atan2(cross(p_b).length(), dot(p_b));
 }
 
@@ -266,29 +266,29 @@ Vector3 Vector3::operator/(const Vector3& p_v) const {
 	return Vector3(x / p_v.x, y / p_v.y, z / p_v.z);
 }
 
-Vector3& Vector3::operator*=(double p_scalar) {
+Vector3& Vector3::operator*=(float p_scalar) {
 	x *= p_scalar;
 	y *= p_scalar;
 	z *= p_scalar;
 	return *this;
 }
 
-inline Vector3 operator*(double p_scalar, const Vector3& p_vec) {
+inline Vector3 operator*(float p_scalar, const Vector3& p_vec) {
 	return p_vec * p_scalar;
 }
 
-Vector3 Vector3::operator*(double p_scalar) const {
+Vector3 Vector3::operator*(float p_scalar) const {
 	return Vector3(x * p_scalar, y * p_scalar, z * p_scalar);
 }
 
-Vector3& Vector3::operator/=(double p_scalar) {
+Vector3& Vector3::operator/=(float p_scalar) {
 	x /= p_scalar;
 	y /= p_scalar;
 	z /= p_scalar;
 	return *this;
 }
 
-Vector3 Vector3::operator/(double p_scalar) const {
+Vector3 Vector3::operator/(float p_scalar) const {
 	return Vector3(x / p_scalar, y / p_scalar, z / p_scalar);
 }
 
@@ -364,33 +364,33 @@ inline Vector3 vec3_cross(const Vector3& p_a, const Vector3& p_b) {
 	return p_a.cross(p_b);
 }
 
-inline double vec3_dot(const Vector3& p_a, const Vector3& p_b) {
+inline float vec3_dot(const Vector3& p_a, const Vector3& p_b) {
 	return p_a.dot(p_b);
 }
 
-double Vector3::length() const {
-	double x2 = x * x;
-	double y2 = y * y;
-	double z2 = z * z;
+float Vector3::length() const {
+	float x2 = x * x;
+	float y2 = y * y;
+	float z2 = z * z;
 
 	return std::sqrt(x2 + y2 + z2);
 }
 
-double Vector3::length_squared() const {
-	double x2 = x * x;
-	double y2 = y * y;
-	double z2 = z * z;
+float Vector3::length_squared() const {
+	float x2 = x * x;
+	float y2 = y * y;
+	float z2 = z * z;
 
 	return x2 + y2 + z2;
 }
 
 void Vector3::normalize() {
-	double lengthsq = length_squared();
+	float lengthsq = length_squared();
 	if (lengthsq == 0) {
 		x = y = z = 0;
 	}
 	else {
-		double length = std::sqrt(lengthsq);
+		float length = std::sqrt(lengthsq);
 		x /= length;
 		y /= length;
 		z /= length;

--- a/src/bno080sensor.cpp
+++ b/src/bno080sensor.cpp
@@ -118,7 +118,7 @@ void BNO080Sensor::motionLoop()
             }
             if(imu.hasNewMagQuat()) {
                 imu.getMagQuat(magQuaternion.x, magQuaternion.y, magQuaternion.z, magQuaternion.w, magneticAccuracyEstimate, magCalibrationAccuracy);
-                quaternion *= sensorOffset;
+                magQuaternion *= sensorOffset;
                 newMagData = true;
             }
         }
@@ -161,7 +161,7 @@ void BNO080Sensor::sendData() {
     }
     if(newMagData) {
         newMagData = false;
-        sendRotationData(&quaternion, DATA_TYPE_CORRECTION, calibrationAccuracy, sensorId, PACKET_ROTATION_DATA);
+        sendRotationData(&magQuaternion, DATA_TYPE_CORRECTION, magCalibrationAccuracy, sensorId, PACKET_ROTATION_DATA);
         sendMagnetometerAccuracy(magneticAccuracyEstimate, sensorId, PACKET_MAGENTOMETER_ACCURACY);
     }
     if(tap != 0) {

--- a/src/bno080sensor.cpp
+++ b/src/bno080sensor.cpp
@@ -79,7 +79,7 @@ void BNO080Sensor::motionSetup()
         } else {
             imu.enableARVRStabilizedGameRotationVector(10);
             if(useMagentometerCorrection)
-                imu.enableARVRStabilizedRotationVector(1000);
+                imu.enableRotationVector(1000);
         }
 #else
     if(useMagentometerAllTheTime) {

--- a/src/defines.h
+++ b/src/defines.h
@@ -119,5 +119,5 @@
 
 #define batteryADCMultiplier 1.0 / 1024.0 * 5.0
 
-#define FIRMWARE_BUILD_NUMBER 3
-#define FIRMWARE_VERSION "0.0.3"
+#define FIRMWARE_BUILD_NUMBER 4
+#define FIRMWARE_VERSION "0.0.4"

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -108,14 +108,14 @@ void setup()
         uint8_t first = I2CSCAN::pickDevice(BNO_ADDR_1, BNO_ADDR_2, true);
         uint8_t second = I2CSCAN::pickDevice(BNO_ADDR_2, BNO_ADDR_1, false);
         if(first != second) {
-            sensor.setupBNO080(false, first, PIN_IMU_INT);
-            sensor2.setupBNO080(true, second, PIN_IMU_INT_2);
+            sensor.setupBNO080(0, first, PIN_IMU_INT);
+            sensor2.setupBNO080(1, second, PIN_IMU_INT_2);
             secondImuActive = true;
         } else {
-            sensor.setupBNO080(false, first, PIN_IMU_INT);
+            sensor.setupBNO080(0, first, PIN_IMU_INT);
         }
     #else
-    sensor.setupBNO080(false, I2CSCAN::pickDevice(BNO_ADDR_1, BNO_ADDR_2, true), PIN_IMU_INT);
+    sensor.setupBNO080(0, I2CSCAN::pickDevice(BNO_ADDR_1, BNO_ADDR_2, true), PIN_IMU_INT);
     #endif
 #endif
 

--- a/src/sensor.h
+++ b/src/sensor.h
@@ -32,6 +32,9 @@
 #include <Adafruit_BNO055.h>
 #include "defines.h"
 
+#define DATA_TYPE_NORMAL 1
+#define DATA_TYPE_CORRECTION 2
+
 class Sensor {
     public:
         Sensor() = default;
@@ -47,6 +50,7 @@ class Sensor {
         Quat quaternion {};
         Quat sensorOffset {Quat(Vector3(0, 0, 1), IMU_ROTATION)};
         bool working {false};
+        uint8_t sensorId {0};
 };
 
 class EmptySensor : public Sensor {
@@ -67,17 +71,23 @@ class BNO080Sensor : public Sensor {
         void motionLoop() override final;
         void sendData() override final;
         void startCalibration(int calibrationType) override final;
-        void setupBNO080(bool auxilary = false, uint8_t addr = 0x4B, uint8_t intPin = 255);
+        void setupBNO080(uint8_t sensorId = 0, uint8_t addr = 0x4B, uint8_t intPin = 255);
     private:
         BNO080 imu {};
         bool newData {false};
+        bool newMagData {false};
         uint8_t tap;
         unsigned long lastData = 0;
         uint8_t lastReset = 0;
         uint8_t addr = 0x4B;
         uint8_t intPin = 255;
-        bool auxilary {false};
         bool setUp {false};
+        Quat magQuaternion {};
+        float magneticAccuracyEstimate {999};
+        uint8_t calibrationAccuracy {0};
+        uint8_t magCalibrationAccuracy {0};
+        bool useMagentometerAllTheTime {false};
+        bool useMagentometerCorrection {true};
 };
 
 class BNO055Sensor : public Sensor {

--- a/src/sensor.h
+++ b/src/sensor.h
@@ -87,7 +87,7 @@ class BNO080Sensor : public Sensor {
         uint8_t calibrationAccuracy {0};
         uint8_t magCalibrationAccuracy {0};
         bool useMagentometerAllTheTime {false};
-        bool useMagentometerCorrection {true};
+        bool useMagentometerCorrection {false};
 };
 
 class BNO055Sensor : public Sensor {

--- a/src/udpclient.cpp
+++ b/src/udpclient.cpp
@@ -167,6 +167,27 @@ void sendByte(unsigned char const value, int type)
     }
 }
 
+void sendByte(uint8_t const value, uint8_t sensorId, int type)
+{
+    if (Udp.beginPacket(host, port) > 0)
+    {
+        sendType(type);
+        sendPacketNumber();
+        Udp.write(&sensorId, 1);
+        Udp.write(&value, 1);
+        if (Udp.endPacket() == 0)
+        {
+            //Serial.print("Write error: ");
+            //Serial.println(Udp.getWriteError());
+        }
+    }
+    else
+    {
+        //Serial.print("Write error: ");
+        //Serial.println(Udp.getWriteError());
+    }
+}
+
 void sendQuat(Quat *const quaternion, int type)
 {
     if (Udp.beginPacket(host, port) > 0)
@@ -181,6 +202,55 @@ void sendQuat(Quat *const quaternion, int type)
         Udp.write(convert_to_chars(y, buf), sizeof(y));
         Udp.write(convert_to_chars(z, buf), sizeof(z));
         Udp.write(convert_to_chars(w, buf), sizeof(w));
+        if (Udp.endPacket() == 0)
+        {
+            //Serial.print("Write error: ");
+            //Serial.println(Udp.getWriteError());
+        }
+    }
+    else
+    {
+        //Serial.print("Write error: ");
+        //Serial.println(Udp.getWriteError());
+    }
+}
+
+void sendRotationData(Quat * const quaternion, uint8_t dataType, uint8_t accuracyInfo, uint8_t sensorId, int type) {
+    if (Udp.beginPacket(host, port) > 0)
+    {
+        float x = quaternion->x;
+        float y = quaternion->y;
+        float z = quaternion->z;
+        float w = quaternion->w;
+        sendType(type);
+        sendPacketNumber();
+        Udp.write(&sensorId, 1);
+        Udp.write(&dataType, 1);
+        Udp.write(convert_to_chars(x, buf), sizeof(x));
+        Udp.write(convert_to_chars(y, buf), sizeof(y));
+        Udp.write(convert_to_chars(z, buf), sizeof(z));
+        Udp.write(convert_to_chars(w, buf), sizeof(w));
+        Udp.write(&accuracyInfo, 1);
+        if (Udp.endPacket() == 0)
+        {
+            //Serial.print("Write error: ");
+            //Serial.println(Udp.getWriteError());
+        }
+    }
+    else
+    {
+        //Serial.print("Write error: ");
+        //Serial.println(Udp.getWriteError());
+    }
+}
+
+void sendMagnetometerAccuracy(float accuracyInfo, uint8_t sensorId, int type) {
+    if (Udp.beginPacket(host, port) > 0)
+    {
+        sendType(type);
+        sendPacketNumber();
+        Udp.write(&sensorId, 1);
+        Udp.write(convert_to_chars(accuracyInfo, buf), sizeof(accuracyInfo));
         if (Udp.endPacket() == 0)
         {
             //Serial.print("Write error: ");

--- a/src/udpclient.cpp
+++ b/src/udpclient.cpp
@@ -459,10 +459,9 @@ void sendHandshake() {
         uint8_t size = (uint8_t) sizeof(FIRMWARE_VERSION);
         Udp.write(&size, 1); // Firmware version string size
         Udp.write((const unsigned char *) FIRMWARE_VERSION, sizeof(FIRMWARE_VERSION)); // Firmware version string
-        const char * mac = WiFi.macAddress().c_str();
-        size = (uint8_t) strlen(mac);
-        Udp.write(&size, 1); // MAC address string size
-        Udp.write((uint8_t *) mac, strlen(mac)); // MAC address string
+        uint8_t mac[6];
+        WiFi.macAddress(mac);
+        Udp.write(mac, 6); // MAC address string
         if (Udp.endPacket() == 0)
         {
             Serial.print("Write error: ");

--- a/src/udpclient.h
+++ b/src/udpclient.h
@@ -54,6 +54,8 @@
 #define PACKET_RESET_REASON 14
 #define PACKET_SENSOR_INFO 15
 #define PACKET_ROTATION_2 16
+#define PACKET_ROTATION_DATA 17
+#define PACKET_MAGENTOMETER_ACCURACY 18
 
 #define PACKET_RECIEVE_HEARTBEAT 1
 #define PACKET_RECIEVE_VIBRATE 2
@@ -71,10 +73,13 @@ void connectClient();
 void clientUpdate(Sensor * const sensor, Sensor * const sensor2);
 void sendQuat(float * const quaternion, int type);
 void sendQuat(Quat * const quaternion, int type);
+void sendRotationData(Quat * const quaternion, uint8_t dataType, uint8_t accuracyInfo, uint8_t sensorId, int type);
+void sendMagnetometerAccuracy(float accuracyInfo, uint8_t sensorId, int type);
 void sendVector(float * const result, int type);
 void sendConfig(DeviceConfig * const config, int type);
 void sendFloat(float const value, int type);
 void sendByte(unsigned char const value, int type);
+void sendByte(uint8_t const value, uint8_t sensorId, int type);
 void sendSensorInfo(unsigned char const sensorId, unsigned char const sensorState, int type);
 void sendRawCalibrationData(int * const data, int calibrationType, unsigned char const sensorId, int type);
 void sendRawCalibrationData(float * const data, int calibrationType, unsigned char const sensorId, int type);


### PR DESCRIPTION
Code and protocol refactoring
* Replace doubles with floats in math: double precision is not used in sensor readings, we can save CPU cycles and memory, and able to use more things without casting
* BNO now sends data to the server with new PACKET_ROTATION_DATA that supports different data types, data accuracy information, and more than 2 sensors
* BNO now can use magnetometer if flag is set, or can separately send magnetometer data as DATA_CORRECTION that server can use however it wishes
* BNO now sends tap data (it's not used by server and seem to be very unreliable, 95% of taps are ignored by it (need higher report rate?))
* Fixed handshake