### PR TITLE
BMI160: Fix magnetometer error check

### DIFF
--- a/lib/bmi160/BMI160.cpp
+++ b/lib/bmi160/BMI160.cpp
@@ -121,16 +121,10 @@ void BMI160::setMagDeviceAddress(uint8_t addr) {
     setRegister(BMI160_RA_MAG_IF_0_DEVADDR, addr << 1); // 0 bit of address is reserved and needs to be shifted
 }
 
-bool BMI160::setMagRegister(uint8_t addr, uint8_t value) {
+void BMI160::setMagRegister(uint8_t addr, uint8_t value) {
     setRegister(BMI160_RA_MAG_IF_4_WRITE_VALUE, value);
     setRegister(BMI160_RA_MAG_IF_3_WRITE_RA, addr);
     delay(3);
-    I2CdevMod::readByte(devAddr, BMI160_RA_ERR, buffer);
-    if (buffer[0] & BMI160_ERR_MASK_I2C_FAIL) {
-        printf("BMI160: mag register proxy write error\n");
-        return false;
-    }
-    return true;
 }
 
 /** Get Device ID.

--- a/lib/bmi160/BMI160.h
+++ b/lib/bmi160/BMI160.h
@@ -52,7 +52,7 @@ THE SOFTWARE.
 #define BMI160_RA_MAG_CONF             0x44
 #define BMI160_RA_MAG_IF_0_DEVADDR     0x4B
 #define BMI160_RA_MAG_IF_1_MODE        0x4C
-#define BMI160_RA_MAG_IF_2_READ_RA    0x4D
+#define BMI160_RA_MAG_IF_2_READ_RA     0x4D
 #define BMI160_RA_MAG_IF_3_WRITE_RA    0x4E
 #define BMI160_RA_MAG_IF_4_WRITE_VALUE 0x4F
 #define BMI160_RA_IF_CONF              0x6B
@@ -343,11 +343,12 @@ typedef enum {
 #define BMI160_FIFO_A_LEN 6
 
 #define BMI160_RA_ERR                        0x02
-#define BMI160_ERR_MASK_MAG_DRDY_ERR         0x10000000
-#define BMI160_ERR_MASK_DROP_CMD_ERR         0x01000000
-#define BMI160_ERR_MASK_I2C_FAIL             0x00100000
-#define BMI160_ERR_MASK_ERROR_CODE           0x00011110
-#define BMI160_ERR_MASK_CHIP_NOT_OPERABLE    0x00000001
+#define BMI160_ERR_MASK_MAG_DRDY_ERR         0b10000000
+#define BMI160_ERR_MASK_DROP_CMD_ERR         0b01000000
+// datasheet is unclear - reserved or i2c_fail_err?
+// #define BMI160_ERR_MASK_I2C_FAIL             0b00100000
+#define BMI160_ERR_MASK_ERROR_CODE           0b00011110
+#define BMI160_ERR_MASK_CHIP_NOT_OPERABLE    0b00000001
 
 /**
  * Interrupt Latch Mode options
@@ -755,7 +756,7 @@ class BMI160 {
         void waitForMagDrdy();
         bool getSensorTime(uint32_t *v_sensor_time_u32);
         void setMagDeviceAddress(uint8_t addr);
-        bool setMagRegister(uint8_t addr, uint8_t value);
+        void setMagRegister(uint8_t addr, uint8_t value);
 
         bool getErrReg(uint8_t* out);
     private:

--- a/src/sensors/bmi160sensor.cpp
+++ b/src/sensors/bmi160sensor.cpp
@@ -33,12 +33,6 @@ void BMI160Sensor::initHMC(BMI160MagRate magRate) {
     imu.setRegister(BMI160_RA_CMD, BMI160_CMD_MAG_MODE_NORMAL);
     delay(60);
 
-    imu.setRegister(BMI160_RA_CMD, BMI160_EN_PULL_UP_REG_1);
-    imu.setRegister(BMI160_RA_CMD, BMI160_EN_PULL_UP_REG_2);
-    imu.setRegister(BMI160_RA_CMD, BMI160_EN_PULL_UP_REG_3);
-    imu.setRegister(BMI160_7F, BMI160_EN_PULL_UP_REG_4);
-    imu.setRegister(BMI160_7F, BMI160_EN_PULL_UP_REG_5);
-
     /* Enable MAG interface */
     imu.setRegister(BMI160_RA_IF_CONF, BMI160_IF_CONF_MODE_PRI_AUTO_SEC_MAG);
     delay(1);
@@ -64,12 +58,6 @@ void BMI160Sensor::initQMC(BMI160MagRate magRate) {
     /* Set MAG interface normal power mode */
     imu.setRegister(BMI160_RA_CMD, BMI160_CMD_MAG_MODE_NORMAL);
     delay(60);
-
-    imu.setRegister(BMI160_RA_CMD, BMI160_EN_PULL_UP_REG_1);
-    imu.setRegister(BMI160_RA_CMD, BMI160_EN_PULL_UP_REG_2);
-    imu.setRegister(BMI160_RA_CMD, BMI160_EN_PULL_UP_REG_3);
-    imu.setRegister(BMI160_7F, BMI160_EN_PULL_UP_REG_4);
-    imu.setRegister(BMI160_7F, BMI160_EN_PULL_UP_REG_5);
 
     /* Enable MAG interface */
     imu.setRegister(BMI160_RA_IF_CONF, BMI160_IF_CONF_MODE_PRI_AUTO_SEC_MAG);


### PR DESCRIPTION
- Removes bugged magnetometer error message;
- Fixes error masks starting with `0x` instead of `0b`;
- Pullups in mag initialization code are not needed.