### PR TITLE
icm20948 timeout correction because of wifi set

### DIFF
--- a/src/sensors/icm20948sensor.cpp
+++ b/src/sensors/icm20948sensor.cpp
@@ -324,11 +324,12 @@ void ICM20948Sensor::startMotionLoop()
 
 void ICM20948Sensor::checkSensorTimeout()
 {
-    if(lastData + 1000 < millis()) {
+    unsigned long currenttime = millis();
+    if(lastData + 2000 < currenttime) {
         working = false;
-        lastData = millis();
-        m_Logger.error("Sensor timeout I2C Address 0x%02x", addr);
+        m_Logger.error("Sensor timeout I2C Address 0x%02x delaytime: %d ms", addr, currenttime-lastData );
         networkConnection.sendSensorError(this->sensorId, 1);
+        lastData = currenttime;
     }
 }
 


### PR DESCRIPTION
When on ESP8266 and ESP32-C3, it seems that the serial command "wifi set" holds up the loop for 1 sec. 
So i had to increase the timeout.