### PR TITLE
fshelper: fixed ESP8266 regression caused by abstracting FS access

### DIFF
--- a/src/FSHelper.cpp
+++ b/src/FSHelper.cpp
@@ -41,11 +41,6 @@ bool ensureDirectory(const char* directory) {
 	auto dir = LittleFS.open(directory);
 	auto isDirectory = dir.isDirectory();
 	dir.close();
-#else
-	auto dir = LittleFS.openDir(directory);
-	auto isDirectory = dir.isDirectory();
-#endif
-
 	if (!isDirectory) {
 		if (!LittleFS.remove(directory)) {
 			m_Logger.error("Failed to remove directory: %s", directory);
@@ -57,7 +52,7 @@ bool ensureDirectory(const char* directory) {
 			return false;
 		}
 	}
-
+#endif
 	return true;
 }
 


### PR DESCRIPTION
This is hotfixing ESP8266 calibration storage which seems to be broken since #319 

isDirectory method on Dir object doesn't tell about the Dir object itself, but about the entry pointed by internal pointer (which you can move using next() to iterate). As next() is never called, isDirectory will always return false (in fact, isFile too).
Considering heavy simplifications in Esp8266 filesystem regarding directories and the fact that previous ESP8266 implementation didn't try to do any file/directory fixing, I made it ESP32 only.