### PR TITLE
Add support for Mixing BNO08X and MPU6XXX IMU's

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -47,16 +47,14 @@
 
 // Deprecated block: Checks for old type of config. Remove after a grace period to allow people to use outdated defines.h for a while.
 #ifndef SECOND_IMU
-    #if IMU == IMU_BNO080
-        #define SECOND_IMU IMU_BNO080
-    #elsif IMU == IMU_BNO085
+    #if IMU == IMU_BNO085
         #define SECOND_IMU IMU_BNO085
-    #elsif IMU == IMU_MPU6500
+    #elif IMU == IMU_BNO080
+        #define SECOND_IMU IMU_BNO080
+    #elif IMU == IMU_MPU6500
         #define SECOND_IMU IMU_MPU6500
-    #elsif IMU == IMU_MPU6050
+    #elif IMU == IMU_MPU6050
         #define SECOND_IMU IMU_MPU6050
-    #else
-        #error Unsupported IMU
     #endif
 #endif
 // End deprecated block

--- a/src/mpu6050sensor.cpp
+++ b/src/mpu6050sensor.cpp
@@ -47,32 +47,22 @@ namespace {
 }
 
 void MPU6050Sensor::setSecond() {
+    addr = I2CSCAN::pickDevice(0x69, 0x68, true);
     isSecond = true;
     sensorOffset = {Quat(Vector3(0, 0, 1), SECOND_IMU_ROTATION)};
 }
 
 void MPU6050Sensor::motionSetup() {
     //DeviceConfig * const config = getConfigPtr();
-
-    uint8_t addr = 0x68;
-
-    if (isSecond) {
-        addr = 0x69;
-        if (!I2CSCAN::isI2CExist(addr)) {
-            Serial.println("[ERR] Can't find I2C device on addr 0x69, returning");
-            signalAssert();
-            return;
-        } else {
-            Serial.println("[INFO] Second I2C device on addr 0x69");
-        }
-    }
-
-    if(!I2CSCAN::isI2CExist(addr)) {
-        addr = 0x69;
+    if (addr == 0) {
+        addr = 0x68;
         if(!I2CSCAN::isI2CExist(addr)) {
-            Serial.println("[ERR] Can't find I2C device on addr 0x68 or 0x69, returning");
-            signalAssert();
-            return;
+            addr = 0x69;
+            if(!I2CSCAN::isI2CExist(addr)) {
+                Serial.println("[ERR] Can't find I2C device on addr 0x68 or 0x69, returning");
+                signalAssert();
+                return;
+            }
         }
     }
     imu.initialize(addr);

--- a/src/sensor.h
+++ b/src/sensor.h
@@ -124,6 +124,7 @@ class MPU6050Sensor : public MPUSensor {
         void startCalibration(int calibrationType) override final;
     private:
         MPU6050 imu {};
+        uint8_t addr = 0;
         bool isSecond{false};
         bool newData{false};
         Quaternion rawQuat {};


### PR DESCRIPTION
This code is currently untested for any configurations except:
* MPU6050 in following configurations
* * Two of them
* * One in 0x68
* * One in 0x69

**This pull request needs to be tested** to make sure 2xBNO085 works, and mixing works.

If merged I will also fix the docs to include the ability to do BNO + MPU. (It will also add `IMU_MPU6050_RUNTIME_CALIBRATION`)

**Future work:**

* Needs more work in defines.h. Needs to add info on how to mix and match.
* We need the ability to mix and match other things, but current defines makes things weird. this commit only works as we don't use has_accell, has_gyro, has_mag. Need to do solve issue for `BNO_HAS_ARVR_STABILIZATION` to mix and match  BNO's.