### PR TITLE
fix warning in new platformio

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -15,7 +15,7 @@
 lib_deps=
   https://github.com/SlimeVR/CmdParser.git
 monitor_speed = 115200
-monitor_flags = --echo
+monitor_echo = yes
 monitor_filters = colorize
 ;monitor_rts = 0
 ;monitor_dtr = 0


### PR DESCRIPTION
fix a warning, and enable the function for echo again