### PR TITLE
Use POWER_SAVING_LEGACY by default

### DIFF
--- a/src/debug.h
+++ b/src/debug.h
@@ -57,7 +57,7 @@
 #define samplingRateInMillis 10
 
 // Sleeping options
-#define POWERSAVING_MODE POWER_SAVING_MINIMUM
+#define POWERSAVING_MODE POWER_SAVING_LEGACY
 #if POWERSAVING_MODE >= POWER_SAVING_MINIMUM
     #define TARGET_LOOPTIME_MICROS (samplingRateInMillis * 1000)
 #endif


### PR DESCRIPTION
BNO users experience strange delays with new power saving options. Revert to legacy to mitigate the issue and for further investigation.