### PR TITLE
Hotfix for esp32 not compiling

### DIFF
--- a/src/consts.h
+++ b/src/consts.h
@@ -46,11 +46,11 @@
 #define BAT_MCP3021 3
 #define BAT_INTERNAL_MCP3021 4
 
-#define POWER_SAVING_NONE 0
-#define POWER_SAVING_MINIMUM 1
-#define POWER_SAVING_MODERATE 2
-//Should not be used yet => disconnects a lot
-//#define POWER_SAVING_MAXIMUM 3
+#define POWER_SAVING_LEGACY 0 // No sleeping, but PS enabled
+#define POWER_SAVING_NONE 1 // No sleeping, no PS => for connection issues
+#define POWER_SAVING_MINIMUM 2 // Sleeping and PS => default
+#define POWER_SAVING_MODERATE 3 // Sleeping and better PS => might miss broadcasts, use at own risk
+#define POWER_SAVING_MAXIMUM 4 // Actual CPU sleeping, currently has issues with disconnecting
 
 #define DEG_0 0.f
 #define DEG_90 -PI / 2


### PR DESCRIPTION
I could have sworn i made a PR for this but i must have forgotten to push the create button, my bad... :c
Might want to test the actual esp32 power saving still on actual trackers => i only have the chips but no imus anymore to hook up.
In any (worst) case if esp32 ps doesn't work you can enable POWER_SAVING_LEGACY now which will literally go back to the state before any power saving edits were even a thing... so then they can at least work again pretty quickly without having to use different code...