### PR TITLE
Fix BNO055 not working at all

### DIFF
--- a/src/sensors/bno055sensor.cpp
+++ b/src/sensors/bno055sensor.cpp
@@ -28,7 +28,7 @@
 void BNO055Sensor::motionSetup() {
     imu = Adafruit_BNO055(sensorId, addr);
     delay(3000);
-    if (!imu.begin(Adafruit_BNO055::OPERATION_MODE_IMUPLUS))
+    if (!imu.begin(Adafruit_BNO055::OPERATION_MODE_NDOF))
     {
         m_Logger.fatal("Can't connect to BNO055 at address 0x%02x", addr);
         ledManager.pattern(50, 50, 200);
@@ -39,6 +39,11 @@ void BNO055Sensor::motionSetup() {
     imu.setAxisRemap(Adafruit_BNO055::REMAP_CONFIG_P0);
     imu.setAxisSign(Adafruit_BNO055::REMAP_SIGN_P0);
     m_Logger.info("Connected to BNO055 at address 0x%02x", addr);
+
+    //Adafruit BNO055's use external crystal. Enable it, otherwise it does not work.
+    delay(1000);
+    imu.setExtCrystalUse(true);
+
     working = true;
     configured = true;
 }


### PR DESCRIPTION
BNO055s require external crystal use. Also, enable NDOF mode to use intelligent drift correction using mag.