### PR TITLE
Move LED define to global + defines to fix TTGO compile

### DIFF
--- a/src/consts.h
+++ b/src/consts.h
@@ -49,6 +49,8 @@
 #define BAT_MCP3021 3
 #define BAT_INTERNAL_MCP3021 4
 
+#define LED_OFF 255
+
 #define POWER_SAVING_LEGACY 0 // No sleeping, but PS enabled
 #define POWER_SAVING_NONE 1 // No sleeping, no PS => for connection issues
 #define POWER_SAVING_MINIMUM 2 // Sleeping and PS => default
@@ -59,10 +61,6 @@
 #define DEG_90 -PI / 2
 #define DEG_180 PI
 #define DEG_270 PI / 2
-
-#ifndef LED_BUILTIN
-#define LED_BUILTIN 2
-#endif
 
 #ifdef ESP8266
   #define HARDWARE_MCU 1

--- a/src/debug.h
+++ b/src/debug.h
@@ -46,10 +46,6 @@
 #define serialDebug false // Set to true to get Serial output for debugging
 #define serialBaudRate 115200
 #define LED_INTERVAL_STANDBY 10000
-#define LED_INVERTED true
-#define ENABLE_LEDS true
-
-#define LED_PIN LED_BUILTIN
 
 // Determines how often we sample and send data
 #define samplingRateInMillis 10

--- a/src/defines.h
+++ b/src/defines.h
@@ -47,6 +47,14 @@
 // #define BATTERY_SHIELD_R1 100 // Board voltage divider resistor Ain to GND in kOhm
 // #define BATTERY_SHIELD_R2 220 // Board voltage divider resistor Ain to INPUT_BOARD in kOhm
 
+// LED configuration:
+//   LED_PIN
+//     - Number or Symbol (D1,..) of the Output
+//     - To turn off the LED, set LED_PIN to LED_OFF
+//   LED_INVERTED 
+//     - false for output 3.3V on high
+//     - true for pull down to GND on high
+
 // Board-specific configurations
 #if BOARD == BOARD_SLIMEVR
   #define PIN_IMU_SDA 14
@@ -54,31 +62,40 @@
   #define PIN_IMU_INT 16
   #define PIN_IMU_INT_2 13
   #define PIN_BATTERY_LEVEL 17
+  #define LED_PIN LED_BUILTIN
+  #define LED_INVERTED true
 #elif BOARD == BOARD_SLIMEVR_LEGACY || BOARD == BOARD_SLIMEVR_DEV
   #define PIN_IMU_SDA 4
   #define PIN_IMU_SCL 5
   #define PIN_IMU_INT 10
   #define PIN_IMU_INT_2 13
   #define PIN_BATTERY_LEVEL 17
+  #define LED_PIN LED_BUILTIN
+  #define LED_INVERTED true
 #elif BOARD == BOARD_NODEMCU || BOARD == BOARD_WEMOSD1MINI
   #define PIN_IMU_SDA D2
   #define PIN_IMU_SCL D1
   #define PIN_IMU_INT D5
   #define PIN_IMU_INT_2 D6
   #define PIN_BATTERY_LEVEL A0
+  #define LED_PIN LED_BUILTIN
+  #define LED_INVERTED true
 #elif BOARD == BOARD_ESP01
   #define PIN_IMU_SDA 2
   #define PIN_IMU_SCL 0
   #define PIN_IMU_INT 255
   #define PIN_IMU_INT_2 255
-  #define ENABLE_LEDS false
   #define PIN_BATTERY_LEVEL 255
+  #define LED_PIN LED_OFF
+  #define LED_INVERTED false
 #elif BOARD == BOARD_TTGO_TBASE
   #define PIN_IMU_SDA 5
   #define PIN_IMU_SCL 4
   #define PIN_IMU_INT 14
   #define PIN_IMU_INT_2 13
   #define PIN_BATTERY_LEVEL A0
+  #define LED_PIN LED_BUILTIN
+  #define LED_INVERTED true
 #elif BOARD == BOARD_CUSTOM
   // Define pins by the examples above
 #elif BOARD == BOARD_WROOM32
@@ -87,4 +104,6 @@
   #define PIN_IMU_INT 23
   #define PIN_IMU_INT_2 25
   #define PIN_BATTERY_LEVEL 36
+  #define LED_PIN LED_BUILTIN
+  #define LED_INVERTED false
 #endif

--- a/src/globals.h
+++ b/src/globals.h
@@ -40,7 +40,32 @@
 #define BATTERY_MONITOR BAT_INTERNAL
 #endif
 
-#if defined(LED_INVERTED) && LED_INVERTED
+// If LED_PIN is not defined in "defines.h" take the default pin from "pins_arduino.h" framework.
+// If there is no pin defined for the board, use LED_PIN 255 and disable LED
+#if defined(LED_PIN)
+    // LED_PIN is defined
+    #if (LED_PIN < 0) || (LED_PIN >= LED_OFF)
+        #define ENABLE_LEDS false    
+    #else
+        #define ENABLE_LEDS true
+    #endif
+#else
+    // LED_PIN is not defined
+    #if defined(LED_BUILTIN)
+        #define LED_PIN LED_BUILTIN
+        #define ENABLE_LEDS true
+    #else
+        #define LED_PIN LED_OFF
+        #define ENABLE_LEDS false
+    #endif
+#endif
+
+#if !defined(LED_INVERTED)
+    // default is inverted for SlimeVR / ESP-12E
+    #define LED_INVERTED true
+#endif
+
+#if LED_INVERTED
 #define LED_ON LOW
 #define LED_OFF HIGH
 #else


### PR DESCRIPTION
the LED_PIN is wrong in const.h
moved it to globals.h with the option to accept changes from defines.h
with that it should fix #37 

my understanding is, that globals.h adds all the missing stuff from defines.h with the default values.
Any meaning on this?