### PR TITLE
Fixed sensor names to be more clear

### DIFF
--- a/src/sensors/mpu6050sensor.cpp
+++ b/src/sensors/mpu6050sensor.cpp
@@ -45,11 +45,11 @@ void MPU6050Sensor::motionSetup()
     imu.initialize(addr);
     if (!imu.testConnection())
     {
-        m_Logger.fatal("Can't connect to MPU6050 (reported device ID 0x%02x) at address 0x%02x", imu.getDeviceID(), addr);
+        m_Logger.fatal("Can't connect to %s (reported device ID 0x%02x) at address 0x%02x",getIMUNameByType(sensorType), imu.getDeviceID(), addr);
         return;
     }
 
-    m_Logger.info("Connected to MPU6050 (reported device ID 0x%02x) at address 0x%02x", imu.getDeviceID(), addr);
+    m_Logger.info("Connected to %s (reported device ID 0x%02x) at address 0x%02x", getIMUNameByType(sensorType), imu.getDeviceID(), addr);
 
 #ifndef IMU_MPU6050_RUNTIME_CALIBRATION
     // Initialize the configuration


### PR DESCRIPTION
Fixed to show real sensors (like MPU-6500) instead of always 'MPU-6050' when using MPU 6 series sensors.