### PR TITLE
GET.INFO Serial Command Should Returns Battery Voltage & Level (in Percentages)

### DIFF
--- a/src/GlobalVars.h
+++ b/src/GlobalVars.h
@@ -32,6 +32,7 @@
 #include "network/manager.h"
 #include "sensors/SensorManager.h"
 #include "status/StatusManager.h"
+#include "batterymonitor.h"
 
 extern Timer<> globalTimer;
 extern SlimeVR::LEDManager ledManager;
@@ -40,5 +41,6 @@ extern SlimeVR::Configuration::Configuration configuration;
 extern SlimeVR::Sensors::SensorManager sensorManager;
 extern SlimeVR::Network::Manager networkManager;
 extern SlimeVR::Network::Connection networkConnection;
+extern BatteryMonitor battery;
 
 #endif

--- a/src/batterymonitor.h
+++ b/src/batterymonitor.h
@@ -72,6 +72,9 @@ public:
     void Setup();
     void Loop();
 
+    float getVoltage() const { return voltage; }
+    float getLevel() const { return level; }
+
 private:
     unsigned long last_battery_sample = 0;
 #if BATTERY_MONITOR == BAT_MCP3021 || BATTERY_MONITOR == BAT_INTERNAL_MCP3021
@@ -82,10 +85,6 @@ private:
 #endif
     float voltage = -1;
     float level = -1;
-
-public:
-    float getVoltage() const { return voltage; }
-    float getLevel() const { return level; }
 
     SlimeVR::Logging::Logger m_Logger = SlimeVR::Logging::Logger("BatteryMonitor");
 };

--- a/src/batterymonitor.h
+++ b/src/batterymonitor.h
@@ -83,6 +83,10 @@ private:
     float voltage = -1;
     float level = -1;
 
+public:
+    float getVoltage() const { return voltage; }
+    float getLevel() const { return level; }
+
     SlimeVR::Logging::Logger m_Logger = SlimeVR::Logging::Logger("BatteryMonitor");
 };
 

--- a/src/serial/serialcommands.cpp
+++ b/src/serial/serialcommands.cpp
@@ -144,6 +144,11 @@ namespace SerialCommands {
                 sensor->getHadData() ? "true" : "false"
             );
         }
+        logger.info(
+            "Battery voltage: %.3f, level: %.1f%%",
+            battery.getVoltage(),
+			battery.getLevel() * 100
+        );
     }
 
     void cmdGet(CmdParser * parser) {


### PR DESCRIPTION
This update modifies the `GET INFO` serial command to include battery voltage and battery level (displayed as a percentage).

This enhancement provides detailed battery status information in the serial output and was a big help when I was troubleshooting a connection issue with the battery sense wire.