### PR TITLE
Fix OPTIMIZE_UPDATES logic for acceleration

### DIFF
--- a/src/network/connection.cpp
+++ b/src/network/connection.cpp
@@ -230,16 +230,16 @@ void Connection::sendHeartbeat() {
 }
 
 // PACKET_ACCEL 4
-void Connection::sendSensorAcceleration(uint8_t sensorId, float* vector) {
+void Connection::sendSensorAcceleration(uint8_t sensorId, Vector3 vector) {
 	MUST(m_Connected);
 
 	MUST(beginPacket());
 
 	MUST(sendPacketType(PACKET_ACCEL));
 	MUST(sendPacketNumber());
-	MUST(sendFloat(vector[0]));
-	MUST(sendFloat(vector[1]));
-	MUST(sendFloat(vector[2]));
+	MUST(sendFloat(vector.x));
+	MUST(sendFloat(vector.y));
+	MUST(sendFloat(vector.z));
 	MUST(sendByte(sensorId));
 
 	MUST(endPacket());

--- a/src/network/connection.h
+++ b/src/network/connection.h
@@ -43,7 +43,7 @@ public:
 	bool isConnected() const { return m_Connected; }
 
 	// PACKET_ACCEL 4
-	void sendSensorAcceleration(uint8_t sensorId, float* vector);
+	void sendSensorAcceleration(uint8_t sensorId, Vector3 vector);
 
 	// PACKET_BATTERY_LEVEL 12
 	void sendBatteryLevel(float batteryVoltage, float batteryPercentage);

--- a/src/sensors/SensorFusion.cpp
+++ b/src/sensors/SensorFusion.cpp
@@ -156,6 +156,12 @@ namespace SlimeVR
             std::copy(linAccel, linAccel+3, outLinAccel);
         }
 
+        Vector3 SensorFusion::getLinearAccVec()
+        {
+            getLinearAcc();
+            return Vector3(linAccel[0], linAccel[1], linAccel[2]);
+        }
+
         void SensorFusion::calcGravityVec(const sensor_real_t qwxyz[4], sensor_real_t gravVec[3])
         {
             gravVec[0] = 2 * (qwxyz[1] * qwxyz[3] - qwxyz[0] * qwxyz[2]);

--- a/src/sensors/SensorFusion.h
+++ b/src/sensors/SensorFusion.h
@@ -75,6 +75,7 @@ namespace SlimeVR
             sensor_real_t const * getGravityVec();
             sensor_real_t const * getLinearAcc();
             void getLinearAcc(sensor_real_t outLinAccel[3]);
+            Vector3 getLinearAccVec();
 
             static void calcGravityVec(const sensor_real_t qwxyz[4], sensor_real_t gravVec[3]);
             static void calcLinearAcc(const sensor_real_t accin[3], const sensor_real_t gravVec[3], sensor_real_t accout[3]);

--- a/src/sensors/SensorFusionDMP.cpp
+++ b/src/sensors/SensorFusionDMP.cpp
@@ -103,6 +103,11 @@ namespace SlimeVR
             getLinearAcc();
             std::copy(linAccel, linAccel+3, outLinAccel);
         }
-        
+
+        Vector3 SensorFusionDMP::getLinearAccVec()
+        {
+            getLinearAcc();
+            return Vector3(linAccel[0], linAccel[1], linAccel[2]);
+        }        
     }
 }

--- a/src/sensors/SensorFusionDMP.h
+++ b/src/sensors/SensorFusionDMP.h
@@ -24,6 +24,7 @@ namespace SlimeVR
             sensor_real_t const * getGravityVec();
             sensor_real_t const * getLinearAcc();
             void getLinearAcc(sensor_real_t outLinAccel[3]);
+            Vector3 getLinearAccVec();
 
         protected:
             DMPMag<sensor_real_t> dmpmag;

--- a/src/sensors/bmi160sensor.cpp
+++ b/src/sensors/bmi160sensor.cpp
@@ -376,17 +376,12 @@ void BMI160Sensor::motionLoop() {
             lastRotationPacketSent = now - (elapsed - sendInterval);
 
             fusedRotation = sfusion.getQuaternionQuat();
+            setFusedRotationReady();
 
-            sfusion.getLinearAcc(this->acceleration);
-			this->newAcceleration = true;
+            acceleration = sfusion.getLinearAccVec();
+            setAccelerationReady();
 
             fusedRotation *= sensorOffset;
-
-            if (!OPTIMIZE_UPDATES || !lastFusedRotationSent.equalsWithEpsilon(fusedRotation))
-            {
-                newFusedRotation = true;
-                lastFusedRotationSent = fusedRotation;
-            }
 
             optimistic_yield(100);
         }

--- a/src/sensors/bno055sensor.cpp
+++ b/src/sensors/bno055sensor.cpp
@@ -63,21 +63,14 @@ void BNO055Sensor::motionLoop() {
     Quat quat = imu.getQuat();
     fusedRotation.set(quat.x, quat.y, quat.z, quat.w);
     fusedRotation *= sensorOffset;
+    setFusedRotationReady();
 
 #if SEND_ACCELERATION
     {
-        Vector3 accel = this->imu.getVector(Adafruit_BNO055::VECTOR_LINEARACCEL);
-        this->acceleration[0] = accel.x;
-        this->acceleration[1] = accel.y;
-        this->acceleration[2] = accel.z;
-        this->newAcceleration = true;
+        acceleration = this->imu.getVector(Adafruit_BNO055::VECTOR_LINEARACCEL);
+        setAccelerationReady();
     }
 #endif
-
-    if(!OPTIMIZE_UPDATES || !lastFusedRotationSent.equalsWithEpsilon(fusedRotation)) {
-        newFusedRotation = true;
-        lastFusedRotationSent = fusedRotation;
-    }
 }
 
 void BNO055Sensor::startCalibration(int calibrationType) {

--- a/src/sensors/icm20948sensor.cpp
+++ b/src/sensors/icm20948sensor.cpp
@@ -102,14 +102,14 @@ void ICM20948Sensor::sendData()
             Network::sendRotationData(sensorId, &fusedRotation, DATA_TYPE_NORMAL, dmpData.Quat9.Data.Accuracy);
         }
         #endif
-    }
 
 #if SEND_ACCELERATION
-    if(newAcceleration) {
-        newAcceleration = false;
-        networkConnection.sendSensorAcceleration(sensorId, acceleration);
-    }
+        if (newAcceleration) {
+            newAcceleration = false;
+            networkConnection.sendSensorAcceleration(sensorId, acceleration);
+        }
 #endif
+    }
 }
 
 void ICM20948Sensor::startCalibration(int calibrationType)
@@ -478,7 +478,7 @@ void ICM20948Sensor::calculateAccelerationWithoutGravity(Quat *quaternion)
                             };
             sfusion.updateAcc(Axyz);
 
-            sfusion.getLinearAcc(this->acceleration);
+            acceleration = sfusion.getLinearAccVec();
 			this->newAcceleration = true;
         }
     }

--- a/src/sensors/mpu6050sensor.cpp
+++ b/src/sensors/mpu6050sensor.cpp
@@ -141,8 +141,9 @@ void MPU6050Sensor::motionLoop()
 
         fusedRotation = sfusion.getQuaternionQuat();
         fusedRotation *= sensorOffset;
+        setFusedRotationReady();
 
-    #if SEND_ACCELERATION
+        #if SEND_ACCELERATION
         {
             this->imu.dmpGetAccel(&this->rawAccel, this->fifoBuffer);
 
@@ -152,16 +153,10 @@ void MPU6050Sensor::motionLoop()
 
             sfusion.updateAcc(Axyz);
 
-            sfusion.getLinearAcc(this->acceleration);
-			this->newAcceleration = true;
+            acceleration = sfusion.getLinearAccVec();
+			setAccelerationReady();
         }
-    #endif
-
-        if (!OPTIMIZE_UPDATES || !lastFusedRotationSent.equalsWithEpsilon(fusedRotation))
-        {
-            newFusedRotation = true;
-            lastFusedRotationSent = fusedRotation;
-        }
+        #endif
     }
 }
 

--- a/src/sensors/mpu9250sensor.cpp
+++ b/src/sensors/mpu9250sensor.cpp
@@ -165,7 +165,7 @@ void MPU9250Sensor::motionLoop() {
 
     fusedRotation = sfusion.getQuaternionQuat();
 
-#if SEND_ACCELERATION
+    #if SEND_ACCELERATION
     {
         int16_t atemp[3];
         this->imu.dmpGetAccel(atemp, dmpPacket);
@@ -173,10 +173,10 @@ void MPU9250Sensor::motionLoop() {
 
         sfusion.updateAcc(Axyz);
 
-        sfusion.getLinearAcc(this->acceleration);
-		this->newAcceleration = true;
+        acceleration = sfusion.getLinearAccVec();
+		setAccelerationReady();
     }
-#endif
+    #endif
 
 #else
     union fifo_sample_raw buf;
@@ -200,16 +200,12 @@ void MPU9250Sensor::motionLoop() {
     fusedRotation = sfusion.getQuaternionQuat();
 
     #if SEND_ACCELERATION
-    sfusion.getLinearAcc(this->acceleration);
-	this->newAcceleration = true;
+    acceleration = sfusion.getLinearAccVec();
+	setAccelerationReady();
     #endif
 #endif
     fusedRotation *= sensorOffset;
-
-    if(!lastFusedRotationSent.equalsWithEpsilon(fusedRotation)) {
-        newFusedRotation = true;
-        lastFusedRotationSent = fusedRotation;
-    }
+    setFusedRotationReady();
 }
 
 void MPU9250Sensor::startCalibration(int calibrationType) {

--- a/src/sensors/sensor.h
+++ b/src/sensors/sensor.h
@@ -58,6 +58,8 @@ public:
     virtual void postSetup(){};
     virtual void motionLoop(){};
     virtual void sendData();
+    virtual void setAccelerationReady();
+    virtual void setFusedRotationReady();
     virtual void startCalibration(int calibrationType){};
     virtual SensorStatus getSensorState();
     virtual void printTemperatureCalibrationState();
@@ -75,6 +77,9 @@ public:
     };
     uint8_t getSensorType() {
         return sensorType;
+    };
+    const Vector3& getAcceleration() {
+        return acceleration;
     };
     const Quat& getFusedRotation() {
         return fusedRotation;
@@ -98,7 +103,7 @@ protected:
     Quat lastFusedRotationSent{};
 
     bool newAcceleration = false;
-    float acceleration[3]{};
+    Vector3 acceleration{};
 
     SlimeVR::Logging::Logger m_Logger;
     


### PR DESCRIPTION
Fixes #267 - acceleration updates are only sent with rotations again.
Refactored acceleration into a `Vector3`, reduced code duplication.
BNO08x was unaffected because it sets `newAcceleration` inside `if (imu.hasNewQuat())`.