### PR TITLE
Fixing buildings error with WEMOS board

### DIFF
--- a/src/globals.h
+++ b/src/globals.h
@@ -23,6 +23,7 @@
 #ifndef SLIMEVR_GLOBALS_H_
 #define SLIMEVR_GLOBALS_H_
 
+#include <Arduino.h>
 #include "consts.h"
 #include "debug.h"
 #include "defines.h"


### PR DESCRIPTION
Including Arduino.h for getting all definitions from Boards before we go trough all other definitions. (Pins Definition)