### PR TITLE
Fix sporadic data pauses from POWER_SAVING_MINIMUM

### DIFF
--- a/src/debug.h
+++ b/src/debug.h
@@ -57,7 +57,7 @@
 #define samplingRateInMillis 10
 
 // Sleeping options
-#define POWERSAVING_MODE POWER_SAVING_MINIMUM
+#define POWERSAVING_MODE POWER_SAVING_LEGACY  // Minimum causes sporadic data pauses
 #if POWERSAVING_MODE >= POWER_SAVING_MINIMUM
     #define TARGET_LOOPTIME_MICROS (samplingRateInMillis * 1000)
 #endif


### PR DESCRIPTION
Discovered today that using POWER_SAVING_MINIMUM causes pauses in data transmission every second or two on BNOs. Using POWER_SAVING_LEGACY fixes the problem.

From discord: https://discord.com/channels/817184208525983775/878727840118505533/952135552323444757