### PR TITLE
Fix to store credentials for ESP8266

### DIFF
--- a/src/configuration.h
+++ b/src/configuration.h
@@ -39,6 +39,8 @@ struct DeviceConfig {
     CalibrationConfig calibration;
     int deviceId;
     int deviceMode;
+    char wifissid[50];
+    char wifipass[50];
 };
 
 DeviceConfig * const getConfigPtr();

--- a/src/wifihandler.cpp
+++ b/src/wifihandler.cpp
@@ -45,12 +45,22 @@ bool isWiFiConnected() {
 
 void setWiFiCredentials(const char * SSID, const char * pass) {
     WiFi.stopSmartConfig();
+#ifndef ESP32
+    DeviceConfig * const config = getConfigPtr();
+    memcpy(config->wifissid, SSID, strlen(SSID));
+    memcpy(config->wifipass, pass, strlen(pass));
+    config->wifissid[strlen(SSID)] = 0; //EOL
+    config->wifipass[strlen(pass)] = 0;
+    saveConfig();
+#endif
     WiFi.begin(SSID, pass);
     wifiState = 2;
     wifiConnectionTimeout = millis();
 }
 
 void setUpWiFi() {
+    DeviceConfig * const config = getConfigPtr();
+    
     Serial.println("[NOTICE] WiFi: Setting up WiFi");
     WiFi.mode(WIFI_STA);
     WiFi.hostname("SlimeVR FBT Tracker");
@@ -66,10 +76,12 @@ void setUpWiFi() {
         WiFi.begin(WiFi.SSID().c_str(), WiFi.psk().c_str());
         wifiState = 1;
     }
-#else
+#elif defined(ESP32)
     WiFi.begin(WiFi.SSID().c_str(), WiFi.psk().c_str());
-    wifiState = 1;
+#else
+    WiFi.begin(config->wifissid, config->wifipass);
 #endif
+    wifiState = 1;
     wifiConnectionTimeout = millis();
 }
 


### PR DESCRIPTION
Fixes #20 

I have modified the code to be ESP8266 specific so I can store credentials in EEPROM(using DeviceConfig).
I tested it on ESP32(WROOM32, WROVER-B) and 8266(nodemcu ESP12F) with an MPU9250 and everything seems to be working fine.