### PR TITLE
Fix sending ErroneousSensor if not found

### DIFF
--- a/src/sensors/SensorManager.cpp
+++ b/src/sensors/SensorManager.cpp
@@ -58,9 +58,10 @@ namespace SlimeVR
             swapI2C(sclPin, sdaPin);
 
             if (I2CSCAN::isI2CExist(address)) {
-                m_Logger.trace("IMU %d found at address 0x%02X", sensorID, address);
+                m_Logger.trace("Sensor %d found at address 0x%02X", sensorID + 1, address);
             } else {
-                sensor = new ErroneousSensor(sensorID, imuType);
+                m_Logger.debug("Sensor %d not found at address 0x%02X", sensorID + 1, address);
+                sensor = new EmptySensor(sensorID);
                 return sensor;
             }
 


### PR DESCRIPTION
Since #249 the firmware has a regression in sensor assignment logic and sets an `ErroneousSensor` instead of leaving an `EmptySensor` as is.

If there are multiple IMUs in defines (main + aux) and some of them are not connected (aux), it sends an `ErroneousSensor`.
Server logic for UDP tracker statuses also seems weird - it briefly shows an error, then gets overwritten with OK.
![image](https://github.com/SlimeVR/SlimeVR-Tracker-ESP/assets/114709761/528bda28-6a22-4c42-bff5-a8ab6a9ec993)

After the change in this PR the extra tracker no longer appears.

For reference old aux logic that used to scan all addresses:
https://github.com/SlimeVR/SlimeVR-Tracker-ESP/blob/ed74944551cc7a635ce0ef2d2c66637a021a157b/src/sensors/SensorManager.cpp#L88-L97

Also logging below uses `sensorId+1` style of sensor numbering, so the new "not found" line uses the same.
https://github.com/SlimeVR/SlimeVR-Tracker-ESP/blob/e33d3e448ef74301876eaf72a9c0dcd34bb32d4b/src/sensors/SensorManager.cpp#L152-L156