### PR TITLE
Report IMU errors

### DIFF
--- a/src/sensors/EmptySensor.h
+++ b/src/sensors/EmptySensor.h
@@ -40,6 +40,10 @@ namespace SlimeVR
             void motionLoop() override final{};
             void sendData() override final{};
             void startCalibration(int calibrationType) override final{};
+            SensorStatus getSensorState() override final
+            {
+                return SensorStatus::SENSOR_OFFLINE;
+            };
         };
     }
 }

--- a/src/sensors/SensorManager.cpp
+++ b/src/sensors/SensorManager.cpp
@@ -187,12 +187,19 @@ namespace SlimeVR
         void SensorManager::update()
         {
             // Gather IMU data
+            bool allIMUGood = true;
             for (auto sensor : m_Sensors) {
                 if (sensor->isWorking()) {
                     swapI2C(sensor->sclPin, sensor->sdaPin);
                     sensor->motionLoop();
                 }
+                if (sensor->getSensorState() == SensorStatus::SENSOR_ERROR)
+                {
+                    allIMUGood = false;
+                }
             }
+
+            statusManager.setStatus(SlimeVR::Status::IMU_ERROR, !allIMUGood);
 
             if (!networkConnection.isConnected()) {
                 return;

--- a/src/sensors/sensor.cpp
+++ b/src/sensors/sensor.cpp
@@ -26,7 +26,7 @@
 #include "calibration.h"
 
 SensorStatus Sensor::getSensorState() {
-    return isWorking() ? SensorStatus::SENSOR_OK : SensorStatus::SENSOR_OFFLINE;
+    return isWorking() ? SensorStatus::SENSOR_OK : SensorStatus::SENSOR_ERROR;
 }
 
 void Sensor::setAccelerationReady() {


### PR DESCRIPTION
This is changing default behavior of Sensors. If sensor failed to initialize (and has working=false) it will report error, not offline.
I added exception to Empty sensor, not to generate errors from disconnected (and not mandatory) aux imus.

I also made sensor manager set IMU_ERROR flag to statusManager. This way user will see 5 blinking leds on imu error. So far only bno sensor was setting that flag.