### PR TITLE
Update defines.h

### DIFF
--- a/src/defines.h
+++ b/src/defines.h
@@ -56,6 +56,7 @@
   #define PIN_IMU_INT 255
   #define PIN_IMU_INT_2 255
   #define ENABLE_LEDS false
+  #define PIN_BATTERY_LEVEL 255
 #elif BOARD == BOARD_TTGO_TBASE
   #define PIN_IMU_SDA 5
   #define PIN_IMU_SCL 4


### PR DESCRIPTION
while board esp01 doesnt have ""#define PIN_BATTERY_LEVEL 255"" line gives 'undefined batter level pin' on build.