### PR TITLE
Fix OTA on 1MB Flash, Add 40MHz crystal option, Add ESP8285 support

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -33,6 +33,9 @@ build_flags =
 ;  -DWIFI_STATIC_GATEWAY=192,168,XXX,XXX
 ;  -DWIFI_STATIC_SUBNET=255,255,255,0
 
+; Uncomment below if your board are using 40MHz crystal instead of 26MHz for ESP8266
+;  -DF_CRYSTAL=40000000
+
 ; Enable -O2 GCC optimization
   -O2
   -std=gnu++17
@@ -60,6 +63,14 @@ upload_speed = 921600
 ;[env:esp01_1m]
 ;platform = espressif8266 @ 4.2.0
 ;board = esp01_1m
+;board_build.arduino.ldscript = "eagle.flash.1m64.ld"
+
+; Uncomment below if you want to build for ESP8285 (ESP8266 with embedded Flash)
+;[env:esp8285]
+;platform = espressif8266 @ 4.2.0
+;board = esp8285
+;board_build.arduino.ldscript = "eagle.flash.1m64.ld"
+;board_build.flash_mode = dout
 
 ; Uncomment below if you want to build for esp32
 ; Check your board name at https://docs.platformio.org/en/latest/platforms/espressif32.html#boards


### PR DESCRIPTION
Fix OTA on 1MB Flash
    Increase maximum OTA firmware size from 384KB to 480KB by using link script "eagle.flash.1m64.ld".

Add 40MHz crystal option
    Fun Fact: ESP8266 was designed with 40MHz crystals in mind.

Add ESP8285 support
    ESP8285 is an ESP8266 with 1MB or 2MB Flash embedded, but can only operate in dout mode.

All functionalities tested on ESP8285 with 40MHz crystal.