### PR TITLE
add platform info for tools

### DIFF
--- a/platformio-tools.ini
+++ b/platformio-tools.ini
@@ -1,0 +1,42 @@
+[env]
+lib_deps=
+  https://github.com/SlimeVR/CmdParser.git
+monitor_speed = 115200
+framework = arduino
+build_flags =
+ -O2
+build_unflags = -Os
+
+[env:BOARD_SLIMEVR]
+platform = espressif8266
+board = esp12e
+
+[env:BOARD_SLIMEVR_DEV]
+platform = espressif8266
+board = esp12e
+
+[env:BOARD_NODEMCU]
+platform = espressif8266
+board = esp12e
+
+[env:BOARD_WEMOSD1MINI]
+platform = espressif8266
+board = esp12e
+
+[env:BOARD_TTGO_TBASE]
+platform = espressif8266
+board = esp12e
+
+[env:BOARD_WROOM32]
+lib_deps=
+  \${env.lib_deps}
+  lorol/LittleFS_esp32@1.0.6
+platform = espressif32@3.5.0
+board = esp32dev
+
+[env:BOARD_ESP01]
+lib_deps=
+  \${env.lib_deps}
+  lorol/LittleFS_esp32@1.0.6
+platform = espressif32@3.5.0
+board = esp32dev


### PR DESCRIPTION
Add a way for the firmware tool to know how to build a board. Allows to maintain compatibility with new and old firmware
without changing firmware tool code