### PR TITLE
Implement better IMU identification in logger

### DIFF
--- a/src/logging/Logger.cpp
+++ b/src/logging/Logger.cpp
@@ -4,6 +4,12 @@ namespace SlimeVR
 {
   namespace Logging
   {
+    void Logger::setTag(const char *tag)
+    {
+      m_Tag = (char *)malloc(strlen(tag) + 1);
+      strcpy(m_Tag, tag);
+    }
+
     void Logger::trace(const char *format, ...)
     {
       va_list args;
@@ -62,7 +68,15 @@ namespace SlimeVR
       char buffer[256];
       vsnprintf(buffer, 256, format, args);
 
-      Serial.printf("[%-5s] [%s] %s\n", levelToString(level), m_Prefix, buffer);
+      char buf[strlen(m_Prefix) + (m_Tag == nullptr ? 0 : strlen(m_Tag)) + 2];
+      strcpy(buf, m_Prefix);
+      if (m_Tag != nullptr)
+      {
+        strcat(buf, ":");
+        strcat(buf, m_Tag);
+      }
+
+      Serial.printf("[%-5s] [%s] %s\n", levelToString(level), buf, buffer);
     }
   }
 }

--- a/src/logging/Logger.h
+++ b/src/logging/Logger.h
@@ -12,7 +12,21 @@ namespace SlimeVR
     class Logger
     {
     public:
-      Logger(const char *prefix) : m_Prefix(prefix){};
+      Logger(const char *prefix) : m_Prefix(prefix), m_Tag(nullptr){};
+      Logger(const char *prefix, const char *tag) : m_Prefix(prefix), m_Tag(nullptr)
+      {
+        setTag(tag);
+      };
+
+      ~Logger()
+      {
+        if (m_Tag != nullptr)
+        {
+          free(m_Tag);
+        }
+      }
+
+      void setTag(const char *tag);
 
       void trace(const char *str, ...);
       void debug(const char *str, ...);
@@ -68,7 +82,15 @@ namespace SlimeVR
           return;
         }
 
-        Serial.printf("[%-5s] [%s] %s", levelToString(level), m_Prefix, str);
+        char buf[strlen(m_Prefix) + (m_Tag == nullptr ? 0 : strlen(m_Tag)) + 2];
+        strcpy(buf, m_Prefix);
+        if (m_Tag != nullptr)
+        {
+          strcat(buf, ":");
+          strcat(buf, m_Tag);
+        }
+
+        Serial.printf("[%-5s] [%s] %s", levelToString(level), buf, str);
 
         for (size_t i = 0; i < size; i++)
         {
@@ -78,7 +100,8 @@ namespace SlimeVR
         Serial.println();
       }
 
-      const char *m_Prefix;
+      const char *const m_Prefix;
+      char *m_Tag;
     };
   }
 }

--- a/src/sensors/sensor.cpp
+++ b/src/sensors/sensor.cpp
@@ -31,6 +31,10 @@ void Sensor::setupSensor(uint8_t expectedSensorType, uint8_t sensorId, uint8_t a
     this->intPin = intPin;
     this->sensorId = sensorId;
     this->sensorOffset = {Quat(Vector3(0, 0, 1), sensorId == 0 ? IMU_ROTATION : SECOND_IMU_ROTATION)};
+
+    char buf[4];
+    sprintf(buf, "%u", sensorId);
+    m_Logger.setTag(buf);
 }
 
 uint8_t Sensor::getSensorState() {


### PR DESCRIPTION
The logger now shows the IMU ID on the tracker in log statements:
![image](https://user-images.githubusercontent.com/29845135/156923999-c89150bd-9a8b-4130-84e6-f5894f6b06d7.png)
