### PR TITLE
Added ON-OFF button support

### DIFF
--- a/lib/bmi160/BMI160.cpp
+++ b/lib/bmi160/BMI160.cpp
@@ -109,6 +109,12 @@ void BMI160::initialize(uint8_t addr,
     // I2CdevMod::writeByte(devAddr, BMI160_RA_INT_MAP_2, 0x00);
 }
 
+void BMI160::deinitialize() {
+    /* Issue a soft-reset to bring the device into a clean state */
+    setRegister(BMI160_RA_CMD, BMI160_CMD_SOFT_RESET);
+    delay(12);
+}
+
 bool BMI160::getErrReg(uint8_t* out) {
     bool ok = I2CdevMod::readByte(devAddr, BMI160_RA_ERR, buffer) >= 0;
     if (!ok) return false;

--- a/lib/bmi160/BMI160.h
+++ b/lib/bmi160/BMI160.h
@@ -564,6 +564,7 @@ class BMI160 {
             BMI160AccelRange accelRange = BMI160_ACCEL_RANGE_4G,
             BMI160DLPFMode accelFilterMode = BMI160_DLPF_MODE_OSR4
         );
+        void deinitialize();
         bool testConnection();
 
         uint8_t getGyroRate();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -30,6 +30,7 @@
 #include "serial/serialcommands.h"
 #include "batterymonitor.h"
 #include "logging/Logger.h"
+#include "onOffButton.h"
 
 Timer<> globalTimer;
 SlimeVR::Logging::Logger logger("SlimeVR");
@@ -39,6 +40,10 @@ SlimeVR::Status::StatusManager statusManager;
 SlimeVR::Configuration::Configuration configuration;
 SlimeVR::Network::Manager networkManager;
 SlimeVR::Network::Connection networkConnection;
+
+#ifdef ON_OFF_BUTTON
+SlimeVR::OnOffButton onOffButton;
+#endif
 
 int sensorToCalibrate = -1;
 bool blinking = false;
@@ -93,6 +98,10 @@ void setup()
 #endif
     Wire.setClock(I2C_SPEED);
 
+    #ifdef ON_OFF_BUTTON
+    onOffButton.setup();
+    #endif
+
     // Wait for IMU to boot
     delay(500);
 
@@ -118,6 +127,10 @@ void loop()
     sensorManager.update();
     battery.Loop();
     ledManager.update();
+
+    #ifdef ON_OFF_BUTTON
+    onOffButton.update();
+    #endif
 #ifdef TARGET_LOOPTIME_MICROS
     long elapsed = (micros() - loopTime);
     if (elapsed < TARGET_LOOPTIME_MICROS)

--- a/src/onOffButton.cpp
+++ b/src/onOffButton.cpp
@@ -1,0 +1,80 @@
+#include "onOffButton.h"
+
+#include "globalVars.h"
+
+void SlimeVR::OnOffButton::setup() {
+#ifdef ON_OFF_BUTTON
+
+#ifdef ESP8266
+    digitalWrite(D0, LOW);
+    pinMode(D0, OUTPUT);
+    pinMode(ON_OFF_BUTTON, INPUT);
+#endif
+
+#ifdef ESP32
+    pinMode(
+        ON_OFF_BUTTON,
+        ON_OFF_BUTTON_ACTIVE_LEVEL == LOW 
+            ? INPUT_PULLUP 
+            : INPUT_PULLDOWN
+        );
+    esp_deep_sleep_enable_gpio_wakeup(
+        1 << ON_OFF_BUTTON,
+        ON_OFF_BUTTON_ACTIVE_LEVEL == LOW
+            ? ESP_GPIO_WAKEUP_GPIO_LOW
+            : ESP_GPIO_WAKEUP_GPIO_HIGH
+        );
+#endif
+
+#endif
+}
+
+void SlimeVR::OnOffButton::update() {
+#ifdef ON_OFF_BUTTON
+
+    if (digitalRead(ON_OFF_BUTTON) != ON_OFF_BUTTON_ACTIVE_LEVEL) {
+        return;
+    }
+
+    uint32_t ringBuffer = 0;
+    long startTime = millis();
+    while (millis() - startTime < ON_OFF_BUTTON_HOLD_TIME_MS) {
+        ringBuffer <<= 1;
+        ringBuffer |= digitalRead(ON_OFF_BUTTON) != ON_OFF_BUTTON_ACTIVE_LEVEL;
+
+        int popCount = __builtin_popcount(ringBuffer);
+        if (popCount > 16) {
+            return;
+        }
+        delay(1);
+    }
+
+    ledManager.off();
+    for (int i = 0; i < 3; i++) {
+        ledManager.on();
+        delay(100);
+        ledManager.off();
+        delay(100);
+    }
+
+    ringBuffer = 0;
+    while (__builtin_popcount(ringBuffer) <= 16) {
+        ringBuffer <<= 1;
+        ringBuffer |= digitalRead(ON_OFF_BUTTON) != ON_OFF_BUTTON_ACTIVE_LEVEL;
+        delay(1);
+    }
+
+    const auto &sensors = sensorManager.getSensors();
+    for (auto sensor : sensors) {
+        sensor->deinitialize();
+    }
+
+#ifdef ESP8266
+    ESP.deepSleep(0);
+#endif
+
+#ifdef ESP32
+    esp_deep_sleep_start();
+#endif
+#endif
+}

--- a/src/onOffButton.h
+++ b/src/onOffButton.h
@@ -8,6 +8,10 @@
 #define ON_OFF_BUTTON_ACTIVE_LEVEL LOW
 #endif
 
+#ifndef ON_OFF_BUTTON_HOLD_TIME_MS
+#define ON_OFF_BUTTON_HOLD_TIME_MS 1000
+#endif
+
 namespace SlimeVR {
 
 class OnOffButton {

--- a/src/onOffButton.h
+++ b/src/onOffButton.h
@@ -1,0 +1,23 @@
+#ifndef SLIMEVR_ONOFFBUTTON_H_
+#define SLIMEVR_ONOFFBUTTON_H_
+
+#include "logging/Logger.h"
+#include "globals.h"
+
+#ifndef ON_OFF_BUTTON_ACTIVE_LEVEL
+#define ON_OFF_BUTTON_ACTIVE_LEVEL LOW
+#endif
+
+namespace SlimeVR {
+
+class OnOffButton {
+public:
+    void setup();
+    void update();
+private:
+    SlimeVR::Logging::Logger m_Logger = SlimeVR::Logging::Logger("OnOffButton");
+};
+
+}
+
+#endif

--- a/src/sensors/bmi160sensor.cpp
+++ b/src/sensors/bmi160sensor.cpp
@@ -1010,3 +1010,7 @@ void BMI160Sensor::getMagnetometerXYZFromBuffer(uint8_t* data, int16_t* x, int16
         *z = ((int16_t)data[5] << 8) | data[4];
     #endif
 }
+
+void BMI160Sensor::deinitialize() {
+    imu.deinitialize();
+}

--- a/src/sensors/bmi160sensor.h
+++ b/src/sensors/bmi160sensor.h
@@ -167,6 +167,8 @@ class BMI160Sensor : public Sensor {
         void getRemappedAcceleration(int16_t* x, int16_t* y, int16_t* z);
 
         bool getTemperature(float* out);
+
+        void deinitialize() override final;
     private:
         BMI160 imu {};
         int axisRemap;

--- a/src/sensors/bno055sensor.cpp
+++ b/src/sensors/bno055sensor.cpp
@@ -76,3 +76,7 @@ void BNO055Sensor::motionLoop() {
 void BNO055Sensor::startCalibration(int calibrationType) {
 
 }
+
+void BNO055Sensor::deinitialize() {
+    imu.enterSuspendMode();
+}

--- a/src/sensors/bno055sensor.h
+++ b/src/sensors/bno055sensor.h
@@ -37,6 +37,7 @@ public:
     void motionSetup() override final;
     void motionLoop() override final;
     void startCalibration(int calibrationType) override final;
+    void deinitialize() override final;
 
 private:
     Adafruit_BNO055 imu;

--- a/src/sensors/bno080sensor.cpp
+++ b/src/sensors/bno080sensor.cpp
@@ -242,3 +242,8 @@ void BNO080Sensor::startCalibration(int calibrationType)
     // it's always enabled except accelerometer
     // that is disabled 30 seconds after startup
 }
+
+void BNO080Sensor::deinitialize() 
+{
+    imu.softReset();
+}

--- a/src/sensors/bno080sensor.h
+++ b/src/sensors/bno080sensor.h
@@ -42,6 +42,7 @@ public:
     void sendData() override final;
     void startCalibration(int calibrationType) override final;
     SensorStatus getSensorState() override final;
+    void deinitialize() override final;
 
 private:
     BNO080 imu{};

--- a/src/sensors/icm20948sensor.cpp
+++ b/src/sensors/icm20948sensor.cpp
@@ -769,3 +769,7 @@ ICM_20948_Status_e ICM_20948::initializeDMP(void)
   return worstResult;
 }
 #endif // OVERRIDEDMPSETUP
+
+void ICM20948Sensor::deinitialize() {
+    imu.swReset();
+}

--- a/src/sensors/icm20948sensor.h
+++ b/src/sensors/icm20948sensor.h
@@ -74,6 +74,7 @@ private:
     void checkSensorTimeout();
     void readRotation();
     void readFIFOToEnd();
+    void deinitialize() override final;
 
 #define OVERRIDEDMPSETUP true
     // TapDetector tapDetector;

--- a/src/sensors/icm42688sensor.cpp
+++ b/src/sensors/icm42688sensor.cpp
@@ -346,3 +346,7 @@ void ICM42688Sensor::parseGyroData() {
     Gxyz[1] = (Gxyz[1] - m_Calibration.G_off[1]);
     Gxyz[2] = (Gxyz[2] - m_Calibration.G_off[2]);
 }
+
+void ICM42688Sensor::deinitialize() {
+    I2Cdev::writeByte(addr, ICM42688_DEVICE_CONFIG, 1); // reset
+}

--- a/src/sensors/icm42688sensor.h
+++ b/src/sensors/icm42688sensor.h
@@ -43,6 +43,7 @@ public:
     void motionSetup() override final;
     void motionLoop() override final;
     void startCalibration(int calibrationType) override final;
+    void deinitialize() override final;
 
 private:
     uint8_t addr_mag = 0x30;

--- a/src/sensors/mpu6050sensor.cpp
+++ b/src/sensors/mpu6050sensor.cpp
@@ -203,3 +203,7 @@ void MPU6050Sensor::startCalibration(int calibrationType) {
 
     ledManager.off();
 }
+
+void MPU6050Sensor::deinitialize() {
+    imu.reset();
+}

--- a/src/sensors/mpu6050sensor.h
+++ b/src/sensors/mpu6050sensor.h
@@ -37,6 +37,7 @@ public:
     void motionSetup() override final;
     void motionLoop() override final;
     void startCalibration(int calibrationType) override final;
+    void deinitialize() override final;
 
 private:
     MPU6050 imu{};

--- a/src/sensors/mpu9250sensor.cpp
+++ b/src/sensors/mpu9250sensor.cpp
@@ -454,3 +454,7 @@ bool MPU9250Sensor::getNextSample(union fifo_sample_raw *buffer, uint16_t *remai
     swapFifoData(buffer);
     return true;
 }
+
+void MPU9250Sensor::deinitialize() {
+    imu.reset();
+}

--- a/src/sensors/mpu9250sensor.h
+++ b/src/sensors/mpu9250sensor.h
@@ -55,6 +55,7 @@ public:
     void motionLoop() override final;
     void startCalibration(int calibrationType) override final;
     void getMPUScaled();
+    void deinitialize() override final;
 
 private:
     MPU9250 imu{};

--- a/src/sensors/sensor.cpp
+++ b/src/sensors/sensor.cpp
@@ -66,6 +66,7 @@ void Sensor::printTemperatureCalibrationState() { printTemperatureCalibrationUns
 void Sensor::printDebugTemperatureCalibrationState() { printTemperatureCalibrationUnsupported(); };
 void Sensor::saveTemperatureCalibration() { printTemperatureCalibrationUnsupported(); };
 void Sensor::resetTemperatureCalibrationState() { printTemperatureCalibrationUnsupported(); };
+void Sensor::deinitialize() {}
 
 const char * getIMUNameByType(int imuType) {
     switch(imuType) {

--- a/src/sensors/sensor.h
+++ b/src/sensors/sensor.h
@@ -87,6 +87,7 @@ public:
     bool hasNewDataToSend() {
         return newFusedRotation || newAcceleration;
     };
+    virtual void deinitialize();
 
     bool hadData = false;
 protected:


### PR DESCRIPTION
This PR adds in support for momentary push button based ON-OFF functionality using the ESP's deep sleep feature. 

The code was tested on an ESP8266 (specifically a D1 mini) and an ESP32-C3 (supermini esp32c3). For the latter, attaching a push button between GND and any of the RTC GPIOs (GPIO0-5), the code should work, but for the ESP8266, the following hardware needs to be added:

![kép](https://github.com/SlimeVR/SlimeVR-Tracker-ESP/assets/5338164/b3cb81d1-a212-4b18-ab5b-0380ed3e1300)

GPIO13 can be set to any of the safe pins (4, 5, 12, 13, 14), however the other ones are already used by the default SlimeVR setup. I have tried to make the setup work with a MOSFET instead of a transistor, but didn't manage to yet.

The on-off behaviour can be activated by defining ON_OFF_BUTTON inside defines.h. For example:

```cpp
#define ON_OFF_BUTTON D7
```

for a D1 mini.

When the tracker is on, holding down the button for 1 second puts it to deep sleep (this is debounced). When it's in deep sleep, pressing the button once will wake it up, resetting it. The hold down time can be changed by defining ON_OFF_BUTTON_HOLD_TIME_MS in defines.h.

The tracker attempts to deinitialize the imus attached to it.

While it varies, this setup should drop the power consumption to somewhere around 100-200uA.

There are some quirks with the ESP8266 implementation:
- Seemingly the tracker can't be flashed while it's off. 
- After flashing, the tracker will start in deep sleep mode

Things that need checking:
- Is it possible to make the necessary circuitry for the ESP8266 out of a MOSFET
- Are the 8266 quirks solvable
- Are the deinitialization routines for the IMUs correct

It's also theoretically possible to add in a hold time for turning on the tracker for the ESP32 variant, but since this isn't at all possible for the ESP8266, I didn't implement it.