### PR TITLE
Add BOARD_WEMOSWROOM02

### DIFF
--- a/platformio-tools.ini
+++ b/platformio-tools.ini
@@ -26,6 +26,10 @@ board = esp12e
 platform = espressif8266 @ 4.2.0
 board = esp12e
 
+[env:BOARD_WEMOSWROOM02]
+platform = espressif8266 @ 4.2.0
+board = esp12e
+
 [env:BOARD_WROOM32]
 platform = espressif32 @ 6.1.0
 board = esp32dev

--- a/src/consts.h
+++ b/src/consts.h
@@ -53,6 +53,7 @@
 #define BOARD_OWOTRACK 13 // Only used by owoTrack mobile app
 #define BOARD_WRANGLER 14 // Only used by wrangler app
 #define BOARD_MOCOPI 15 // Used by mocopi/moslime
+#define BOARD_WEMOSWROOM02 16
 #define BOARD_DEV_RESERVED 250 // Reserved, should not be used in any release firmware
 
 #define BAT_EXTERNAL 1

--- a/src/defines.h
+++ b/src/defines.h
@@ -181,4 +181,12 @@ IMU_DESC_ENTRY(IMU_BMP160, PRIMARY_IMU_ADDRESS_ONE, IMU_ROTATION, PIN_IMU_SCL, P
   #define PIN_BATTERY_LEVEL 3
   #define LED_PIN LED_OFF  // RGB LED Protocol would need to be implementetet did not brother for the test, because the board ideal for tracker ifself
 //  #define LED_INVERTED false
+#elif BOARD == BOARD_WEMOSWROOM02
+  #define PIN_IMU_SDA 2
+  #define PIN_IMU_SCL 14
+  #define PIN_IMU_INT 0
+  #define PIN_IMU_INT_2 4
+  #define PIN_BATTERY_LEVEL A0
+  #define LED_PIN 16
+  #define LED_INVERTED true
 #endif


### PR DESCRIPTION
This adds definition for ESP-WROOM-02

Tested against a board "WeMos D1 ESP Wroom 02"
![WROOM02_18650](https://github.com/SlimeVR/SlimeVR-Tracker-ESP/assets/74481/bf20d302-880f-4e94-ba74-de0abdfbd6c6)
![20210604071434338](https://github.com/SlimeVR/SlimeVR-Tracker-ESP/assets/74481/f13f9645-826f-45b7-984b-de0941bdcd93)
