### PR TITLE
cmdFactoryReset function implementation

### DIFF
--- a/src/serial/serialcommands.cpp
+++ b/src/serial/serialcommands.cpp
@@ -70,7 +70,14 @@ namespace SerialCommands {
     }
 
     void cmdFactoryReset(CmdParser * parser) {
-        // TODO Factory reset
+        Serial.print("[OK] FACTORY RESET");
+        for (int i = 0; i <= 4096; i++) // Clear EEPROM
+            EEPROM.write(i, 0xFF);
+        EEPROM.commit();
+        WiFi.disconnect(true); // Clear WiFi credentials
+        ESP.eraseConfig(); // Clear ESP config
+        delay(3000);
+        ESP.restart();
     }
 
     void setUp() {


### PR DESCRIPTION
Erase the EEPROM and credentials for use when using the ESP for selling or other purposes.
(I fixed the EEPROM size to 4096 bytes, but as far as I know, there was no other size.If a change is required, it may need to be modified.)