### PR TITLE
Wemos D1 Mini support and batteryADCMultiplier fix

### DIFF
--- a/src/consts.h
+++ b/src/consts.h
@@ -34,6 +34,7 @@
 #define BOARD_NODEMCU 3
 #define BOARD_CUSTOM 4
 #define BOARD_WROOM32 5
+#define BOARD_WEMOSD1MINI 6
 
 #ifndef LED_BUILTIN
 #define LED_BUILTIN 2

--- a/src/defines.h
+++ b/src/defines.h
@@ -103,10 +103,22 @@
   #define PIN_BATTERY_LEVEL 36
   #define BNO_ADDR_1 0x4A
   #define BNO_ADDR_2 0x4B
+#elif BOARD == BOARD_WEMOSD1MINI
+  #define PIN_IMU_SDA D2
+  #define PIN_IMU_SCL D1
+  #define PIN_BATTERY_LEVEL A0
+  #define WEMOS_BATTERY_SHIELD_130K true
 #endif
 
 #define LOADING_LED LED_BUILTIN
 #define CALIBRATING_LED LED_BUILTIN
 #define STATUS_LED LED_BUILTIN
 
-#define batteryADCMultiplier 1.0 / 1024.0 * 5.0
+#if BOARD == BOARD_WEMOSD1MINI && WEMOS_BATTERY_SHIELD_130K == true
+  // Wemos D1 Mini has an internal Voltage Divider with R1=220K and R2=100K > this means, 3.3V analogRead input voltage results in 1023.0
+  // Wemos D1 Mini with Wemos BatteryShiled v1.2.0 or higher: BatteryShield with J2 closed, has an addtional 130K resistor. So the resulting Voltage Divider is R1=220K+100K=320K and R2=100K > this means, 4.5V analogRead input voltage results in 1023.0
+  #define batteryADCMultiplier 1.0 / 1023.0 * 4.5
+#else
+  // SlimeVR Board can handle max 5V > so analogRead of 5.0V input will result in 1023.0
+  #define batteryADCMultiplier 1.0 / 1023.0 * 5.0
+#endif


### PR DESCRIPTION
1. Added support for Wemos D1 Mini board and Wemos D1 Battery shield
2. Fixed batteryADCMultiplier calculation to be more accurate on voltage value