### PR TITLE
cmdReport -> cmdReboot

### DIFF
--- a/src/serial/serialcommands.cpp
+++ b/src/serial/serialcommands.cpp
@@ -78,7 +78,7 @@ namespace SerialCommands {
         cmdCallbacks.addCmd("GET", &cmdGet);
         cmdCallbacks.addCmd("FRST", &cmdFactoryReset);
         cmdCallbacks.addCmd("REP", &cmdReport);
-        cmdCallbacks.addCmd("REBOOT", &cmdReport);
+        cmdCallbacks.addCmd("REBOOT", &cmdReboot);
     }
 
     void update() {


### PR DESCRIPTION
It's seems like a typo.
(It was so similar that I didn't know what was wrong...!)