### PR TITLE
Add support for new variants of BMI160.

### DIFF
--- a/lib/bmi160/BMI160.cpp
+++ b/lib/bmi160/BMI160.cpp
@@ -28,6 +28,7 @@ THE SOFTWARE.
 #include "I2Cdev.h"
 
 #define BMI160_CHIP_ID 0xD1
+#define BMI160C3_CHIP_ID 0xD3
 
 #define BMI160_ACCEL_POWERUP_DELAY_MS 10
 #define BMI160_GYRO_POWERUP_DELAY_MS 100
@@ -148,7 +149,8 @@ uint8_t BMI160::getDeviceID() {
  */
 bool BMI160::testConnection()
 {
-    return (BMI160_CHIP_ID == getDeviceID());
+    uint8_t device_id = getDeviceID();
+    return (BMI160_CHIP_ID == device_id || BMI160C3_CHIP_ID == device_id);
 }
 
 /** Set gyroscope output data rate.


### PR DESCRIPTION
When testing my AIO tracker, I found that the whole batch of BMI160 all have 0xD3 as CHIP_ID instead of 0xD1, with all functionalities checked out ok after skipping the CHIP_ID check in testConnection().

I found this header containing three different CHIP_IDs:
    0xD0 for 'BMI' (probably for engineering samples)
    0xD1 for 'BMI_C2' (Matches the value listed in the datasheet)
    0xD3 for 'BMI_C3' (probably for newer revisions of the chip).

https://github.com/BST-Github-Admin/drivers/blob/master/drivers/iio/imu/bmi160/bmi160_core.h

Considering 'BMI_C3' may get more usage if it's really a newer revision of the chip, add support for CHIP_ID value 0xD3 in case anyone gets their hands on some new chips as I do.