### PR TITLE
Faster upload speed for ESP8266

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -40,6 +40,8 @@ build_unflags = -Os
 [env:esp12e]
 platform = espressif8266
 board = esp12e
+; Comment this line below if you have any trouble uploading the firmware
+upload_speed = 921600
 
 ; Uncomment below if you want to build for ESP-01
 ;[env:esp01_1m]


### PR DESCRIPTION
### Change the upload baud rate to 921600 (as CH340G can handle it) and save quite a lot of time actually

Before
`Wrote 389152 bytes (280698 compressed) at 0x00000000 in 24.8 seconds (effective 125.7 kbit/s)...`

After
`Wrote 389152 bytes (280698 compressed) at 0x00000000 in 4.1 seconds (effective 760.6 kbit/s)...`