### PR TITLE
Improve magnetometer support for MPU-9250

### DIFF
--- a/lib/math/helper_3dmath.cpp
+++ b/lib/math/helper_3dmath.cpp
@@ -23,15 +23,18 @@
 
 #include "helper_3dmath.h"
 
-float vector_dot(float a[3], float b[3])
-{
-    return a[0] * b[0] + a[1] * b[1] + a[2] * b[2];
+// Fast inverse square root function (https://en.wikipedia.org/wiki/Fast_inverse_square_root).
+// Source: https://pizer.wordpress.com/2008/10/12/fast-inverse-square-root/
+float invSqrt(float x) {
+   uint32_t i = 0x5F1F1412 - (*(uint32_t*)&x >> 1);
+   float tmp = *(float*)&i;
+   return tmp * (1.69000231f - 0.714158168f * x * tmp * tmp);
 }
 
 void vector_normalize(float a[3])
 {
-    float mag = sqrt(vector_dot(a, a));
-    a[0] /= mag;
-    a[1] /= mag;
-    a[2] /= mag;
+    float norm = invSqrt(a[0] * a[0] + a[1] * a[1] + a[2] * a[2]);
+    a[0] *= norm;
+    a[1] *= norm;
+    a[2] *= norm;
 }

--- a/lib/math/helper_3dmath.h
+++ b/lib/math/helper_3dmath.h
@@ -215,8 +215,7 @@ class VectorFloat {
         }
 };
 
-float vector_dot(float a[3], float b[3]);
-
 void vector_normalize(float a[3]);
+float invSqrt(float x);
 
 #endif /* _HELPER_3DMATH_H_ */

--- a/lib/mpu9250/MPU9250.cpp
+++ b/lib/mpu9250/MPU9250.cpp
@@ -41,6 +41,9 @@ THE SOFTWARE.
  */
 MPU9250::MPU9250() {
     devAddr = MPU9250_DEFAULT_ADDRESS;
+    asax = 0;
+    asay = 0;
+    asaz = 0;
 }
 
 /** Power on and prepare for general usage.
@@ -56,6 +59,55 @@ void MPU9250::initialize(uint8_t address) {
     setFullScaleGyroRange(MPU9250_GYRO_FS_250);
     setFullScaleAccelRange(MPU9250_ACCEL_FS_2);
     setSleepEnabled(false); // thanks to Jack Elston for pointing this one out!
+
+    // Enable I2C bypass to access magnetometer
+    setI2CBypassEnabled(true);
+    // Power down magnetometer
+    I2Cdev::writeByte(MPU9250_RA_MAG_ADDRESS, MPU9250_RA_MAG_CNTL1, 0x00);
+    delay(10);
+
+    // Enable FUSE rom access
+    I2Cdev::writeByte(MPU9250_RA_MAG_ADDRESS, MPU9250_RA_MAG_CNTL1, 0x0F);
+    delay(10);
+
+    // Read and store magnetometer factory sensitivity adjustments
+    uint8_t adjx = 0, adjy = 0, adjz = 0;
+    I2Cdev::readByte(MPU9250_RA_MAG_ADDRESS, MPU9250_RA_MAG_ASAX, &adjx);
+    I2Cdev::readByte(MPU9250_RA_MAG_ADDRESS, MPU9250_RA_MAG_ASAY, &adjy);
+    I2Cdev::readByte(MPU9250_RA_MAG_ADDRESS, MPU9250_RA_MAG_ASAZ, &adjz);
+    asax = (0.5 * (adjx - 128)) / 128 + 1;
+    asay = (0.5 * (adjy - 128)) / 128 + 1;
+    asaz = (0.5 * (adjz - 128)) / 128 + 1;
+
+    // Power down magnetometer
+    I2Cdev::writeByte(MPU9250_RA_MAG_ADDRESS, MPU9250_RA_MAG_CNTL1, 0x00);
+    delay(10);
+
+    // Enable magnetometer in continuous reading mode 16-bit 100hz
+    I2Cdev::writeByte(MPU9250_RA_MAG_ADDRESS, MPU9250_RA_MAG_CNTL1, 0x16);
+    delay(10);
+
+    // Disable I2C bypass to avoid conflicts with aux tracker's magnetometer
+    setI2CBypassEnabled(false);
+
+    // Set up magnetometer as slave 0 for reading
+    I2Cdev::writeByte(devAddr, MPU9250_RA_I2C_SLV0_ADDR, MPU9250_RA_MAG_ADDRESS|0x80);
+    // Start reading from HXL register
+    I2Cdev::writeByte(devAddr, MPU9250_RA_I2C_SLV0_REG,  MPU9250_RA_MAG_XOUT_L);
+    // Read 7 bytes (until ST2 register), group LSB and MSB
+    I2Cdev::writeByte(devAddr, MPU9250_RA_I2C_SLV0_CTRL, 0x97);
+    delay(10);
+
+    // Enable I2C master to read from magnetometer
+    setI2CMasterModeEnabled(true);
+    // Set I2C clock speed to 400kHz
+    setMasterClockSpeed(13);
+}
+
+void MPU9250::getMagnetometerAdjustments(float adjustments[3]) {
+    adjustments[0] = asax;
+    adjustments[1] = asay;
+    adjustments[2] = asaz;
 }
 
 uint8_t MPU9250::getAddr() {
@@ -1715,15 +1767,13 @@ void MPU9250::getMotion9(int16_t* ax, int16_t* ay, int16_t* az, int16_t* gx, int
 	//get accel and gyro
 	getMotion6(ax, ay, az, gx, gy, gz);
 
-	//read mag
-	I2Cdev::writeByte(devAddr, MPU9250_RA_INT_PIN_CFG, 0x02); //set i2c bypass enable pin to true to access magnetometer
-	delay(10);
-	I2Cdev::writeByte(MPU9150_RA_MAG_ADDRESS, 0x0A, 0x01); //enable the magnetometer
-	delay(10);
-	I2Cdev::readBytes(MPU9150_RA_MAG_ADDRESS, MPU9150_RA_MAG_XOUT_L, 6, buffer);
-	*mx = (((int16_t)buffer[1]) << 8) | buffer[0];
-    *my = (((int16_t)buffer[3]) << 8) | buffer[2];
-    *mz = (((int16_t)buffer[5]) << 8) | buffer[4];
+	//read mag from SLV0 external sensor registers
+    I2Cdev::readBytes(devAddr, MPU9250_RA_EXT_SENS_DATA_00, 7, buffer);
+    if (!(buffer[6] & 0x8)) { // Check ST2 for sensor overflow
+        *mx = (((int16_t)buffer[1]) << 8) | buffer[0];
+        *my = (((int16_t)buffer[3]) << 8) | buffer[2];
+        *mz = (((int16_t)buffer[5]) << 8) | buffer[4];
+    }
 }
 /** Get raw 6-axis motion sensor readings (accel/gyro).
  * Retrieves all currently available motion sensor values.

--- a/lib/mpu9250/MPU9250.h
+++ b/lib/mpu9250/MPU9250.h
@@ -45,13 +45,20 @@ THE SOFTWARE.
 #define MPU9250_INCLUDE_DMP_MOTIONAPPS20
 
 //Magnetometer Registers
-#define MPU9150_RA_MAG_ADDRESS		0x0C
-#define MPU9150_RA_MAG_XOUT_L		0x03
-#define MPU9150_RA_MAG_XOUT_H		0x04
-#define MPU9150_RA_MAG_YOUT_L		0x05
-#define MPU9150_RA_MAG_YOUT_H		0x06
-#define MPU9150_RA_MAG_ZOUT_L		0x07
-#define MPU9150_RA_MAG_ZOUT_H		0x08
+#define MPU9250_RA_MAG_ADDRESS      0x0C
+#define MPU9250_RA_MAG_WHOAMI       0x01
+#define MPU9250_RA_MAG_ST1          0x02
+#define MPU9250_RA_MAG_XOUT_L       0x03
+#define MPU9250_RA_MAG_XOUT_H       0x04
+#define MPU9250_RA_MAG_YOUT_L       0x05
+#define MPU9250_RA_MAG_YOUT_H       0x06
+#define MPU9250_RA_MAG_ZOUT_L       0x07
+#define MPU9250_RA_MAG_ZOUT_H       0x08
+#define MPU9250_RA_MAG_ST2          0x09
+#define MPU9250_RA_MAG_ASAX         0x10
+#define MPU9250_RA_MAG_ASAY         0x11
+#define MPU9250_RA_MAG_ASAZ         0x12
+#define MPU9250_RA_MAG_CNTL1        0x0A
 
 #define MPU9250_ADDRESS_AD0_LOW     0x68 // address pin low (GND), default for InvenSense evaluation board
 #define MPU9250_ADDRESS_AD0_HIGH    0x69 // address pin high (VCC)
@@ -997,9 +1004,11 @@ class MPU9250 {
             uint16_t dmpGetFIFOPacketSize();
         #endif
 
+        void getMagnetometerAdjustments(float *adjustments);
     private:
         uint8_t devAddr;
         uint8_t buffer[14];
+        float asax, asay, asaz;
 };
 
 #endif /* _MPU9250_H_ */

--- a/src/mahony.cpp
+++ b/src/mahony.cpp
@@ -65,10 +65,7 @@ void mahonyQuaternionUpdate(float q[4], float ax, float ay, float az, float gx, 
     hy = az * mx - ax * mz;
     hz = ax * my - ay * mx;
     // Normalise horizon vector
-    norm = sqrt(hx * hx + hy * hy + hz * hz);
-    if (norm == 0.0f) return;
-
-    norm = 1.0f / norm;
+    norm = invSqrt(hx * hx + hy * hy + hz * hz);
     hx *= norm;
     hy *= norm;
     hz *= norm;
@@ -114,8 +111,7 @@ void mahonyQuaternionUpdate(float q[4], float ax, float ay, float az, float gx, 
     q4 = pc + (q1 * gz + pa * gy - pb * gx) * (0.5f * deltat);
 
     // Normalise quaternion
-    norm = sqrt(q1 * q1 + q2 * q2 + q3 * q3 + q4 * q4);
-    norm = 1.0f / norm;
+    norm = invSqrt(q1 * q1 + q2 * q2 + q3 * q3 + q4 * q4);
     q[0] = q1 * norm;
     q[1] = q2 * norm;
     q[2] = q3 * norm;
@@ -181,7 +177,7 @@ void mahonyQuaternionUpdate(float q[4], float ax, float ay, float az, float gx, 
     q[3] += (qa * gz + qb * gy - qc * gx);
 
     // normalise quaternion
-    norm = 1.0f / sqrt(q[0] * q[0] + q[1] * q[1] + q[2] * q[2] + q[3] * q[3]);
+    norm = invSqrt(q[0] * q[0] + q[1] * q[1] + q[2] * q[2] + q[3] * q[3]);
     q[0] = q[0] * norm;
     q[1] = q[1] * norm;
     q[2] = q[2] * norm;

--- a/src/mahony.cpp
+++ b/src/mahony.cpp
@@ -1,0 +1,189 @@
+/*
+    SlimeVR Code is placed under the MIT license
+    Copyright (c) 2021 Eiren Rain
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+    THE SOFTWARE.
+*/
+
+#include "mahony.h"
+
+// These are the free parameters in the Mahony filter and fusion scheme,
+// Kp for proportional feedback, Ki for integral
+// with MPU-9250, angles start oscillating at Kp=40. Ki does not seem to help and is not required.
+#define Kp 10.0f
+#define Ki 0.0f
+
+// Mahony orientation filter, assumed World Frame NWU (xNorth, yWest, zUp)
+// Modified from Madgwick version to remove Z component of magnetometer:
+// reference vectors are Up (Acc) and West (Acc cross Mag)
+// sjr 12/2020
+// input vectors ax, ay, az and mx, my, mz MUST be normalized!
+// gx, gy, gz must be in units of radians/second
+void mahonyQuaternionUpdate(float q[4], float ax, float ay, float az, float gx, float gy, float gz, float mx, float my, float mz, float deltat)
+{
+    // Vector to hold integral error for Mahony method
+    static float eInt[3] = {0.0f, 0.0f, 0.0f};
+
+    // short name local variable for readability
+    float q1 = q[0], q2 = q[1], q3 = q[2], q4 = q[3];
+    float norm;
+    float hx, hy, hz;  //observed West vector W = AxM
+    float ux, uy, uz, wx, wy, wz; //calculated A (Up) and W in body frame
+    float ex, ey, ez;
+    float pa, pb, pc;
+
+    // Auxiliary variables to avoid repeated arithmetic
+    float q1q1 = q1 * q1;
+    float q1q2 = q1 * q2;
+    float q1q3 = q1 * q3;
+    float q1q4 = q1 * q4;
+    float q2q2 = q2 * q2;
+    float q2q3 = q2 * q3;
+    float q2q4 = q2 * q4;
+    float q3q3 = q3 * q3;
+    float q3q4 = q3 * q4;
+    float q4q4 = q4 * q4;
+
+    // Measured horizon vector = a x m (in body frame)
+    hx = ay * mz - az * my;
+    hy = az * mx - ax * mz;
+    hz = ax * my - ay * mx;
+    // Normalise horizon vector
+    norm = sqrt(hx * hx + hy * hy + hz * hz);
+    if (norm == 0.0f) return;
+
+    norm = 1.0f / norm;
+    hx *= norm;
+    hy *= norm;
+    hz *= norm;
+
+    // Estimated direction of Up reference vector
+    ux = 2.0f * (q2q4 - q1q3);
+    uy = 2.0f * (q1q2 + q3q4);
+    uz = q1q1 - q2q2 - q3q3 + q4q4;
+
+    // estimated direction of horizon (West) reference vector
+    wx = 2.0f * (q2q3 + q1q4);
+    wy = q1q1 - q2q2 + q3q3 - q4q4;
+    wz = 2.0f * (q3q4 - q1q2);
+
+    // Error is cross product between estimated direction and measured direction of the reference vectors
+    ex = (ay * uz - az * uy) + (hy * wz - hz * wy);
+    ey = (az * ux - ax * uz) + (hz * wx - hx * wz);
+    ez = (ax * uy - ay * ux) + (hx * wy - hy * wx);
+
+    if (Ki > 0.0f)
+    {
+        eInt[0] += ex; // accumulate integral error
+        eInt[1] += ey;
+        eInt[2] += ez;
+        // Apply I feedback
+        gx += Ki * eInt[0];
+        gy += Ki * eInt[1];
+        gz += Ki * eInt[2];
+    }
+
+    // Apply P feedback
+    gx = gx + Kp * ex;
+    gy = gy + Kp * ey;
+    gz = gz + Kp * ez;
+
+    // Integrate rate of change of quaternion
+    pa = q2;
+    pb = q3;
+    pc = q4;
+    q1 = q1 + (-q2 * gx - q3 * gy - q4 * gz) * (0.5f * deltat);
+    q2 = pa + (q1 * gx + pb * gz - pc * gy) * (0.5f * deltat);
+    q3 = pb + (q1 * gy - pa * gz + pc * gx) * (0.5f * deltat);
+    q4 = pc + (q1 * gz + pa * gy - pb * gx) * (0.5f * deltat);
+
+    // Normalise quaternion
+    norm = sqrt(q1 * q1 + q2 * q2 + q3 * q3 + q4 * q4);
+    norm = 1.0f / norm;
+    q[0] = q1 * norm;
+    q[1] = q2 * norm;
+    q[2] = q3 * norm;
+    q[3] = q4 * norm;
+}
+
+void mahonyQuaternionUpdate(float q[4], float ax, float ay, float az, float gx, float gy, float gz, float deltat) {
+    float norm;
+    float vx, vy, vz;
+    float ex, ey, ez;  //error terms
+    float qa, qb, qc;
+    static float ix = 0.0f, iy = 0.0f, iz = 0.0f;  //integral feedback terms
+    float tmp;
+
+    // Compute feedback only if accelerometer measurement valid (avoids NaN in accelerometer normalisation)
+    tmp = ax * ax + ay * ay + az * az;
+    if (tmp > 0.0f)
+    {
+        // Normalise accelerometer (assumed to measure the direction of gravity in body frame)
+        norm = invSqrt(tmp);
+        ax *= norm;
+        ay *= norm;
+        az *= norm;
+
+        // Estimated direction of gravity in the body frame (factor of two divided out)
+        vx = q[1] * q[3] - q[0] * q[2];
+        vy = q[0] * q[1] + q[2] * q[3];
+        vz = q[0] * q[0] - 0.5f + q[3] * q[3];
+
+        // Error is cross product between estimated and measured direction of gravity in body frame
+        // (half the actual magnitude)
+        ex = (ay * vz - az * vy);
+        ey = (az * vx - ax * vz);
+        ez = (ax * vy - ay * vx);
+
+        // Compute and apply to gyro term the integral feedback, if enabled
+        if (Ki > 0.0f) {
+            ix += Ki * ex * deltat;  // integral error scaled by Ki
+            iy += Ki * ey * deltat;
+            iz += Ki * ez * deltat;
+            gx += ix;  // apply integral feedback
+            gy += iy;
+            gz += iz;
+        }
+
+        // Apply proportional feedback to gyro term
+        gx += Kp * ex;
+        gy += Kp * ey;
+        gz += Kp * ez;
+    }
+
+    // Integrate rate of change of quaternion, q cross gyro term
+    deltat = 0.5f * deltat;
+    gx *= deltat;   // pre-multiply common factors
+    gy *= deltat;
+    gz *= deltat;
+    qa = q[0];
+    qb = q[1];
+    qc = q[2];
+    q[0] += (-qb * gx - qc * gy - q[3] * gz);
+    q[1] += (qa * gx + qc * gz - q[3] * gy);
+    q[2] += (qa * gy - qb * gz + q[3] * gx);
+    q[3] += (qa * gz + qb * gy - qc * gx);
+
+    // normalise quaternion
+    norm = 1.0f / sqrt(q[0] * q[0] + q[1] * q[1] + q[2] * q[2] + q[3] * q[3]);
+    q[0] = q[0] * norm;
+    q[1] = q[1] * norm;
+    q[2] = q[2] * norm;
+    q[3] = q[3] * norm;
+}

--- a/src/mahony.h
+++ b/src/mahony.h
@@ -1,0 +1,32 @@
+/*
+    SlimeVR Code is placed under the MIT license
+    Copyright (c) 2021 Eiren Rain
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+    THE SOFTWARE.
+*/
+
+#ifndef _MAHONY_H_
+#define _MAHONY_H_
+
+#include "helper_3dmath.h"
+
+void mahonyQuaternionUpdate(float q[4], float ax, float ay, float az, float gx, float gy, float gz, float deltat);
+void mahonyQuaternionUpdate(float q[4], float ax, float ay, float az, float gx, float gy, float gz, float mx, float my, float mz, float deltat);
+
+#endif /* _MAHONY_H_ */

--- a/src/mpu9250sensor.cpp
+++ b/src/mpu9250sensor.cpp
@@ -108,16 +108,16 @@ void MPU9250Sensor::getMPUScaled()
     Axyz[1] = (float)ay;
     Axyz[2] = (float)az;
     //apply offsets (bias) and scale factors from Magneto
-    if(useFullCalibrationMatrix) {
+    #if useFullCalibrationMatrix == true
         for (i = 0; i < 3; i++)
             temp[i] = (Axyz[i] - calibration->A_B[i]);
         Axyz[0] = calibration->A_Ainv[0][0] * temp[0] + calibration->A_Ainv[0][1] * temp[1] + calibration->A_Ainv[0][2] * temp[2];
         Axyz[1] = calibration->A_Ainv[1][0] * temp[0] + calibration->A_Ainv[1][1] * temp[1] + calibration->A_Ainv[1][2] * temp[2];
         Axyz[2] = calibration->A_Ainv[2][0] * temp[0] + calibration->A_Ainv[2][1] * temp[1] + calibration->A_Ainv[2][2] * temp[2];
-    } else {
+    #else
         for (i = 0; i < 3; i++)
             Axyz[i] = (Axyz[i] - calibration->A_B[i]);
-    }
+    #endif
     vector_normalize(Axyz);
 
     // Apply correction for 16-bit mode and factory sensitivity adjustments
@@ -125,16 +125,16 @@ void MPU9250Sensor::getMPUScaled()
     Mxyz[1] = (float)my * 0.15f * adjustments[1];
     Mxyz[2] = (float)mz * 0.15f * adjustments[2];
     //apply offsets and scale factors from Magneto
-    if(useFullCalibrationMatrix) {
+    #if useFullCalibrationMatrix == true
         for (i = 0; i < 3; i++)
             temp[i] = (Mxyz[i] - calibration->M_B[i]);
         Mxyz[0] = calibration->M_Ainv[0][0] * temp[0] + calibration->M_Ainv[0][1] * temp[1] + calibration->M_Ainv[0][2] * temp[2];
         Mxyz[1] = calibration->M_Ainv[1][0] * temp[0] + calibration->M_Ainv[1][1] * temp[1] + calibration->M_Ainv[1][2] * temp[2];
         Mxyz[2] = calibration->M_Ainv[2][0] * temp[0] + calibration->M_Ainv[2][1] * temp[1] + calibration->M_Ainv[2][2] * temp[2];
-    } else {
+    #else
         for (i = 0; i < 3; i++)
             Mxyz[i] = (Mxyz[i] - calibration->M_B[i]);
-    }
+    #endif
     rawMag[0] = Mxyz[0];
     rawMag[1] = Mxyz[1];
     rawMag[2] = Mxyz[2];

--- a/src/mpu9250sensor.cpp
+++ b/src/mpu9250sensor.cpp
@@ -30,7 +30,7 @@
 #include "calibration.h"
 #include "mahony.h"
 
-#define gscale (250. / 32768.0) * (PI / 180.0) //gyro default 250 LSB per d/s -> rad/s
+constexpr float gscale = (250. / 32768.0) * (PI / 180.0); //gyro default 250 LSB per d/s -> rad/s
 
 namespace {
     void signalAssert() {

--- a/src/mpu9250sensor.cpp
+++ b/src/mpu9250sensor.cpp
@@ -28,18 +28,9 @@
 #include "helper_3dmath.h"
 #include <i2cscan.h>
 #include "calibration.h"
+#include "mahony.h"
 
 #define gscale (250. / 32768.0) * (PI / 180.0) //gyro default 250 LSB per d/s -> rad/s
-// These are the free parameters in the Mahony filter and fusion scheme,
-// Kp for proportional feedback, Ki for integral
-// with MPU-9250, angles start oscillating at Kp=40. Ki does not seem to help and is not required.
-#define Kp 10.0
-#define Ki 0.0
-
-CalibrationConfig * calibration;
-
-void get_MPU_scaled();
-void MahonyQuaternionUpdate(float ax, float ay, float az, float gx, float gy, float gz, float mx, float my, float mz, float deltat);
 
 namespace {
     void signalAssert() {
@@ -81,7 +72,7 @@ void MPU9250Sensor::motionLoop() {
     deltat = (now - last) * 1.0e-6; //seconds since last update
     last = now;
     getMPUScaled();
-    MahonyQuaternionUpdate(Axyz[0], Axyz[1], Axyz[2], Gxyz[0], Gxyz[1], Gxyz[2], Mxyz[1], Mxyz[0], -Mxyz[2], deltat);
+    mahonyQuaternionUpdate(q, Axyz[0], Axyz[1], Axyz[2], Gxyz[0], Gxyz[1], Gxyz[2], Mxyz[1], Mxyz[0], -Mxyz[2], deltat);
     quaternion.set(-q[1], -q[2], -q[0], q[3]);
     quaternion *= sensorOffset;
     if(!lastQuatSent.equalsWithEpsilon(quaternion)) {
@@ -141,100 +132,6 @@ void MPU9250Sensor::getMPUScaled()
     rawMag[1] = Mxyz[1];
     rawMag[2] = Mxyz[2];
     vector_normalize(Mxyz);
-}
-
-// Mahony orientation filter, assumed World Frame NWU (xNorth, yWest, zUp)
-// Modified from Madgwick version to remove Z component of magnetometer:
-// reference vectors are Up (Acc) and West (Acc cross Mag)
-// sjr 12/2020
-// input vectors ax, ay, az and mx, my, mz MUST be normalized!
-// gx, gy, gz must be in units of radians/second
-//
-void MPU9250Sensor::MahonyQuaternionUpdate(float ax, float ay, float az, float gx, float gy, float gz, float mx, float my, float mz, float deltat)
-{
-    // Vector to hold integral error for Mahony method
-    static float eInt[3] = {0.0, 0.0, 0.0};
-
-    // short name local variable for readability
-    float q1 = q[0], q2 = q[1], q3 = q[2], q4 = q[3];
-    float norm;
-    float hx, hy, hz;  //observed West vector W = AxM
-    float ux, uy, uz, wx, wy, wz; //calculated A (Up) and W in body frame
-    float ex, ey, ez;
-    float pa, pb, pc;
-
-    // Auxiliary variables to avoid repeated arithmetic
-    float q1q1 = q1 * q1;
-    float q1q2 = q1 * q2;
-    float q1q3 = q1 * q3;
-    float q1q4 = q1 * q4;
-    float q2q2 = q2 * q2;
-    float q2q3 = q2 * q3;
-    float q2q4 = q2 * q4;
-    float q3q3 = q3 * q3;
-    float q3q4 = q3 * q4;
-    float q4q4 = q4 * q4;
-
-    // Measured horizon vector = a x m (in body frame)
-    hx = ay * mz - az * my;
-    hy = az * mx - ax * mz;
-    hz = ax * my - ay * mx;
-    // Normalise horizon vector
-    norm = sqrt(hx * hx + hy * hy + hz * hz);
-    if (norm == 0.0f) return; // Handle div by zero
-
-    norm = 1.0f / norm;
-    hx *= norm;
-    hy *= norm;
-    hz *= norm;
-
-    // Estimated direction of Up reference vector
-    ux = 2.0f * (q2q4 - q1q3);
-    uy = 2.0f * (q1q2 + q3q4);
-    uz = q1q1 - q2q2 - q3q3 + q4q4;
-
-    // estimated direction of horizon (West) reference vector
-    wx = 2.0f * (q2q3 + q1q4);
-    wy = q1q1 - q2q2 + q3q3 - q4q4;
-    wz = 2.0f * (q3q4 - q1q2);
-
-    // Error is cross product between estimated direction and measured direction of the reference vectors
-    ex = (ay * uz - az * uy) + (hy * wz - hz * wy);
-    ey = (az * ux - ax * uz) + (hz * wx - hx * wz);
-    ez = (ax * uy - ay * ux) + (hx * wy - hy * wx);
-
-    if (Ki > 0.0f)
-    {
-        eInt[0] += ex; // accumulate integral error
-        eInt[1] += ey;
-        eInt[2] += ez;
-        // Apply I feedback
-        gx += Ki * eInt[0];
-        gy += Ki * eInt[1];
-        gz += Ki * eInt[2];
-    }
-
-    // Apply P feedback
-    gx = gx + Kp * ex;
-    gy = gy + Kp * ey;
-    gz = gz + Kp * ez;
-
-    // Integrate rate of change of quaternion
-    pa = q2;
-    pb = q3;
-    pc = q4;
-    q1 = q1 + (-q2 * gx - q3 * gy - q4 * gz) * (0.5f * deltat);
-    q2 = pa + (q1 * gx + pb * gz - pc * gy) * (0.5f * deltat);
-    q3 = pb + (q1 * gy - pa * gz + pc * gx) * (0.5f * deltat);
-    q4 = pc + (q1 * gz + pa * gy - pb * gx) * (0.5f * deltat);
-
-    // Normalise quaternion
-    norm = sqrt(q1 * q1 + q2 * q2 + q3 * q3 + q4 * q4);
-    norm = 1.0f / norm;
-    q[0] = q1 * norm;
-    q[1] = q2 * norm;
-    q[2] = q3 * norm;
-    q[3] = q4 * norm;
 }
 
 void MPU9250Sensor::startCalibration(int calibrationType) {

--- a/src/mpu9250sensor.cpp
+++ b/src/mpu9250sensor.cpp
@@ -69,15 +69,20 @@ void MPU9250Sensor::motionSetup() {
 void MPU9250Sensor::motionLoop() {
     // Update quaternion
     now = micros();
-    deltat = (now - last) * 1.0e-6; //seconds since last update
-    last = now;
-    getMPUScaled();
-    mahonyQuaternionUpdate(q, Axyz[0], Axyz[1], Axyz[2], Gxyz[0], Gxyz[1], Gxyz[2], Mxyz[1], Mxyz[0], -Mxyz[2], deltat);
-    quaternion.set(-q[1], -q[2], -q[0], q[3]);
-    quaternion *= sensorOffset;
-    if(!lastQuatSent.equalsWithEpsilon(quaternion)) {
-        newData = true;
-        lastQuatSent = quaternion;
+    deltat = now - last; //seconds since last update
+    if ((deltat * 1.0e-3) >= samplingRateInMillis) {
+        last = now;
+        getMPUScaled();
+        // Orientations of axes are set in accordance with the datasheet
+        // See Section 9.1 Orientation of Axes
+        // https://invensense.tdk.com/wp-content/uploads/2015/02/PS-MPU-9250A-01-v1.1.pdf
+        mahonyQuaternionUpdate(q, Axyz[0], Axyz[1], Axyz[2], Gxyz[0], Gxyz[1], Gxyz[2], Mxyz[1], Mxyz[0], -Mxyz[2], deltat * 1.0e-6);
+        quaternion.set(-q[1], -q[2], -q[0], q[3]);
+        quaternion *= sensorOffset;
+        if(!lastQuatSent.equalsWithEpsilon(quaternion)) {
+            newData = true;
+            lastQuatSent = quaternion;
+        }
     }
 }
 

--- a/src/mpu9250sensor.cpp
+++ b/src/mpu9250sensor.cpp
@@ -64,6 +64,7 @@ void MPU9250Sensor::motionSetup() {
         Serial.print("[OK] Connected to MPU, ID 0x");
         Serial.println(imu.getDeviceID(), HEX);
     }
+    imu.getMagnetometerAdjustments(adjustments);
 }
 
 void MPU9250Sensor::motionLoop() {
@@ -119,9 +120,10 @@ void MPU9250Sensor::getMPUScaled()
     }
     vector_normalize(Axyz);
 
-    Mxyz[0] = (float)mx;
-    Mxyz[1] = (float)my;
-    Mxyz[2] = (float)mz;
+    // Apply correction for 16-bit mode and factory sensitivity adjustments
+    Mxyz[0] = (float)mx * 0.15f * adjustments[0];
+    Mxyz[1] = (float)my * 0.15f * adjustments[1];
+    Mxyz[2] = (float)mz * 0.15f * adjustments[2];
     //apply offsets and scale factors from Magneto
     if(useFullCalibrationMatrix) {
         for (i = 0; i < 3; i++)

--- a/src/sensor.h
+++ b/src/sensor.h
@@ -145,7 +145,6 @@ class MPU9250Sensor : public MPUSensor {
         void sendData() override final;
         void startCalibration(int calibrationType) override final;
         void getMPUScaled();
-        void MahonyQuaternionUpdate(float ax, float ay, float az, float gx, float gy, float gz, float mx, float my, float mz, float deltat);
     private:
         MPU9250 imu {};
         //raw data and scaled as vector

--- a/src/sensor.h
+++ b/src/sensor.h
@@ -160,6 +160,7 @@ class MPU9250Sensor : public MPUSensor {
         unsigned long now = 0, last = 0;   //micros() timers
         float deltat = 0;                  //loop time in seconds
         bool newData {false};
+        CalibrationConfig * calibration;
 };
 
 #endif // SLIMEVR_SENSOR_H_

--- a/src/sensor.h
+++ b/src/sensor.h
@@ -155,6 +155,7 @@ class MPU9250Sensor : public MPUSensor {
         float Gxyz[3] {};
         float Mxyz[3] {};
         float rawMag[3] {};
+        float adjustments[3] {};
         // Loop timing globals
         unsigned long now = 0, last = 0;   //micros() timers
         float deltat = 0;                  //loop time in seconds


### PR DESCRIPTION
> NOTE: This is not tested. Similar code was used on different magnetometer and it works. Any volunteers with MPU-9250 are welcome.

Improves magnetometer support for MPU-9250. This includes faster update rate (100hz), proper scaling using factory adjustments and mode correction, and possibility to run two 9250 without conflicts due to magnetometer.

This will require to add scaling factors to calibration process introduced in https://github.com/SlimeVR/SlimeVR-Tracker-ESP/pull/32.