### PR TITLE
Inspection packet improvements

### DIFF
--- a/src/network/packets.h
+++ b/src/network/packets.h
@@ -57,6 +57,7 @@
 
 #define PACKET_INSPECTION_PACKETTYPE_RAW_IMU_DATA 1
 #define PACKET_INSPECTION_PACKETTYPE_FUSED_IMU_DATA 2
+#define PACKET_INSPECTION_PACKETTYPE_CORRECTION_DATA 3
 #define PACKET_INSPECTION_DATATYPE_INT 1
 #define PACKET_INSPECTION_DATATYPE_FLOAT 2
 
@@ -106,6 +107,8 @@ namespace Network {
     void sendRawIMUData(uint8_t sensorId, float rX, float rY, float rZ, uint8_t rA, float aX, float aY, float aZ, uint8_t aA, float mX, float mY, float mZ, uint8_t mA);
 
     void sendFusedIMUData(uint8_t sensorId, Quat quaternion);
+
+    void sendInspectionCorrectionData(uint8_t sensorId, Quat quaternion);
 #endif
 }
 

--- a/src/network/packets.h
+++ b/src/network/packets.h
@@ -103,10 +103,10 @@ namespace Network {
     void sendTemperature(float temperature, uint8_t sensorId);
 
 #if ENABLE_INSPECTION
-    void sendRawIMUData(uint8_t sensorId, int16_t rX, int16_t rY, int16_t rZ, uint8_t rA, int16_t aX, int16_t aY, int16_t aZ, uint8_t aA, int16_t mX, int16_t mY, int16_t mZ, uint8_t mA);
-    void sendRawIMUData(uint8_t sensorId, float rX, float rY, float rZ, uint8_t rA, float aX, float aY, float aZ, uint8_t aA, float mX, float mY, float mZ, uint8_t mA);
+    void sendInspectionRawIMUData(uint8_t sensorId, int16_t rX, int16_t rY, int16_t rZ, uint8_t rA, int16_t aX, int16_t aY, int16_t aZ, uint8_t aA, int16_t mX, int16_t mY, int16_t mZ, uint8_t mA);
+    void sendInspectionRawIMUData(uint8_t sensorId, float rX, float rY, float rZ, uint8_t rA, float aX, float aY, float aZ, uint8_t aA, float mX, float mY, float mZ, uint8_t mA);
 
-    void sendFusedIMUData(uint8_t sensorId, Quat quaternion);
+    void sendInspectionFusedIMUData(uint8_t sensorId, Quat quaternion);
 
     void sendInspectionCorrectionData(uint8_t sensorId, Quat quaternion);
 #endif

--- a/src/network/udpclient.cpp
+++ b/src/network/udpclient.cpp
@@ -463,6 +463,38 @@ void Network::sendFusedIMUData(uint8_t sensorId, Quat quaternion)
         udpClientLogger.error("FusedIMUData write end error: %d", Udp.getWriteError());
     }
 }
+
+void Network::sendInspectionCorrectionData(uint8_t sensorId, Quat quaternion)
+{
+    if (!connected) 
+    {
+        return;
+    }
+
+    if (!DataTransfer::beginPacket())
+    {
+        udpClientLogger.error("CorrectionData write begin error: %d", Udp.getWriteError());
+        return;
+    }
+
+    DataTransfer::sendPacketType(PACKET_INSPECTION);
+    DataTransfer::sendPacketNumber();
+
+    DataTransfer::sendByte(PACKET_INSPECTION_PACKETTYPE_CORRECTION_DATA);
+
+    DataTransfer::sendByte(sensorId);
+    DataTransfer::sendByte(PACKET_INSPECTION_DATATYPE_FLOAT);
+
+    DataTransfer::sendFloat(quaternion.x);
+    DataTransfer::sendFloat(quaternion.y);
+    DataTransfer::sendFloat(quaternion.z);
+    DataTransfer::sendFloat(quaternion.w);
+
+    if(!DataTransfer::endPacket())
+    {
+        udpClientLogger.error("CorrectionData write end error: %d", Udp.getWriteError());
+    }
+}
 #endif
 
 void returnLastPacket(int len) {

--- a/src/network/udpclient.cpp
+++ b/src/network/udpclient.cpp
@@ -348,7 +348,7 @@ void Network::sendHandshake() {
 }
 
 #if ENABLE_INSPECTION
-void Network::sendRawIMUData(uint8_t sensorId, int16_t rX, int16_t rY, int16_t rZ, uint8_t rA, int16_t aX, int16_t aY, int16_t aZ, uint8_t aA, int16_t mX, int16_t mY, int16_t mZ, uint8_t mA)
+void Network::sendInspectionRawIMUData(uint8_t sensorId, int16_t rX, int16_t rY, int16_t rZ, uint8_t rA, int16_t aX, int16_t aY, int16_t aZ, uint8_t aA, int16_t mX, int16_t mY, int16_t mZ, uint8_t mA)
 {
     if (!connected)
     {
@@ -390,7 +390,7 @@ void Network::sendRawIMUData(uint8_t sensorId, int16_t rX, int16_t rY, int16_t r
     }
 }
 
-void Network::sendRawIMUData(uint8_t sensorId, float rX, float rY, float rZ, uint8_t rA, float aX, float aY, float aZ, uint8_t aA, float mX, float mY, float mZ, uint8_t mA)
+void Network::sendInspectionRawIMUData(uint8_t sensorId, float rX, float rY, float rZ, uint8_t rA, float aX, float aY, float aZ, uint8_t aA, float mX, float mY, float mZ, uint8_t mA)
 {
     if (!connected) 
     {
@@ -432,7 +432,7 @@ void Network::sendRawIMUData(uint8_t sensorId, float rX, float rY, float rZ, uin
     }
 }
 
-void Network::sendFusedIMUData(uint8_t sensorId, Quat quaternion)
+void Network::sendInspectionFusedIMUData(uint8_t sensorId, Quat quaternion)
 {
     if (!connected) 
     {

--- a/src/sensors/bmi160sensor.cpp
+++ b/src/sensors/bmi160sensor.cpp
@@ -95,7 +95,7 @@ void BMI160Sensor::motionLoop() {
         imu.getRotation(&rX, &rY, &rZ);
         imu.getAcceleration(&aX, &aY, &aZ);
 
-        Network::sendRawIMUData(sensorId, rX, rY, rZ, 255, aX, aY, aZ, 255, 0, 0, 0, 255);
+        Network::sendInspectionRawIMUData(sensorId, rX, rY, rZ, 255, aX, aY, aZ, 255, 0, 0, 0, 255);
     }
 #endif
 
@@ -113,7 +113,7 @@ void BMI160Sensor::motionLoop() {
 
 #if ENABLE_INSPECTION
     {
-        Network::sendFusedIMUData(sensorId, quaternion);
+        Network::sendInspectionFusedIMUData(sensorId, quaternion);
     }
 #endif
 
@@ -141,7 +141,7 @@ void BMI160Sensor::getScaledValues(float Gxyz[3], float Axyz[3])
         imu.getRotation(&rX, &rY, &rZ);
         imu.getAcceleration(&aX, &aY, &aZ);
 
-        Network::sendRawIMUData(sensorId, rX, rY, rZ, 255, aX, aY, aZ, 255, 0, 0, 0, 255);
+        Network::sendInspectionRawIMUData(sensorId, rX, rY, rZ, 255, aX, aY, aZ, 255, 0, 0, 0, 255);
     }
 #endif
 

--- a/src/sensors/bno055sensor.cpp
+++ b/src/sensors/bno055sensor.cpp
@@ -50,7 +50,7 @@ void BNO055Sensor::motionLoop() {
         Vector3 accel = imu.getVector(Adafruit_BNO055::VECTOR_LINEARACCEL);
         Vector3 mag = imu.getVector(Adafruit_BNO055::VECTOR_MAGNETOMETER);
 
-        Network::sendRawIMUData(sensorId, UNPACK_VECTOR(gyro), 255, UNPACK_VECTOR(accel), 255, UNPACK_VECTOR(mag), 255);
+        Network::sendInspectionRawIMUData(sensorId, UNPACK_VECTOR(gyro), 255, UNPACK_VECTOR(accel), 255, UNPACK_VECTOR(mag), 255);
     }
 #endif
 
@@ -61,7 +61,7 @@ void BNO055Sensor::motionLoop() {
 
 #if ENABLE_INSPECTION
     {
-        Network::sendFusedIMUData(sensorId, quaternion);
+        Network::sendInspectionFusedIMUData(sensorId, quaternion);
     }
 #endif
 

--- a/src/sensors/bno080sensor.cpp
+++ b/src/sensors/bno080sensor.cpp
@@ -121,6 +121,13 @@ void BNO080Sensor::motionLoop()
             {
                 imu.getQuat(quaternion.x, quaternion.y, quaternion.z, quaternion.w, magneticAccuracyEstimate, calibrationAccuracy);
                 quaternion *= sensorOffset;
+
+#if ENABLE_INSPECTION
+                {
+                    Network::sendFusedIMUData(sensorId, quaternion);
+                }
+#endif
+
                 if (!OPTIMIZE_UPDATES || !lastQuatSent.equalsWithEpsilon(quaternion))
                 {
                     newData = true;

--- a/src/sensors/bno080sensor.cpp
+++ b/src/sensors/bno080sensor.cpp
@@ -109,7 +109,7 @@ void BNO080Sensor::motionLoop()
             int16_t mZ = imu.getRawMagZ();
             uint8_t mA = imu.getMagAccuracy();
 
-            Network::sendRawIMUData(sensorId, rX, rY, rZ, rA, aX, aY, aZ, aA, mX, mY, mZ, mA);
+            Network::sendInspectionRawIMUData(sensorId, rX, rY, rZ, rA, aX, aY, aZ, aA, mX, mY, mZ, mA);
         }
 #endif
 
@@ -124,7 +124,7 @@ void BNO080Sensor::motionLoop()
 
 #if ENABLE_INSPECTION
                 {
-                    Network::sendFusedIMUData(sensorId, quaternion);
+                    Network::sendInspectionFusedIMUData(sensorId, quaternion);
                 }
 #endif
 
@@ -144,7 +144,7 @@ void BNO080Sensor::motionLoop()
 
 #if ENABLE_INSPECTION
                 {
-                    Network::sendFusedIMUData(sensorId, quaternion);
+                    Network::sendInspectionFusedIMUData(sensorId, quaternion);
                 }
 #endif
 

--- a/src/sensors/bno080sensor.cpp
+++ b/src/sensors/bno080sensor.cpp
@@ -147,6 +147,13 @@ void BNO080Sensor::motionLoop()
             {
                 imu.getMagQuat(magQuaternion.x, magQuaternion.y, magQuaternion.z, magQuaternion.w, magneticAccuracyEstimate, magCalibrationAccuracy);
                 magQuaternion *= sensorOffset;
+
+#if ENABLE_INSPECTION
+                {
+                    Network::sendInspectionCorrectionData(sensorId, quaternion);
+                }
+#endif
+
                 newMagData = true;
             }
         }

--- a/src/sensors/icm20948sensor.cpp
+++ b/src/sensors/icm20948sensor.cpp
@@ -447,7 +447,7 @@ void ICM20948Sensor::motionLoop() {
         float mY = imu.magY();
         float mZ = imu.magZ();
 
-        Network::sendRawIMUData(sensorId, rX, rY, rZ, 255, aX, aY, aZ, 255, mX, mY, mZ, 255);
+        Network::sendInspectionRawIMUData(sensorId, rX, rY, rZ, 255, aX, aY, aZ, 255, mX, mY, mZ, 255);
     }
 #endif
 
@@ -478,7 +478,7 @@ void ICM20948Sensor::motionLoop() {
 
 #if ENABLE_INSPECTION
                     {
-                        Network::sendFusedIMUData(sensorId, quaternion);
+                        Network::sendInspectionFusedIMUData(sensorId, quaternion);
                     }
 #endif
 
@@ -506,7 +506,7 @@ void ICM20948Sensor::motionLoop() {
 
 #if ENABLE_INSPECTION
                     {
-                        Network::sendFusedIMUData(sensorId, quaternion);
+                        Network::sendInspectionFusedIMUData(sensorId, quaternion);
                     }
 #endif
 

--- a/src/sensors/mpu6050sensor.cpp
+++ b/src/sensors/mpu6050sensor.cpp
@@ -103,7 +103,7 @@ void MPU6050Sensor::motionLoop()
         imu.getRotation(&rX, &rY, &rZ);
         imu.getAcceleration(&aX, &aY, &aZ);
 
-        Network::sendRawIMUData(sensorId, rX, rY, rZ, 255, aX, aY, aZ, 255, 0, 0, 0, 255);
+        Network::sendInspectionRawIMUData(sensorId, rX, rY, rZ, 255, aX, aY, aZ, 255, 0, 0, 0, 255);
     }
 #endif
 
@@ -117,9 +117,9 @@ void MPU6050Sensor::motionLoop()
         quaternion *= sensorOffset;
 
 #if ENABLE_INSPECTION
-    {
-        Network::sendFusedIMUData(sensorId, quaternion);
-    }
+        {
+            Network::sendInspectionFusedIMUData(sensorId, quaternion);
+        }
 #endif
 
         if (!OPTIMIZE_UPDATES || !lastQuatSent.equalsWithEpsilon(quaternion))

--- a/src/sensors/mpu9250sensor.cpp
+++ b/src/sensors/mpu9250sensor.cpp
@@ -114,7 +114,7 @@ void MPU9250Sensor::motionLoop() {
         imu.getAcceleration(&aX, &aY, &aZ);
         imu.getMagnetometer(&mX, &mY, &mZ);
 
-        Network::sendRawIMUData(sensorId, rX, rY, rZ, 255, aX, aY, aZ, 255, mX, mY, mZ, 255);
+        Network::sendInspectionRawIMUData(sensorId, rX, rY, rZ, 255, aX, aY, aZ, 255, mX, mY, mZ, 255);
     }
 #endif
 
@@ -157,7 +157,7 @@ void MPU9250Sensor::motionLoop() {
 
 #if ENABLE_INSPECTION
     {
-        Network::sendFusedIMUData(sensorId, quaternion);
+        Network::sendInspectionFusedIMUData(sensorId, quaternion);
     }
 #endif
 


### PR DESCRIPTION
- Fixed BNO08x not sending inspection packets when `useMagnetometerAllTheTime || !useMagnetometerCorrection` is `true`
- Renamed inspection packet sending related to clearly indicated that they're meant for the inspection subprotocol
- Introduced calibration packet type for inspection