### PR TITLE
Fix for I2C startup issues on BNO055 and ICM20948

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -70,9 +70,9 @@ void setup()
 
     SerialCommands::setUp();
 
-#if IMU == IMU_MPU6500 || IMU == IMU_MPU6050 || IMU == IMU_MPU9250
+#if IMU == IMU_MPU6500 || IMU == IMU_MPU6050 || IMU == IMU_MPU9250 || IMU == IMU_BNO055 || IMU == IMU_ICM20948
     I2CSCAN::clearBus(PIN_IMU_SDA, PIN_IMU_SCL); // Make sure the bus isn't stuck when resetting ESP without powering it down
-    // Do it only for MPU, cause reaction of BNO to this is not investigated yet
+    // Fixes I2C issues for certain IMUs. Only has been tested on IMUs above. Testing advised when adding other IMUs.
 #endif
     // join I2C bus
 


### PR DESCRIPTION
For still unknown reasons BNO055 and ICM20948 (and may probably others) have I2C-Scan issues when starting up or resetting. Without this fix, I2C-Scan has a random chance of not finding those IMUs. It either fails to find them or deadlocks the ESP.

Example error:
```
[INFO ] [SlimeVR] SlimeVR v0.2.3 starting up...
[INFO ] [Configuration] Found up-to-date configuration v1
[DEBUG] [Configuration] Found sensor calibration for ICM20948 at index 0
[INFO ] [Configuration] Loaded configuration
[ERR] I2C: Can't find I2C device on provided addresses, scanning for all I2C devices and returning 
[DBG] I2C (@ D2(4) : D1(5)): I2C device found at address 0x28  ! 
[ERROR] [ErroneousSensor:0] IMU of type BNO055 failed to initialize 
[INFO ] [BNO055Sensor:1] Connected to BNO055 at address 0x28
```