### PR TITLE
ESP32: Fix ADC/battery sense logic

### DIFF
--- a/src/batterymonitor.cpp
+++ b/src/batterymonitor.cpp
@@ -79,9 +79,9 @@ void BatteryMonitor::Loop()
             #endif
             #if ESP8266 && BATTERY_MONITOR == BAT_EXTERNAL
                 voltage = ((float)analogRead(PIN_BATTERY_LEVEL)) * batteryADCMultiplier;
+            #endif
             #if ESP32 && BATTERY_MONITOR == BAT_EXTERNAL
                 voltage = ((float)analogReadMilliVolts(PIN_BATTERY_LEVEL)) / 1000 * (BATTERY_SHIELD_RESISTANCE + BATTERY_SHIELD_R1 + BATTERY_SHIELD_R2) / BATTERY_SHIELD_R1;
-            #endif
             #endif
             #if BATTERY_MONITOR == BAT_MCP3021 || BATTERY_MONITOR == BAT_INTERNAL_MCP3021
                 if (address > 0)

--- a/src/batterymonitor.cpp
+++ b/src/batterymonitor.cpp
@@ -77,8 +77,11 @@ void BatteryMonitor::Loop()
                     }
                 }
             #endif
-            #if BATTERY_MONITOR == BAT_EXTERNAL
+            #if ESP8266 && BATTERY_MONITOR == BAT_EXTERNAL
                 voltage = ((float)analogRead(PIN_BATTERY_LEVEL)) * batteryADCMultiplier;
+            #if ESP32 && BATTERY_MONITOR == BAT_EXTERNAL
+                voltage = ((float)analogReadMilliVolts(PIN_BATTERY_LEVEL)) / 1000 * (BATTERY_SHIELD_RESISTANCE + BATTERY_SHIELD_R1 + BATTERY_SHIELD_R2) / BATTERY_SHIELD_R1;
+            #endif
             #endif
             #if BATTERY_MONITOR == BAT_MCP3021 || BATTERY_MONITOR == BAT_INTERNAL_MCP3021
                 if (address > 0)


### PR DESCRIPTION
At least on ESP32-C3, default logic returns completely wrong values for voltage. This fixes it.