### PR TITLE
mpu9250: Swap the first two components of mag readings

### DIFF
--- a/src/sensors/mpu9250sensor.cpp
+++ b/src/sensors/mpu9250sensor.cpp
@@ -163,7 +163,7 @@ void MPU9250Sensor::motionLoop() {
     Quat quat(-rawQuat.y,rawQuat.x,rawQuat.z,rawQuat.w);
 
     int16_t temp[3];
-    imu.getMagnetometer(temp + 0, temp + 1, temp + 2);
+    imu.getMagnetometer(&temp[0], &temp[1], &temp[2]);
     parseMagData(temp);
 
     if (Mxyz[0] == 0.0f && Mxyz[1] == 0.0f && Mxyz[2] == 0.0f) {

--- a/src/sensors/mpu9250sensor.cpp
+++ b/src/sensors/mpu9250sensor.cpp
@@ -402,9 +402,9 @@ void MPU9250Sensor::startCalibration(int calibrationType) {
 
 void MPU9250Sensor::parseMagData(int16_t data[3]) {
     // reading *little* endian int16
-    Mxyz[0] = (float)data[0];
-    Mxyz[1] = (float)data[1];
-    Mxyz[2] = -(float)data[2];
+    Mxyz[0] = (float)data[1]; // my
+    Mxyz[1] = (float)data[0]; // mx
+    Mxyz[2] = -(float)data[2]; // mz
 
     float temp[3];
 


### PR DESCRIPTION
This restores the swap from before #192, which I previously missed during that PR.

This may help with #218.