### PR TITLE
Proper battery sense fix

### DIFF
--- a/src/batterymonitor.h
+++ b/src/batterymonitor.h
@@ -45,6 +45,9 @@
     #define ADCVoltageMax 1.0
 #endif
 
+#ifndef BATTERY_SHIELD_RESISTANCE
+    #define BATTERY_SHIELD_RESISTANCE 180.0
+#endif
 #ifndef BATTERY_SHIELD_R1
     #define BATTERY_SHIELD_R1 100.0
 #endif
@@ -56,7 +59,7 @@
     #ifndef PIN_BATTERY_LEVEL
         #error Internal ADC enabled without pin! Please select a pin.
     #endif
-    // Wemos D1 Mini has an internal Voltage Divider with R1=220K and R2=100K > this means, 3.3V analogRead input voltage results in 1023.0
+    // Wemos D1 Mini has an internal Voltage Divider with R1=100K and R2=220K > this means, 3.3V analogRead input voltage results in 1023.0
     // Wemos D1 Mini with Wemos Battery Shield v1.2.0 or higher: Battery Shield with J2 closed, has an additional 130K resistor. So the resulting Voltage Divider is R1=220K+100K=320K and R2=100K > this means, 4.5V analogRead input voltage results in 1023.0
     // ESP32 Boards may have not the internal Voltage Divider. Also ESP32 has a 12bit ADC (0..4095). So R1 and R2 can be changed.
     // Diagramm: 

--- a/src/defines.h
+++ b/src/defines.h
@@ -38,12 +38,12 @@
 //   BAT_MCP3021 for external ADC connected over I2C
 #define BATTERY_MONITOR BAT_EXTERNAL
 
-// BAT_EXTERNAL definition
+// BAT_EXTERNAL definition override
 // D1 Mini boards with ESP8266 have internal resistors. For these boards you only have to adjust BATTERY_SHIELD_RESISTANCE.
 // For other boards you can now adjust the other resistor values.
 // The diagram looks like this:
 //   (Battery)--- [BATTERY_SHIELD_RESISTANCE] ---(INPUT_BOARD)---  [BATTERY_SHIELD_R2] ---(ESP32_INPUT)--- [BATTERY_SHIELD_R1] --- (GND)
-#define BATTERY_SHIELD_RESISTANCE 180 //130k BatteryShield, 180k SlimeVR or fill in external resistor value in kOhm
+// #define BATTERY_SHIELD_RESISTANCE 180 //130k BatteryShield, 180k SlimeVR or fill in external resistor value in kOhm
 // #define BATTERY_SHIELD_R1 100 // Board voltage divider resistor Ain to GND in kOhm
 // #define BATTERY_SHIELD_R2 220 // Board voltage divider resistor Ain to INPUT_BOARD in kOhm
 
@@ -68,6 +68,15 @@
   #define PIN_BATTERY_LEVEL 17
   #define LED_PIN 2
   #define LED_INVERTED true
+  #ifndef BATTERY_SHIELD_RESISTANCE
+    #define BATTERY_SHIELD_RESISTANCE 0
+  #endif
+  #ifndef BATTERY_SHIELD_R1 
+    #define BATTERY_SHIELD_R1 10
+  #endif
+  #ifndef BATTERY_SHIELD_R2
+    #define BATTERY_SHIELD_R2 40.2
+  #endif
 #elif BOARD == BOARD_SLIMEVR_LEGACY || BOARD == BOARD_SLIMEVR_DEV
   #define PIN_IMU_SDA 4
   #define PIN_IMU_SCL 5
@@ -76,6 +85,15 @@
   #define PIN_BATTERY_LEVEL 17
   #define LED_PIN 2
   #define LED_INVERTED true
+  #ifndef BATTERY_SHIELD_RESISTANCE
+    #define BATTERY_SHIELD_RESISTANCE 0
+  #endif
+  #ifndef BATTERY_SHIELD_R1 
+    #define BATTERY_SHIELD_R1 10
+  #endif
+  #ifndef BATTERY_SHIELD_R2
+    #define BATTERY_SHIELD_R2 40.2
+  #endif
 #elif BOARD == BOARD_NODEMCU || BOARD == BOARD_WEMOSD1MINI
   #define PIN_IMU_SDA D2
   #define PIN_IMU_SCL D1
@@ -84,6 +102,15 @@
   #define PIN_BATTERY_LEVEL A0
 //  #define LED_PIN 2
 //  #define LED_INVERTED true
+  #ifndef BATTERY_SHIELD_RESISTANCE
+    #define BATTERY_SHIELD_RESISTANCE 180
+  #endif
+  #ifndef BATTERY_SHIELD_R1 
+    #define BATTERY_SHIELD_R1 100
+  #endif
+  #ifndef BATTERY_SHIELD_R2
+    #define BATTERY_SHIELD_R2 220
+  #endif
 #elif BOARD == BOARD_ESP01
   #define PIN_IMU_SDA 2
   #define PIN_IMU_SCL 0


### PR DESCRIPTION
This commit properly "fixes" the battery sense, in the previous fix I submitted (#139) I simply swapped the R1 and R2 values not noticing that the formula itself was wrong, not the default values. 

This rectifies that mistake by swapping the values again and fixing the formula instead. Now it should be consistent with the comments and the actual values inside the datasheet again and should cause less confusion.

This fix is OPTIONAL as it does not change anything relating to the behavior and only tries to improve code readability and consistency.  

![image](https://user-images.githubusercontent.com/25586367/214426139-79c1b257-50d6-46c1-a31e-9435786b56be.png)
