### PR TITLE
Use strict device ID check for MPUs

### DIFF
--- a/lib/mpu6050/MPU6050.cpp
+++ b/lib/mpu6050/MPU6050.cpp
@@ -66,7 +66,8 @@ void MPU6050::initialize(uint8_t address) {
  * @return True if connection is valid, false otherwise
  */
 bool MPU6050::testConnection() {
-    return getDeviceID() > 0;
+    uint8_t deviceId = getDeviceID();
+    return deviceId == 0x68 || deviceId == 0x70 || deviceId == 0x71 || deviceId == 0x73; // Allow any MPUs
 }
 
 // AUX_VDDIO register (InvenSense demo code calls this RA_*G_OFFS_TC)
@@ -2801,7 +2802,7 @@ void MPU6050::setFIFOByte(uint8_t data) {
  * @see MPU6050_WHO_AM_I_LENGTH
  */
 uint8_t MPU6050::getDeviceID() {
-    I2Cdev::readBits(devAddr, MPU6050_RA_WHO_AM_I, MPU6050_WHO_AM_I_BIT, MPU6050_WHO_AM_I_LENGTH, buffer);
+    I2Cdev::readByte(devAddr, MPU6050_RA_WHO_AM_I, buffer);
     return buffer[0];
 }
 /** Set Device ID.

--- a/lib/mpu9250/MPU9250.cpp
+++ b/lib/mpu9250/MPU9250.cpp
@@ -73,7 +73,8 @@ uint8_t MPU9250_Base::getAddr() {
  * @return True if connection is valid, false otherwise
  */
 bool MPU9250_Base::testConnection() {
-    return getDeviceID() == 0x71;
+    uint8_t deviceId = getDeviceID();
+    return deviceId == 0x71 || deviceId == 0x73; // MPU9250 or MPU9255
 }
 
 // AUX_VDDIO register (InvenSense demo code calls this RA_*G_OFFS_TC)
@@ -2700,7 +2701,7 @@ void MPU9250_Base::setFIFOByte(uint8_t data) {
  * @see MPU9250_WHO_AM_I_LENGTH
  */
 uint8_t MPU9250_Base::getDeviceID() {
-    I2Cdev::readBits(devAddr, MPU9250_RA_WHO_AM_I, MPU9250_WHO_AM_I_BIT, MPU9250_WHO_AM_I_LENGTH, buffer);
+    I2Cdev::readByte(devAddr, MPU9250_RA_WHO_AM_I, buffer);
     return buffer[0];
 }
 /** Set Device ID.

--- a/src/sensors/mpu6050sensor.cpp
+++ b/src/sensors/mpu6050sensor.cpp
@@ -48,6 +48,9 @@ void MPU6050Sensor::motionSetup()
         return;
     }
 
+    Serial.print("[OK] MPU6050: Connected to MPU, ID 0x");
+    Serial.println(imu.getDeviceID(), HEX);
+
     devStatus = imu.dmpInitialize();
 
     if (devStatus == 0)

--- a/src/sensors/mpu9250sensor.cpp
+++ b/src/sensors/mpu9250sensor.cpp
@@ -46,10 +46,11 @@ void MPU9250Sensor::motionSetup() {
         Serial.print("[ERR] MPU9250: Can't communicate with MPU, response 0x");
         Serial.println(imu.getDeviceID(), HEX);
         return;
-    } else {
-        Serial.print("[OK] Connected to MPU, ID 0x");
-        Serial.println(imu.getDeviceID(), HEX);
     }
+
+    Serial.print("[OK] MPU9250: Connected to MPU, ID 0x");
+        Serial.println(imu.getDeviceID(), HEX);
+
     int16_t ax,ay,az;
 
     // turn on while flip back to calibrate. then, flip again after 5 seconds.    


### PR DESCRIPTION
Allow only MPU92xx for MPU9250 library, and any MPU for MPU6050 library. Also fixes broken device ID check for MPU92xx family.