### PR TITLE
Provide pre-defined rotation values

### DIFF
--- a/src/consts.h
+++ b/src/consts.h
@@ -37,6 +37,11 @@
 #define BOARD_WEMOSD1MINI 6
 #define BOARD_TTGO_TBASE 7
 
+#define DEG_0 0.f
+#define DEG_90 -PI / 2
+#define DEG_180 PI
+#define DEG_270 PI / 2
+
 #ifndef LED_BUILTIN
 #define LED_BUILTIN 2
 #endif

--- a/src/defines.h
+++ b/src/defines.h
@@ -26,8 +26,8 @@
 // Set parameters of IMU and board used
 #define IMU IMU_BNO085
 #define BOARD BOARD_SLIMEVR
-#define IMU_ROTATION -PI / 2.0
-#define SECOND_IMU_ROTATION PI / 2.0
+#define IMU_ROTATION DEG_90
+#define SECOND_IMU_ROTATION DEG_270
 #define BATTERY_SHIELD_130K false
 
 #if IMU == IMU_BNO085


### PR DESCRIPTION
Provide pre-defined values to reduce possible mistakes caused by user input. The change is backward compatible with custom values and names of defines assume clockwise rotation.

Rationale:
1. There were several issues caused by accidental division by zero, modification of wrong values and etc.
2. Such values are easier to invert with `-` in case IMU is facing towards the user and also allows to invert sign of zero value.