### PR TITLE
Fixing compile Error if LED_BUILTIN is not defined

### DIFF
--- a/ci/build.py
+++ b/ci/build.py
@@ -30,7 +30,7 @@ class DeviceConfiguration:
         platform = {self.platform}
         board = {self.platformio_board}""")
 
-        if self.platform == "espressif32":
+        if self.platform == "espressif32 @ 3.5.0":
             section += dedent("""
             lib_deps =
                 ${env.lib_deps}
@@ -48,7 +48,8 @@ class DeviceConfiguration:
         imu_int = ""
         imu_int2 = ""
         battery_level = ""
-        leds = True
+        led_pin = 2
+        led_invert = False
 
         if self.board == Board.SLIMEVR:
             sda = "4"
@@ -56,6 +57,7 @@ class DeviceConfiguration:
             imu_int = "10"
             imu_int2 = "13"
             battery_level = "17"
+            led_invert = True
         elif self.board == Board.WROOM32:
             sda = "21"
             scl = "22"
@@ -69,18 +71,19 @@ class DeviceConfiguration:
 #define IMU IMU_BNO085
 #define SECOND_IMU IMU
 #define BOARD {self.board.value}
+#define IMU_ROTATION DEG_90
+#define SECOND_IMU_ROTATION DEG_90
+
 #define BATTERY_MONITOR BAT_EXTERNAL
+#define BATTERY_SHIELD_RESISTANCE 180
 
 #define PIN_IMU_SDA {sda}
 #define PIN_IMU_SCL {scl}
 #define PIN_IMU_INT {imu_int}
 #define PIN_IMU_INT_2 {imu_int2}
 #define PIN_BATTERY_LEVEL {battery_level}
-#define ENABLE_LEDS {leds.__str__().lower()}
-
-#define BATTERY_SHIELD_RESISTANCE 180
-#define IMU_ROTATION DEG_90
-#define SECOND_IMU_ROTATION DEG_90
+#define LED_PIN {led_pin}
+#define LED_INVERTED {led_invert.__str__().lower()}
 """
 
     def __str__(self) -> str:

--- a/ci/devices.json
+++ b/ci/devices.json
@@ -5,7 +5,7 @@
     "board": "SLIMEVR"
   },
   {
-    "platform": "espressif32",
+    "platform": "espressif32 @ 3.5.0",
     "platformio_board": "esp32dev",
     "board": "WROOM32"
   }

--- a/platformio.ini
+++ b/platformio.ini
@@ -56,7 +56,7 @@ upload_speed = 921600
 ; lib_deps =
 ;   ${env.lib_deps}
 ;   lorol/LittleFS_esp32 @ 1.0.6
-; platform = espressif32
+; platform = espressif32 @ 3.5.0
 ; board = esp32dev
 ; Comment out this line below if you have any trouble uploading the firmware - and if it has a CP2102 on it (a square chip next to the usb port): change to 3000000 (3 million) for even faster upload speed
 ; upload_speed = 921600

--- a/src/defines.h
+++ b/src/defines.h
@@ -48,6 +48,10 @@
 // #define BATTERY_SHIELD_R2 220 // Board voltage divider resistor Ain to INPUT_BOARD in kOhm
 
 // LED configuration:
+// Configuration Priority 1 = Highest:
+// 1. LED_PIN
+// 2. LED_BUILTIN
+//
 //   LED_PIN
 //     - Number or Symbol (D1,..) of the Output
 //     - To turn off the LED, set LED_PIN to LED_OFF
@@ -62,7 +66,7 @@
   #define PIN_IMU_INT 16
   #define PIN_IMU_INT_2 13
   #define PIN_BATTERY_LEVEL 17
-  #define LED_PIN LED_BUILTIN
+  #define LED_PIN 2
   #define LED_INVERTED true
 #elif BOARD == BOARD_SLIMEVR_LEGACY || BOARD == BOARD_SLIMEVR_DEV
   #define PIN_IMU_SDA 4
@@ -70,7 +74,7 @@
   #define PIN_IMU_INT 10
   #define PIN_IMU_INT_2 13
   #define PIN_BATTERY_LEVEL 17
-  #define LED_PIN LED_BUILTIN
+  #define LED_PIN 2
   #define LED_INVERTED true
 #elif BOARD == BOARD_NODEMCU || BOARD == BOARD_WEMOSD1MINI
   #define PIN_IMU_SDA D2
@@ -78,8 +82,8 @@
   #define PIN_IMU_INT D5
   #define PIN_IMU_INT_2 D6
   #define PIN_BATTERY_LEVEL A0
-  #define LED_PIN LED_BUILTIN
-  #define LED_INVERTED true
+//  #define LED_PIN 2
+//  #define LED_INVERTED true
 #elif BOARD == BOARD_ESP01
   #define PIN_IMU_SDA 2
   #define PIN_IMU_SCL 0
@@ -94,8 +98,8 @@
   #define PIN_IMU_INT 14
   #define PIN_IMU_INT_2 13
   #define PIN_BATTERY_LEVEL A0
-  #define LED_PIN LED_BUILTIN
-  #define LED_INVERTED true
+//  #define LED_PIN 2
+//  #define LED_INVERTED false
 #elif BOARD == BOARD_CUSTOM
   // Define pins by the examples above
 #elif BOARD == BOARD_WROOM32
@@ -104,6 +108,6 @@
   #define PIN_IMU_INT 23
   #define PIN_IMU_INT_2 25
   #define PIN_BATTERY_LEVEL 36
-  #define LED_PIN LED_BUILTIN
-  #define LED_INVERTED false
+//  #define LED_PIN 2
+//  #define LED_INVERTED false
 #endif

--- a/src/globals.h
+++ b/src/globals.h
@@ -51,7 +51,7 @@
     #endif
 #else
     // LED_PIN is not defined
-    #if defined(LED_BUILTIN)
+    #if defined(LED_BUILTIN) && (LED_BUILTIN < LED_OFF) && (LED_BUILTIN >= 0)
         #define LED_PIN LED_BUILTIN
         #define ENABLE_LEDS true
     #else


### PR DESCRIPTION
Instead of using LED_BUILTIN as a value in defines.h
we can leave LED_PIN undefined. In that case global.h 
will look if LED_BUILTIN is defined or not.