### PR TITLE
Fix 9250 loop

### DIFF
--- a/src/sensors/mpu9250sensor.cpp
+++ b/src/sensors/mpu9250sensor.cpp
@@ -398,8 +398,9 @@ void MPU9250Sensor::parseMagData(int16_t data[3]) {
     float temp[3];
 
     //apply offsets and scale factors from Magneto
-    for (unsigned i = 0; i < 3; i++)
+    for (unsigned i = 0; i < 3; i++) {
         temp[i] = (Mxyz[i] - m_Calibration.M_B[i]);
+    }
     
     for (unsigned i = 0; i < 3; i++) {
         #if useFullCalibrationMatrix == true
@@ -419,8 +420,9 @@ void MPU9250Sensor::parseAccelData(int16_t data[3]) {
     float temp[3];
 
     //apply offsets (bias) and scale factors from Magneto
-    for (unsigned i = 0; i < 3; i++)
-        temp[i] = (Axyz[i] - m_Calibration.A_B[i]);
+    for (unsigned i = 0; i < 3; i++) {
+        temp[i] = (Mxyz[i] - m_Calibration.M_B[i]);
+    }
     
     for (unsigned i = 0; i < 3; i++) {
         #if useFullCalibrationMatrix == true

--- a/src/sensors/mpu9250sensor.cpp
+++ b/src/sensors/mpu9250sensor.cpp
@@ -421,7 +421,7 @@ void MPU9250Sensor::parseAccelData(int16_t data[3]) {
 
     //apply offsets (bias) and scale factors from Magneto
     for (unsigned i = 0; i < 3; i++) {
-        temp[i] = (Mxyz[i] - m_Calibration.M_B[i]);
+        temp[i] = (Axyz[i] - m_Calibration.A_B[i]);
     }
     
     for (unsigned i = 0; i < 3; i++) {

--- a/src/sensors/mpu9250sensor.cpp
+++ b/src/sensors/mpu9250sensor.cpp
@@ -398,8 +398,10 @@ void MPU9250Sensor::parseMagData(int16_t data[3]) {
     float temp[3];
 
     //apply offsets and scale factors from Magneto
-    for (unsigned i = 0; i < 3; i++) {
+    for (unsigned i = 0; i < 3; i++)
         temp[i] = (Mxyz[i] - m_Calibration.M_B[i]);
+    
+    for (unsigned i = 0; i < 3; i++) {
         #if useFullCalibrationMatrix == true
             Mxyz[i] = m_Calibration.M_Ainv[i][0] * temp[0] + m_Calibration.M_Ainv[i][1] * temp[1] + m_Calibration.M_Ainv[i][2] * temp[2];
         #else
@@ -417,8 +419,10 @@ void MPU9250Sensor::parseAccelData(int16_t data[3]) {
     float temp[3];
 
     //apply offsets (bias) and scale factors from Magneto
-    for (unsigned i = 0; i < 3; i++) {
+    for (unsigned i = 0; i < 3; i++)
         temp[i] = (Axyz[i] - m_Calibration.A_B[i]);
+    
+    for (unsigned i = 0; i < 3; i++) {
         #if useFullCalibrationMatrix == true
             Axyz[i] = m_Calibration.A_Ainv[i][0] * temp[0] + m_Calibration.A_Ainv[i][1] * temp[1] + m_Calibration.A_Ainv[i][2] * temp[2];
         #else


### PR DESCRIPTION
Previous refactoring of the code rolled both the assignment of the temp variable and the calibration matrix multiplication into a single loop.

This causes issue because every iteration of the loop for the matrix multiplication uses every value of temp, and it is not completely initialized until the final loop iteration.

The solution is to split the loop into two.