### PR TITLE
ESP32C3 stability improvements

### DIFF
--- a/lib/i2cscan/i2cscan.cpp
+++ b/lib/i2cscan/i2cscan.cpp
@@ -20,10 +20,10 @@ namespace I2CSCAN
 {
 
     uint8_t pickDevice(uint8_t addr1, uint8_t addr2, bool scanIfNotFound) {
-        if(I2CSCAN::isI2CExist(addr1)) {
+        if(I2CSCAN::hasDevOnBus(addr1)) {
             return addr1;
         }
-        if(I2CSCAN::isI2CExist(addr2)) {
+        if(I2CSCAN::hasDevOnBus(addr2)) {
             return addr2;
         }
         if (scanIfNotFound) {
@@ -104,23 +104,24 @@ namespace I2CSCAN
             }
             else if (error == 4)
             {
-                Serial.printf("[ERR] I2C (@ %s(%d) : %s(%d)): Unknow error at address 0x%02x\n", 
+                Serial.printf("[ERR] I2C (@ %s(%d) : %s(%d)): Unknown error at address 0x%02x\n",
                                 portMap[i].c_str(), portArray[i], portMap[j].c_str(), portArray[j], address);
             }
         }
         return found;
     }
 
-    bool isI2CExist(uint8_t addr) {
+    bool hasDevOnBus(uint8_t addr) {
         byte error;
 #if ESP32C3
+        int retries = 1;
         do {
 #endif
             Wire.beginTransmission(addr);
             error = Wire.endTransmission();
 #if ESP32C3
         }
-        while (error == 5);
+        while (error == 5 && retries--);
 #endif
         if(error == 0)
             return true;

--- a/lib/i2cscan/i2cscan.cpp
+++ b/lib/i2cscan/i2cscan.cpp
@@ -20,18 +20,19 @@ namespace I2CSCAN
 {
 
     uint8_t pickDevice(uint8_t addr1, uint8_t addr2, bool scanIfNotFound) {
-        if(I2CSCAN::isI2CExist(addr1))
+        if(I2CSCAN::isI2CExist(addr1)) {
             return addr1;
-        if(!I2CSCAN::isI2CExist(addr2)) {
-            if(scanIfNotFound) {
-                Serial.println("[ERR] I2C: Can't find I2C device on provided addresses, scanning for all I2C devices and returning");
-                I2CSCAN::scani2cports();
-            } else {
-                Serial.println("[ERR] I2C: Can't find I2C device on provided addresses");
-            }
-            return 0;
         }
-        return addr2;
+        if(I2CSCAN::isI2CExist(addr2)) {
+            return addr2;
+        }
+        if (scanIfNotFound) {
+            Serial.println("[ERR] I2C: Can't find I2C device on provided addresses, scanning for all I2C devices and returning");
+            I2CSCAN::scani2cports();
+        } else {
+            Serial.println("[ERR] I2C: Can't find I2C device on provided addresses");
+        }
+        return 0;
     }
 
     void scani2cports()
@@ -111,8 +112,16 @@ namespace I2CSCAN
     }
 
     bool isI2CExist(uint8_t addr) {
-        Wire.beginTransmission(addr);
-        byte error = Wire.endTransmission();
+        byte error;
+#if ESP32C3
+        do {
+#endif
+            Wire.beginTransmission(addr);
+            error = Wire.endTransmission();
+#if ESP32C3
+        }
+        while (error == 5);
+#endif
         if(error == 0)
             return true;
         return false;

--- a/lib/i2cscan/i2cscan.h
+++ b/lib/i2cscan/i2cscan.h
@@ -7,7 +7,7 @@
 namespace I2CSCAN {
     void scani2cports();
     bool checkI2C(uint8_t i, uint8_t j);
-    bool isI2CExist(uint8_t addr);
+    bool hasDevOnBus(uint8_t addr);
     uint8_t pickDevice(uint8_t addr1, uint8_t addr2, bool scanIfNotFound);
     int clearBus(uint8_t SDA, uint8_t SCL);
     boolean inArray(uint8_t value, uint8_t* arr, size_t arrSize);

--- a/src/batterymonitor.cpp
+++ b/src/batterymonitor.cpp
@@ -32,7 +32,7 @@ void BatteryMonitor::Setup()
 #if BATTERY_MONITOR == BAT_MCP3021 || BATTERY_MONITOR == BAT_INTERNAL_MCP3021
     for (uint8_t i = 0x48; i < 0x4F; i++)
     {
-        if (I2CSCAN::isI2CExist(i))
+        if (I2CSCAN::hasDevOnBus(i))
         {
             address = i;
             break;

--- a/src/configuration/Configuration.cpp
+++ b/src/configuration/Configuration.cpp
@@ -32,8 +32,6 @@
 
 namespace SlimeVR {
     namespace Configuration {
-        CalibrationConfig Configuration::m_EmptyCalibration = {NONE};
-
         void Configuration::setup() {
             if (m_Loaded) {
                 return;
@@ -140,7 +138,7 @@ namespace SlimeVR {
 
         CalibrationConfig Configuration::getCalibration(size_t sensorID) const {
             if (sensorID >= m_Calibrations.size()) {
-                return m_EmptyCalibration;
+                return {};
             }
 
             return m_Calibrations.at(sensorID);
@@ -150,7 +148,7 @@ namespace SlimeVR {
             size_t currentCalibrations = m_Calibrations.size();
 
             if (sensorID >= currentCalibrations) {
-                m_Calibrations.resize(sensorID + 1, m_EmptyCalibration);
+                m_Calibrations.resize(sensorID + 1);
             }
 
             m_Calibrations[sensorID] = config;

--- a/src/configuration/Configuration.h
+++ b/src/configuration/Configuration.h
@@ -60,8 +60,6 @@ namespace SlimeVR {
             std::vector<CalibrationConfig> m_Calibrations;
 
             Logging::Logger m_Logger = Logging::Logger("Configuration");
-
-            static CalibrationConfig m_EmptyCalibration;
         };
     }
 }

--- a/src/sensors/SensorManager.cpp
+++ b/src/sensors/SensorManager.cpp
@@ -57,7 +57,7 @@ namespace SlimeVR
             I2CSCAN::clearBus(sdaPin, sclPin);
             swapI2C(sclPin, sdaPin);
 
-            if (I2CSCAN::isI2CExist(address)) {
+            if (I2CSCAN::hasDevOnBus(address)) {
                 m_Logger.trace("IMU %d found at address 0x%02X", sensorID, address);
             } else {
                 sensor = new ErroneousSensor(sensorID, imuType);

--- a/src/sensors/bmi160sensor.h
+++ b/src/sensors/bmi160sensor.h
@@ -217,13 +217,13 @@ class BMI160Sensor : public Sensor {
         double gscaleY = BMI160_GSCALE;
         double gscaleZ = BMI160_GSCALE;
 
-        double GOxyzStaticTempCompensated[3];
+        double GOxyzStaticTempCompensated[3] = {0.0, 0.0, 0.0};
 
         bool isGyroCalibrated = false;
         bool isAccelCalibrated = false;
         bool isMagCalibrated = false;
 
-        SlimeVR::Configuration::BMI160CalibrationConfig m_Calibration;
+        SlimeVR::Configuration::BMI160CalibrationConfig m_Calibration = {};
 };
 
 #endif

--- a/src/sensors/icm20948sensor.h
+++ b/src/sensors/icm20948sensor.h
@@ -55,7 +55,7 @@ private:
     icm_20948_DMP_data_t dmpData{};
     icm_20948_DMP_data_t dmpDataTemp{};
 
-    SlimeVR::Configuration::ICM20948CalibrationConfig m_Calibration;
+    SlimeVR::Configuration::ICM20948CalibrationConfig m_Calibration = {};
 
     SlimeVR::Sensors::SensorFusionDMP sfusion;
 

--- a/src/sensors/mpu6050sensor.h
+++ b/src/sensors/mpu6050sensor.h
@@ -53,7 +53,7 @@ private:
     SlimeVR::Sensors::SensorFusionDMP sfusion;
 
 #ifndef IMU_MPU6050_RUNTIME_CALIBRATION
-    SlimeVR::Configuration::MPU6050CalibrationConfig m_Calibration;
+    SlimeVR::Configuration::MPU6050CalibrationConfig m_Calibration = {};
 #endif
 };
 

--- a/src/sensors/mpu9250sensor.h
+++ b/src/sensors/mpu9250sensor.h
@@ -75,8 +75,8 @@ private:
     float Mxyz[3]{};
     VectorInt16 rawAccel{};
     Quat correction{0, 0, 0, 0};
-    
-    SlimeVR::Configuration::MPU9250CalibrationConfig m_Calibration;
+
+    SlimeVR::Configuration::MPU9250CalibrationConfig m_Calibration = {};
 
     // outputs to respective member variables
     void parseAccelData(int16_t data[3]);


### PR DESCRIPTION
This PR contains my recent findings when enabling ESP32C3 board. With this changes the following issues are fixed:
- BMI160 shaky/not functional/completely drifty before calibration (because of uninitialized memory)
- BMI160 being broken after some amount of time, especially on rest ( may help with https://github.com/SlimeVR/SlimeVR-Tracker-ESP/issues/245 ) when temperature calibration is enabled (default).
- (Possibly) other sensors with calibration stored in tracker being broken before performing it.
- Trackers with AUX IMU compiled but not connected making server going crazy with OK/Error status changing every second (workaround for https://github.com/espressif/arduino-esp32/issues/8454 )
