### PR TITLE
Set baudrate to 74880 for esp8266

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -11,7 +11,6 @@
 [env]
 lib_deps=
   https://github.com/pvizeli/CmdParser.git
-monitor_speed = 115200
 framework = arduino
 ;If you want to set hardcoded WiFi SSID and password, uncomment and edit the lines below
 ; '" - quotes are necessary!
@@ -30,11 +29,13 @@ framework = arduino
 ; Settings for different boards
 
 [env:esp12e]
+monitor_speed = 74880
 platform = espressif8266
 board = esp12e
 
 ; Uncomment below if you want to build for esp32
 ; Check your board name at https://docs.platformio.org/en/latest/platforms/espressif32.html#boards
 ;[env:esp32]
+;monitor_speed = 115200
 ;platform = espressif32
 ;board = esp32dev

--- a/src/debug.h
+++ b/src/debug.h
@@ -28,7 +28,11 @@
 //Debug information
 //#define FULL_DEBUG
 #define serialDebug false // Set to true to get Serial output for debugging
-#define serialBaudRate 115200
+#ifdef ESP8266
+    #define serialBaudRate 74880
+#else
+    #define serialBaudRate 115200
+#endif
 #define UPDATE_IMU_UNCONNECTED 1
 #define SEND_UPDATES_UNCONNECTED 1
 #define LED_INTERVAL_STANDBUY 10000


### PR DESCRIPTION
This fixes garbage characters during boot at a cost of lower serial speed in general. Helps with debugging weird board issues by looking at the boot mode:
https://riktronics.wordpress.com/2017/10/02/esp8266-error-messages-and-exceptions-explained/
![image](https://user-images.githubusercontent.com/6103913/148298428-50964dd3-b358-4df5-b131-c38a1c93a30b.png)