### PR TITLE
Fix ICM20948 PacketBundling and LastData

### DIFF
--- a/src/sensors/icm20948sensor.cpp
+++ b/src/sensors/icm20948sensor.cpp
@@ -79,7 +79,7 @@ void ICM20948Sensor::motionLoop()
         cntbuf = 0;
         cntrounds = 0;
     }
-*/  
+*/
 }
 
 void ICM20948Sensor::readFIFOToEnd()
@@ -104,9 +104,8 @@ void ICM20948Sensor::readFIFOToEnd()
 
 void ICM20948Sensor::sendData()
 {
-    if(newFusedRotation && lastDataSent + 7 < millis())
+    if(newFusedRotation)
     {
-        lastDataSent = millis();
         newFusedRotation = false;
 
         #if(USE_6_AXIS)
@@ -320,6 +319,7 @@ void ICM20948Sensor::startMotionLoop()
 {
     lastData = millis();
     working = true;
+	hadData = true;
 }
 
 void ICM20948Sensor::checkSensorTimeout()

--- a/src/sensors/icm20948sensor.h
+++ b/src/sensors/icm20948sensor.h
@@ -45,7 +45,6 @@ public:
 private:
     void calculateAccelerationWithoutGravity(Quat *quaternion);
     unsigned long lastData = 0;
-    unsigned long lastDataSent = 0;
     int bias_save_counter = 0;
     bool hasdata = false;
 // Performance test


### PR DESCRIPTION
The delay in sendData() makes at somepoint that the packetbundling does not work correctly. The ICM works without delay on ESP8266, ESP32-C3, ESP32-S2 Also added the LastData Flag for get info