### PR TITLE
Add threading support

### DIFF
--- a/src/debug.h
+++ b/src/debug.h
@@ -59,6 +59,9 @@
     #define TARGET_LOOPTIME_MICROS (samplingRateInMillis * 1000)
 #endif
 
+// Enable threading for higher performance on ESP32 variants
+#define SENSOR_THREADING true
+
 // Packet bundling/aggregation
 #define PACKET_BUNDLING PACKET_BUNDLING_BUFFERED
 // Extra tunable for PACKET_BUNDLING_BUFFERED (10000us = 10ms timeout, 100hz target)

--- a/src/sensors/SensorManager.cpp
+++ b/src/sensors/SensorManager.cpp
@@ -186,7 +186,7 @@ namespace SlimeVR
                     sensor->postSetup();
                 }
             }
-#if ESP32
+#if ESP32 && SENSOR_THREADING
             for (auto & sensor : m_Sensors) {
                 sensor->updateMutex = xSemaphoreCreateMutex();
             }
@@ -194,7 +194,7 @@ namespace SlimeVR
 #endif
         }
         
-#if ESP32
+#if ESP32 && SENSOR_THREADING
         void SensorManager::updateSensors(void * pxParameter) {
             SensorManager *pthis = (SensorManager *)pxParameter;
             for (;;) {
@@ -217,7 +217,7 @@ namespace SlimeVR
 
         void SensorManager::update()
         {
-#if !ESP32
+#if !(ESP32 && SENSOR_THREADING)
             // Gather IMU data
             bool allIMUGood = true;
             for (auto sensor : m_Sensors) {

--- a/src/sensors/SensorManager.h
+++ b/src/sensors/SensorManager.h
@@ -71,6 +71,10 @@ namespace SlimeVR
             void swapI2C(uint8_t scl, uint8_t sda);
             
             uint32_t m_LastBundleSentAtMicros = micros();
+        #if ESP32
+            TaskHandle_t sensorTask = NULL;
+            static void updateSensors(void * pvParameters);
+        #endif
         };
     }
 }

--- a/src/sensors/SensorManager.h
+++ b/src/sensors/SensorManager.h
@@ -71,7 +71,7 @@ namespace SlimeVR
             void swapI2C(uint8_t scl, uint8_t sda);
             
             uint32_t m_LastBundleSentAtMicros = micros();
-        #if ESP32
+        #if ESP32 && SENSOR_THREADING
             TaskHandle_t sensorTask = NULL;
             static void updateSensors(void * pvParameters);
         #endif

--- a/src/sensors/sensor.cpp
+++ b/src/sensors/sensor.cpp
@@ -30,18 +30,18 @@ SensorStatus Sensor::getSensorState() {
 }
 
 void Sensor::setAcceleration(Vector3 a) {
-#if ESP32
+#if ESP32 && SENSOR_THREADING
     xSemaphoreTake(updateMutex, portMAX_DELAY);
 #endif
     acceleration = a;
     newAcceleration = true;
-#if ESP32
+#if ESP32 && SENSOR_THREADING
     xSemaphoreGive(updateMutex);
 #endif
 }
 
 void Sensor::setFusedRotation(Quat r) {
-#if ESP32
+#if ESP32 && SENSOR_THREADING
     xSemaphoreTake(updateMutex, portMAX_DELAY);
 #endif
     fusedRotation = r * sensorOffset;
@@ -50,13 +50,13 @@ void Sensor::setFusedRotation(Quat r) {
         newFusedRotation = true;
         lastFusedRotationSent = fusedRotation;
     }
-#if ESP32
+#if ESP32 && SENSOR_THREADING
     xSemaphoreGive(updateMutex);
 #endif
 }
 
 void Sensor::sendData() {
-#if ESP32
+#if ESP32 && SENSOR_THREADING
     Quat lquat;
     xSemaphoreTake(updateMutex, portMAX_DELAY);
     if (newFusedRotation) {
@@ -81,7 +81,7 @@ void Sensor::sendData() {
 #endif
 
 #if SEND_ACCELERATION
-    #if ESP32
+    #if ESP32 && SENSOR_THREADING
         Vector3 laccel;
         xSemaphoreTake(updateMutex, portMAX_DELAY);
         if (newAcceleration) {

--- a/src/sensors/sensor.h
+++ b/src/sensors/sensor.h
@@ -111,7 +111,7 @@ public:
     uint8_t sclPin = 0;
     uint8_t sdaPin = 0;
 
-    #if ESP32
+    #if ESP32 && SENSOR_THREADING
         SemaphoreHandle_t updateMutex = NULL;
     #endif
 private:

--- a/src/sensors/sensor.h
+++ b/src/sensors/sensor.h
@@ -111,6 +111,9 @@ public:
     uint8_t sclPin = 0;
     uint8_t sdaPin = 0;
 
+    #if ESP32
+        SemaphoreHandle_t updateMutex = NULL;
+    #endif
 private:
     void printTemperatureCalibrationUnsupported();
 };


### PR DESCRIPTION
This patch adds threading for ESP32 variants, allowing more sensors on a single ESP chip.
At current stage, threading mainly separates network packet building and networking stack from sensor operations.

Depending on #314