### PR TITLE
Set C3 default clock speed to 80MHz

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -60,6 +60,9 @@ board = esp12e
 ; Comment out this line below if you have any trouble uploading the firmware
 ; and if it has a CP2102 on it (a square chip next to the usb port): change to 3000000 (3 million) for even faster upload speed
 upload_speed = 921600
+; Consider enabling if tracker is only 1 IMU with esp sensor fusion (BMI160) or 2 IMU without esp sensor fusion (BNO08X)
+; this will slightly improve battery life of the tracker.
+;board_build.f_cpu = 40000000L
 
 ; Uncomment below if you want to build for ESP-01
 ;[env:esp01_1m]
@@ -76,13 +79,13 @@ upload_speed = 921600
 
 ; Uncomment below if you want to build for esp32
 ; Check your board name at https://docs.platformio.org/en/latest/platforms/espressif32.html#boards
-; [env:esp32]
-; platform = espressif32 @ 6.1.0
-; board = esp32dev
+;[env:esp32]
+;platform = espressif32 @ 6.4.0
+;board = esp32dev
 ; Comment out this line below if you have any trouble uploading the firmware - and if it has a CP2102 on it (a square chip next to the usb port): change to 3000000 (3 million) for even faster upload speed
 ;upload_speed = 921600
 
-; If you want to use a ESP32C3, you can use this (experimental)
+; Uncomment below if you want to build for esp32c3
 ; Check your board name at https://docs.platformio.org/en/latest/platforms/espressif32.html#boards
 ; There are 2 main Boardtypes:
 ; 1. Boards that use a USB 2 Serial Chipset ( esp32-c3-devkitm-1, ttgo-t-oi-plus )
@@ -92,8 +95,9 @@ upload_speed = 921600
 ;    -DARDUINO_USB_CDC_ON_BOOT=1
 
 ;[env:esp32c3]
-;platform = espressif32 @ 6.1.0
+;platform = espressif32 @ 6.4.0
 ;build_flags = 
 ;  ${env.build_flags}
 ;  -DESP32C3
 ;board = lolin_c3_mini
+;board_build.f_cpu = 80000000L


### PR DESCRIPTION
This reduces the esp32c3 power consumption by around 15 ma. The platformIO version was also updated to the latest for the 32 series