### PR TITLE
Using common I2C pins for ESP32 to prevent lockup

### DIFF
--- a/src/defines.h
+++ b/src/defines.h
@@ -94,9 +94,9 @@
 #elif BOARD == BOARD_CUSTOM
   // Define pins by the examples above
 #elif BOARD == BOARD_WROOM32
-  #define PIN_IMU_SDA 12
-  #define PIN_IMU_SCL 13
-  #define PIN_IMU_INT 26
+  #define PIN_IMU_SDA 21
+  #define PIN_IMU_SCL 22
+  #define PIN_IMU_INT 23
   #define PIN_IMU_INT_2 25
   #define PIN_BATTERY_LEVEL 36
   #define BNO_ADDR_1 0x4A


### PR DESCRIPTION
Using common I2C pins for ESP32 to prevent lockup when using MPU
Pin 12 cause boot to fail when pull to HIGH (which it does on mpu6050)
![image](https://user-images.githubusercontent.com/36285359/130340526-c2681597-2dc4-4912-8185-fcacd11908b0.png)
![image](https://user-images.githubusercontent.com/36285359/130340558-00328427-2117-482f-8303-59e50bc3a71a.png)

Source: https://randomnerdtutorials.com/esp32-pinout-reference-gpios
Pinout: https://lastminuteengineers.com/esp32-arduino-ide-tutorial/#esp32-development-board-pinout