### PR TITLE
Handling exceptions when SET has no args

### DIFF
--- a/src/serialcommands.cpp
+++ b/src/serialcommands.cpp
@@ -30,7 +30,7 @@ CmdParser cmdParser;
 CmdBuffer<64> cmdBuffer;
 
 void cmdSet(CmdParser * parser) {
-    if(parser->equalCmdParam(1, "WIFI")) {
+    if(parser->getParamCount() != 1 && parser->equalCmdParam(1, "WIFI")  ) {
         if(parser->getParamCount() < 3) {
             Serial.println("[ERR] CMD SET WIFI ERROR: Too few arguments");
             Serial.println("[NOTICE] Syntax: SET WIFI \"<SSID>\" \"<PASSWORD>\"");


### PR DESCRIPTION
Exception (28) occurs on ESP8266 when no arguments are given to the serial command 'SET'.