### PR TITLE
Enable -O2 optimization option

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -27,6 +27,10 @@ framework = arduino
 ;upload_flags =
 ;  --auth=SlimeVR-OTA
 
+; Enable -O2 GCC optimization
+build_unflags = -Os
+build_flags = -O2
+
 ; Settings for different boards
 
 [env:esp12e]


### PR DESCRIPTION
With -O2 optimization, the speed increases by 30% while RAM usage increased by 0.2% and FLASH usage - by 1.1% on esp8266 (IMU_MPU6050). Might be a subject to additional testing, but no bugs were noticed.

With `-Os`:
```
RAM:   [====      ]  44.6% (used 36504 bytes from 81920 bytes)
Flash: [===       ]  33.8% (used 352907 bytes from 1044464 bytes)
```
Loop execution times
Min: 241uS
Max: 1870uS
Average: 329uS

With `-O2`:
```
RAM:   [====      ]  44.8% (used 36720 bytes from 81920 bytes)
Flash: [===       ]  34.9% (used 364271 bytes from 1044464 bytes)
```
Loop execution times
Min: 162uS
Max: 1430uS
Average: 242uS