### PR TITLE
Using avr/pgmspace for ESP8266 for DMP

### DIFF
--- a/lib/ICM20948/ICM_20948_C.c
+++ b/lib/ICM20948/ICM_20948_C.c
@@ -10,7 +10,7 @@
 
 #if defined(ARDUINO_ARCH_MBED) // ARDUINO_ARCH_MBED (APOLLO3 v2) does not support or require pgmspace.h / PROGMEM
 const uint8_t dmp3_image[] = {
-#elif (defined(__AVR__) || defined(__arm__) || defined(__ARDUINO_ARC__)) && !defined(__linux__) // Store the DMP firmware in PROGMEM on older AVR (ATmega) platforms
+#elif (defined(__AVR__) || defined(__arm__) || defined(__ARDUINO_ARC__) || defined(ESP8266)) && !defined(__linux__) // Store the DMP firmware in PROGMEM on older AVR (ATmega) platforms
 #define ICM_20948_USE_PROGMEM_FOR_DMP
 #include <avr/pgmspace.h>
 const uint8_t dmp3_image[] PROGMEM = {

--- a/lib/mpu6050/MPU6050.h
+++ b/lib/mpu6050/MPU6050.h
@@ -42,7 +42,7 @@ THE SOFTWARE.
 // supporting link:  http://forum.arduino.cc/index.php?&topic=143444.msg1079517#msg1079517
 // also: http://forum.arduino.cc/index.php?&topic=141571.msg1062899#msg1062899s
 
-#ifdef __AVR__
+#if (defined(__AVR__) || defined(ESP8266))
 #include <avr/pgmspace.h>
 #elif defined(ESP32)
     #include <pgmspace.h>

--- a/lib/mpu6050/MPU6050_6Axis_MotionApps_V6_12.h
+++ b/lib/mpu6050/MPU6050_6Axis_MotionApps_V6_12.h
@@ -48,7 +48,7 @@ THE SOFTWARE.
 
 // Tom Carpenter's conditional PROGMEM code
 // http://forum.arduino.cc/index.php?topic=129407.0
-#ifdef __AVR__
+#if (defined(__AVR__) || defined(ESP8266))
     #include <avr/pgmspace.h>
 #elif defined(ESP32)
     #include <pgmspace.h>

--- a/lib/mpu9250/MPU9250.h
+++ b/lib/mpu9250/MPU9250.h
@@ -40,7 +40,7 @@ THE SOFTWARE.
 #include "I2Cdev.h"
 #include "helper_3dmath.h"
 
-#ifdef __AVR__
+#if (defined(__AVR__) || defined(ESP8266))
     #include <avr/pgmspace.h>
 #elif defined(ESP32)
     #include <pgmspace.h>

--- a/lib/mpu9250/MPU9250MotionApps.cpp
+++ b/lib/mpu9250/MPU9250MotionApps.cpp
@@ -37,7 +37,7 @@ THE SOFTWARE.
 
 // Tom Carpenter's conditional PROGMEM code
 // http://forum.arduino.cc/index.php?topic=129407.0
-#ifdef __AVR__
+#if (defined(__AVR__) || defined(ESP8266))
     #include <avr/pgmspace.h>
 #elif defined(ESP32)
     #include <pgmspace.h>

--- a/lib/mpu9250/MPU9250_6Axis_MotionApps_V6_12.cpp
+++ b/lib/mpu9250/MPU9250_6Axis_MotionApps_V6_12.cpp
@@ -42,7 +42,7 @@ THE SOFTWARE.
 
 // Tom Carpenter's conditional PROGMEM code
 // http://forum.arduino.cc/index.php?topic=129407.0
-#ifdef __AVR__
+#if (defined(__AVR__) || defined(ESP8266))
     #include <avr/pgmspace.h>
 #elif defined(ESP32)
     #include <pgmspace.h>


### PR DESCRIPTION
This change should fix #127.