### PR TITLE
Add "flip to calibrate" and remove unnecessary accelerometer normalization

### DIFF
--- a/src/sensors/bmi160sensor.cpp
+++ b/src/sensors/bmi160sensor.cpp
@@ -66,6 +66,17 @@ void BMI160Sensor::motionSetup() {
     Serial.print("[OK] Connected to BMI160, ID 0x");
     Serial.println(imu.getDeviceID(), HEX);
 
+    int16_t ax, ay, az;
+    imu.getAcceleration(&ax, &ay, &az);
+    if(az < 0 && 10 * (ax * ax + ay * ay) < az * az) {
+        digitalWrite(CALIBRATING_LED, HIGH);
+        Serial.println("Calling Calibration... Flip front to confirm start calibration.");
+        imu.getAcceleration(&ax, &ay, &az);
+        if(az > 0 && 10 * (ax * ax + ay * ay) < az * az)
+            startCalibration(0);
+        digitalWrite(CALIBRATING_LED, LOW);
+    }
+
     DeviceConfig * const config = getConfigPtr();
     calibration = &config->calibration[sensorId];
     working = true;

--- a/src/sensors/bmi160sensor.cpp
+++ b/src/sensors/bmi160sensor.cpp
@@ -133,7 +133,6 @@ void BMI160Sensor::getScaledValues(float Gxyz[3], float Axyz[3])
         for (uint8_t i = 0; i < 3; i++)
             Axyz[i] = (Axyz[i] - calibration->A_B[i]);
     #endif
-    vector_normalize(Axyz);
 }
 
 void BMI160Sensor::startCalibration(int calibrationType) {


### PR DESCRIPTION
1. Add "flip to calibrate" code from MPU9250 to make it possible to calibrate.
2. Accelerometer is already being normalized in Mahony filter function, so not needed on scaling stage.