### PR TITLE
Fix MPU-6500 cannot connect

### DIFF
--- a/lib/mpu6050/MPU6050.cpp
+++ b/lib/mpu6050/MPU6050.cpp
@@ -67,8 +67,12 @@ void MPU6050::initialize(uint8_t address) {
  */
 bool MPU6050::testConnection() {
     uint8_t deviceId = getDeviceID();
-    // some MPU-6500 seem to have their ID as 0x74
-    return deviceId == 0x68 || deviceId == 0x70 || deviceId == 0x71 || deviceId == 0x73 || deviceId == 0x74; // Allow any MPUs; 
+    // 0x68 -> MPU-6050
+    // 0x70 -> MPU-6500
+    // 0x71 -> MPU-9250
+    // 0x73 -> MPU-9255
+    // 0x74 -> MPU-6515
+    return deviceId == 0x68 || deviceId == 0x70 || deviceId == 0x71 || deviceId == 0x73 || deviceId == 0x74; 
 }
 
 // AUX_VDDIO register (InvenSense demo code calls this RA_*G_OFFS_TC)

--- a/lib/mpu6050/MPU6050.cpp
+++ b/lib/mpu6050/MPU6050.cpp
@@ -67,7 +67,8 @@ void MPU6050::initialize(uint8_t address) {
  */
 bool MPU6050::testConnection() {
     uint8_t deviceId = getDeviceID();
-    return deviceId == 0x68 || deviceId == 0x70 || deviceId == 0x71 || deviceId == 0x73; // Allow any MPUs
+    // some MPU-6500 seem to have their ID as 0x74
+    return deviceId == 0x68 || deviceId == 0x70 || deviceId == 0x71 || deviceId == 0x73 || deviceId == 0x74; // Allow any MPUs; 
 }
 
 // AUX_VDDIO register (InvenSense demo code calls this RA_*G_OFFS_TC)


### PR DESCRIPTION
some MPU-6500 seem to have their ID as 0x74.
This commit adds 0x74 as an legal deviceID for the MPU6050 library