### PR TITLE
 fshelper: fixed ESP8266 regression caused by abstracting FS access #321

### DIFF
--- a/src/FSHelper.cpp
+++ b/src/FSHelper.cpp
@@ -37,15 +37,9 @@ bool ensureDirectory(const char* directory) {
 		}
 	}
 
-#ifdef ESP32
-	auto dir = LittleFS.open(directory);
-	auto isDirectory = dir.isDirectory();
-	dir.close();
-#else
 	auto dir = LittleFS.open(directory, "r");
 	auto isDirectory = dir.isDirectory();
 	dir.close();
-#endif
 
 	if (!isDirectory) {
 		if (!LittleFS.remove(directory)) {

--- a/src/FSHelper.cpp
+++ b/src/FSHelper.cpp
@@ -42,8 +42,9 @@ bool ensureDirectory(const char* directory) {
 	auto isDirectory = dir.isDirectory();
 	dir.close();
 #else
-	auto dir = LittleFS.openDir(directory);
+	auto dir = LittleFS.open(directory, "r");
 	auto isDirectory = dir.isDirectory();
+	dir.close();
 #endif
 
 	if (!isDirectory) {


### PR DESCRIPTION
This is fixing ESP8266 calibration storage which seems to be broken since https://github.com/SlimeVR/SlimeVR-Tracker-ESP/pull/319

Use open to check if it is a directory or not as on ESP32.

As requested in comments in https://github.com/SlimeVR/SlimeVR-Tracker-ESP/pull/321