### PR TITLE
Support for dual MPU-6050's

### DIFF
--- a/src/defines.h
+++ b/src/defines.h
@@ -63,6 +63,8 @@
   #define IMU_HAS_MAG false
   #define I2C_SPEED 100000
   #define IMU_MPU6050_RUNTIME_CALIBRATION // Comment to revert to startup/traditional-calibration
+  // If you want to use dual MPU6050's, change I2C_SPEED to 400000 and uncomment the next line
+  // #define HAS_SECOND_IMU true
 #elif IMU == IMU_MPU6500
   #define IMU_NAME "MPU6500"
   #define IMU_HAS_ACCELL true

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -45,6 +45,9 @@
     MPU9250Sensor sensor{};
 #elif IMU == IMU_MPU6500 || IMU == IMU_MPU6050
     MPU6050Sensor sensor{};
+    #if defined(HAS_SECOND_IMU)
+        MPU6050Sensor sensor2{};
+    #endif
 #else
     #error Unsupported IMU
 #endif
@@ -119,6 +122,14 @@ void setup()
     #else
     sensor.setupBNO080(0, I2CSCAN::pickDevice(BNO_ADDR_1, BNO_ADDR_2, true), PIN_IMU_INT);
     #endif
+#endif
+#if IMU == IMU_MPU6050 && HAS_SECOND_IMU
+    if (I2CSCAN::isI2CExist(0x68) && I2CSCAN::isI2CExist(0x69)) {
+        sensor2.setSecond();
+        secondImuActive = true;
+    } else {
+        Serial.println("[ERR] HAS_SECOND_IMU defined but can't find I2C devices 0x68 and 0x69. Running in single sensor mode.");
+    }
 #endif
 
     sensor.motionSetup();

--- a/src/sensor.h
+++ b/src/sensor.h
@@ -117,11 +117,14 @@ class MPU6050Sensor : public MPUSensor {
         MPU6050Sensor() = default;
         ~MPU6050Sensor() override  = default;
         void motionSetup() override final;
+        void setSecond();
         void motionLoop() override final;
         void sendData() override final;
         void startCalibration(int calibrationType) override final;
     private:
         MPU6050 imu {};
+        bool isSecond{false};
+        bool hasNewData{false};
         Quaternion rawQuat {};
         // MPU dmp control/status vars
         bool dmpReady{false};  // set true if DMP init was successful


### PR DESCRIPTION
This pull request adds support for using two MPU-6050's connected to one device.

This mode is more subject to interference than running in single MPU mode. Good solder joints, cables and a good Wi-Fi connection is needed to keep the TPS high. I can run 4 normal trackers, and one with dual on my Wi-Fi with minimal issues, but adding more dual trackers unfortunately makes my router sad.

Any future documentation for this mode should explain these issues (I will simply create a discord post for now). If the user has problems with TPS they should try to unplug the second tracker and run it in single MPU mode.