### PR TITLE
Fix MPU9250 calibration matrix multiplication

### DIFF
--- a/src/sensors/mpu9250sensor.cpp
+++ b/src/sensors/mpu9250sensor.cpp
@@ -362,8 +362,10 @@ void MPU9250Sensor::parseMagData(int16_t data[3]) {
     float temp[3];
 
     //apply offsets and scale factors from Magneto
-    for (unsigned i = 0; i < 3; i++) {
+    for (unsigned i = 0; i < 3; i++)
         temp[i] = (Mxyz[i] - m_Calibration.M_B[i]);
+    
+    for (unsigned i = 0; i < 3; i++) {
         #if useFullCalibrationMatrix == true
             Mxyz[i] = m_Calibration.M_Ainv[i][0] * temp[0] + m_Calibration.M_Ainv[i][1] * temp[1] + m_Calibration.M_Ainv[i][2] * temp[2];
         #else
@@ -383,9 +385,14 @@ void MPU9250Sensor::parseAccelData(int16_t data[3]) {
     #endif
 
     //apply offsets (bias) and scale factors from Magneto
+    #if !MPU_USE_DMPMAG
+    float temp[3];
+    for (unsigned i = 0; i < 3; i++)
+        temp[i] = (Axyz[i] - m_Calibration.A_B[i]);
+    #endif
+    
     for (unsigned i = 0; i < 3; i++) {
         #if !MPU_USE_DMPMAG
-        temp[i] = (Axyz[i] - m_Calibration.A_B[i]);
         #if useFullCalibrationMatrix == true
             Axyz[i] = m_Calibration.A_Ainv[i][0] * temp[0] + m_Calibration.A_Ainv[i][1] * temp[1] + m_Calibration.A_Ainv[i][2] * temp[2];
         #else


### PR DESCRIPTION
 Split applying calibration values into 2 loops - first the bias, then the matrix(like for BMI160)
 If done in a single loop the matrix multiplication uses uninitialized `temp[]` values, which is wrong