### PR TITLE
Fix enabling motion bias estimation

### DIFF
--- a/src/sensors/SensorFusion.h
+++ b/src/sensors/SensorFusion.h
@@ -44,7 +44,7 @@ namespace SlimeVR
         struct SensorVQFParams: VQFParams {
             SensorVQFParams() : VQFParams() {
                 #ifndef VQF_NO_MOTION_BIAS_ESTIMATION
-                motionBiasEstEnabled = false;
+                motionBiasEstEnabled = true;
                 #endif
                 tauAcc = 2.0f;
                 restMinT = 2.0f;


### PR DESCRIPTION
`motionBiasEstEnabled` should be `true` if `VQF_NO_MOTION_BIAS_ESTIMATION` isn't defined