### PR TITLE
[MPU9250] Fix too aggressive magnetometer correction

### DIFF
--- a/src/sensors/mpu9250sensor.cpp
+++ b/src/sensors/mpu9250sensor.cpp
@@ -37,7 +37,7 @@
 constexpr float gscale = (250. / 32768.0) * (PI / 180.0); //gyro default 250 LSB per d/s -> rad/s
 #endif
 
-#define MAG_CORR_RATIO 0.2
+#define MAG_CORR_RATIO 0.02
 
 void MPU9250Sensor::motionSetup() {
     // initialize device


### PR DESCRIPTION
The MPU9250's magnetometer correction seems to be quite aggressive and creates heavy orientation jitter.
Lowering it to ``0.02``  reduces the jitter and also corrects itself fast enough for fast movements.
The value probably can be set lower tbh.
Orientation quality seems to be equal with ICM20948 with this change.

**Correction with 0.2:**
https://user-images.githubusercontent.com/22834512/163219863-1ad64f75-1d44-41eb-87dd-0c5f7cac869f.mp4

**Correction with 0.02:**
https://user-images.githubusercontent.com/22834512/163221958-8f3071e8-cf10-42e8-a2c5-67b3d6451cf9.mp4


