### PR TITLE
Small addition to comments for platformio file

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -18,6 +18,7 @@ monitor_speed = 115200
 framework = arduino
 build_flags =
 ;If you want to set hardcoded WiFi SSID and password, uncomment and edit the lines below
+;To uncomment, only remove ";" and leave the two spaces in front of the tags
 ; '" - quotes are necessary!
 ;  -DWIFI_CREDS_SSID='"SSID"'
 ;  -DWIFI_CREDS_PASSWD='"PASSWORD"'


### PR DESCRIPTION
Silly little commit that just adds a comment about the importance of the spaces in front of the wifi build flags. Feel free to modify the wording if it is still not clear enough.