### PR TITLE
Fix quaternion values

### DIFF
--- a/src/sensors/bmi160sensor.cpp
+++ b/src/sensors/bmi160sensor.cpp
@@ -94,7 +94,7 @@ void BMI160Sensor::motionLoop() {
         getScaledValues(Gxyz, Axyz);
 
         mahonyQuaternionUpdate(q, Axyz[0], Axyz[1], Axyz[2], Gxyz[0], Gxyz[1], Gxyz[2], deltat * 1.0e-6f);
-        quaternion.set(-q[1], -q[2], -q[0], q[3]);
+        quaternion.set(-q[2], q[1], q[3], q[0]);
         quaternion *= sensorOffset;
         if (!OPTIMIZE_UPDATES || !lastQuatSent.equalsWithEpsilon(quaternion))
         {


### PR DESCRIPTION
I've no idea why I did this and how it was working, but the values are misplaced. Use the same as MPU9250.