### PR TITLE
Magnetometer support in sfusion

### DIFF
--- a/src/consts.h
+++ b/src/consts.h
@@ -63,6 +63,9 @@ enum class ImuID {
 #define IMU_LSM6DSR SoftFusionLSM6DSR
 #define IMU_MPU6050_SF SoftFusionMPU6050
 
+#define IMU_LSM6DSO_QMC SoftFusionLSM6DSO_QMC
+#define IMU_LSM6DSR_QMC SoftFusionLSM6DSR_QMC
+
 #define IMU_DEV_RESERVED 250 // Reserved, should not be used in any release firmware
 
 #define BOARD_UNKNOWN 0

--- a/src/sensors/SensorManager.cpp
+++ b/src/sensors/SensorManager.cpp
@@ -38,6 +38,7 @@
 #include "softfusion/drivers/lsm6dso.h"
 #include "softfusion/drivers/lsm6dsr.h"
 #include "softfusion/drivers/mpu6050.h"
+#include "softfusion/drivers/qmc5883l.h"
 
 #include "softfusion/i2cimpl.h"
 
@@ -56,6 +57,14 @@ namespace SlimeVR
         using SoftFusionLSM6DSO = SoftFusionSensor<SoftFusion::Drivers::LSM6DSO, SoftFusion::I2CImpl>;
         using SoftFusionLSM6DSR = SoftFusionSensor<SoftFusion::Drivers::LSM6DSR, SoftFusion::I2CImpl>;
         using SoftFusionMPU6050 = SoftFusionSensor<SoftFusion::Drivers::MPU6050, SoftFusion::I2CImpl>;
+
+        template <typename I2CImpl>
+        using _LSM6DSR_QMC = SoftFusion::Drivers::LSM6DSR<I2CImpl, SoftFusion::Drivers::QMC5883L>;
+        using SoftFusionLSM6DSR_QMC = SoftFusionSensor<_LSM6DSR_QMC, SoftFusion::I2CImpl>;
+
+        template <typename I2CImpl>
+        using _LSM6DSO_QMC = SoftFusion::Drivers::LSM6DSO<I2CImpl, SoftFusion::Drivers::QMC5883L>;
+        using SoftFusionLSM6DSO_QMC = SoftFusionSensor<_LSM6DSO_QMC, SoftFusion::I2CImpl>;
 
         // TODO Make it more generic in the future and move another place (abstract sensor interface)
         void SensorManager::swapI2C(uint8_t sclPin, uint8_t sdaPin)

--- a/src/sensors/SensorManager.h
+++ b/src/sensors/SensorManager.h
@@ -93,7 +93,7 @@ namespace SlimeVR
                     return sensor;
                 }
 
-                uint8_t intPin = extraParam;
+                int intPin = extraParam;
                 sensor = std::make_unique<ImuType>(sensorID, addrSuppl, rotation, sclPin, sdaPin, intPin);
 
                 sensor->motionSetup();

--- a/src/sensors/softfusion/drivers/bmi270.h
+++ b/src/sensors/softfusion/drivers/bmi270.h
@@ -370,8 +370,8 @@ struct BMI270
         return to_ret;
     }
 
-    template <typename AccelCall, typename GyroCall>
-    void bulkRead(AccelCall &&processAccelSample, GyroCall &&processGyroSample) {
+    template <typename AccelCall, typename GyroCall, typename MagCall>
+    void bulkRead(AccelCall &&processAccelSample, GyroCall &&processGyroSample, MagCall &&processMagSample) {
         const auto fifo_bytes = i2c.readReg16(Regs::FifoCount);
         
         const auto bytes_to_read = std::min(static_cast<size_t>(read_buffer.size()),

--- a/src/sensors/softfusion/drivers/icm42688.h
+++ b/src/sensors/softfusion/drivers/icm42688.h
@@ -140,8 +140,8 @@ struct ICM42688
         return result;
     }
 
-    template <typename AccelCall, typename GyroCall>
-    void bulkRead(AccelCall &&processAccelSample, GyroCall &&processGyroSample) {
+    template <typename AccelCall, typename GyroCall, typename MagCall>
+    void bulkRead(AccelCall &&processAccelSample, GyroCall &&processGyroSample, MagCall &&processMagSample) {
         const auto fifo_bytes = i2c.readReg16(Regs::FifoCount);
         
         std::array<uint8_t, FullFifoEntrySize * 8> read_buffer; // max 8 readings

--- a/src/sensors/softfusion/drivers/lsm6ds3trc.h
+++ b/src/sensors/softfusion/drivers/lsm6ds3trc.h
@@ -108,8 +108,8 @@ struct LSM6DS3TRC
         return result;
     }
 
-    template <typename AccelCall, typename GyroCall>
-    void bulkRead(AccelCall &&processAccelSample, GyroCall &&processGyroSample) {
+    template <typename AccelCall, typename GyroCall, typename MagCall>
+    void bulkRead(AccelCall &&processAccelSample, GyroCall &&processGyroSample, MagCall &&processMagSample) {
         const auto read_result = i2c.readReg16(Regs::FifoStatus);
         if (read_result & 0x4000) { // overrun!
             // disable and re-enable fifo to clear it

--- a/src/sensors/softfusion/drivers/lsm6dso.h
+++ b/src/sensors/softfusion/drivers/lsm6dso.h
@@ -28,6 +28,7 @@
 #include <algorithm>
 
 #include "lsm6ds-common.h"
+#include "../empty_mag.h"
 
 namespace SlimeVR::Sensors::SoftFusion::Drivers
 {
@@ -36,8 +37,8 @@ namespace SlimeVR::Sensors::SoftFusion::Drivers
 // and gyroscope range at 1000dps
 // Gyroscope ODR = 416Hz, accel ODR = 104Hz
 
-template <typename I2CImpl>
-struct LSM6DSO : LSM6DSOutputHandler<I2CImpl>
+template <typename I2CImpl, typename Mag = NoMag>
+struct LSM6DSO : LSM6DSOutputHandler<I2CImpl, Mag>
 {
     static constexpr uint8_t Address = 0x6a;
     static constexpr auto Name = "LSM6DSO";
@@ -54,7 +55,7 @@ struct LSM6DSO : LSM6DSOutputHandler<I2CImpl>
     static constexpr float GyroSensitivity = 1000 / 35.0f;
     static constexpr float AccelSensitivity = 1000 / 0.244f;
 
-    using LSM6DSOutputHandler<I2CImpl>::i2c;
+    using LSM6DSOutputHandler<I2CImpl, Mag>::i2c;
 
     struct Regs {
         struct WhoAmI {
@@ -89,7 +90,7 @@ struct LSM6DSO : LSM6DSOutputHandler<I2CImpl>
     };
 
     LSM6DSO(I2CImpl i2c, SlimeVR::Logging::Logger &logger)
-        : LSM6DSOutputHandler<I2CImpl>(i2c, logger) {
+        : LSM6DSOutputHandler<I2CImpl, Mag>(i2c, logger) {
     }
 
     bool initialize()
@@ -102,17 +103,21 @@ struct LSM6DSO : LSM6DSOutputHandler<I2CImpl>
         i2c.writeReg(Regs::Ctrl3C::reg, Regs::Ctrl3C::value);
         i2c.writeReg(Regs::FifoCtrl3BDR::reg, Regs::FifoCtrl3BDR::value);
         i2c.writeReg(Regs::FifoCtrl4Mode::reg, Regs::FifoCtrl4Mode::value);
+
+        LSM6DSOutputHandler<I2CImpl, Mag>::initializeMag();
         return true;
     }
 
     float getDirectTemp() const
     {
-        return LSM6DSOutputHandler<I2CImpl>::template getDirectTemp<Regs>();
+        return LSM6DSOutputHandler<I2CImpl, Mag>::template getDirectTemp<Regs>();
     }
 
-    template <typename AccelCall, typename GyroCall>
-    void bulkRead(AccelCall &&processAccelSample, GyroCall &&processGyroSample) {
-        LSM6DSOutputHandler<I2CImpl>::template bulkRead<AccelCall, GyroCall, Regs>(processAccelSample, processGyroSample, GyrTs, AccTs);
+    template <typename AccelCall, typename GyroCall, typename MagCall>
+    void bulkRead(AccelCall &&processAccelSample, GyroCall &&processGyroSample, MagCall &&processMagSample) {
+        LSM6DSOutputHandler<I2CImpl, Mag>::template bulkRead<AccelCall, GyroCall, MagCall, Regs>(
+            processAccelSample, processGyroSample, processMagSample, GyrTs, AccTs, MagTs
+        );
     }
 
 };

--- a/src/sensors/softfusion/drivers/lsm6dsr.h
+++ b/src/sensors/softfusion/drivers/lsm6dsr.h
@@ -28,6 +28,7 @@
 #include <algorithm>
 
 #include "lsm6ds-common.h"
+#include "../empty_mag.h"
 
 namespace SlimeVR::Sensors::SoftFusion::Drivers
 {
@@ -36,8 +37,8 @@ namespace SlimeVR::Sensors::SoftFusion::Drivers
 // and gyroscope range at 1000dps
 // Gyroscope ODR = 416Hz, accel ODR = 104Hz
 
-template <typename I2CImpl>
-struct LSM6DSR : LSM6DSOutputHandler<I2CImpl>
+template <typename I2CImpl, typename Mag = NoMag>
+struct LSM6DSR : LSM6DSOutputHandler<I2CImpl, Mag>
 {
     static constexpr uint8_t Address = 0x6a;
     static constexpr auto Name = "LSM6DSR";
@@ -45,7 +46,7 @@ struct LSM6DSR : LSM6DSOutputHandler<I2CImpl>
 
     static constexpr float GyrFreq = 416;
     static constexpr float AccFreq = 104;
-    static constexpr float MagFreq = 120;
+    static constexpr float MagFreq = 26;
 
     static constexpr float GyrTs=1.0/GyrFreq;
     static constexpr float AccTs=1.0/AccFreq;
@@ -54,7 +55,7 @@ struct LSM6DSR : LSM6DSOutputHandler<I2CImpl>
     static constexpr float GyroSensitivity = 1000 / 35.0f;
     static constexpr float AccelSensitivity = 1000 / 0.244f;
 
-    using LSM6DSOutputHandler<I2CImpl>::i2c;
+    using LSM6DSOutputHandler<I2CImpl, Mag>::i2c;
 
     struct Regs {
         struct WhoAmI {
@@ -89,7 +90,7 @@ struct LSM6DSR : LSM6DSOutputHandler<I2CImpl>
     };
 
     LSM6DSR(I2CImpl i2c, SlimeVR::Logging::Logger &logger)
-        : LSM6DSOutputHandler<I2CImpl>(i2c, logger) {
+        : LSM6DSOutputHandler<I2CImpl, Mag>(i2c, logger) {
     }
 
     bool initialize()
@@ -102,17 +103,21 @@ struct LSM6DSR : LSM6DSOutputHandler<I2CImpl>
         i2c.writeReg(Regs::Ctrl3C::reg, Regs::Ctrl3C::value);
         i2c.writeReg(Regs::FifoCtrl3BDR::reg, Regs::FifoCtrl3BDR::value);
         i2c.writeReg(Regs::FifoCtrl4Mode::reg, Regs::FifoCtrl4Mode::value);
+
+        LSM6DSOutputHandler<I2CImpl, Mag>::initializeMag();
         return true;
     }
 
     float getDirectTemp() const
     {
-        return LSM6DSOutputHandler<I2CImpl>::template getDirectTemp<Regs>();
+        return LSM6DSOutputHandler<I2CImpl, Mag>::template getDirectTemp<Regs>();
     }
 
-    template <typename AccelCall, typename GyroCall>
-    void bulkRead(AccelCall &&processAccelSample, GyroCall &&processGyroSample) {
-        LSM6DSOutputHandler<I2CImpl>::template bulkRead<AccelCall, GyroCall, Regs>(processAccelSample, processGyroSample, GyrTs, AccTs);
+    template <typename AccelCall, typename GyroCall, typename MagCall>
+    void bulkRead(AccelCall &&processAccelSample, GyroCall &&processGyroSample, MagCall &&processMagSample) {
+        LSM6DSOutputHandler<I2CImpl, Mag>::template bulkRead<AccelCall, GyroCall, MagCall, Regs>(
+            processAccelSample, processGyroSample, processMagSample, GyrTs, AccTs, MagTs
+        );
     }
 
 };

--- a/src/sensors/softfusion/drivers/mpu6050.h
+++ b/src/sensors/softfusion/drivers/mpu6050.h
@@ -141,8 +141,8 @@ struct MPU6050
         return result;
     }
 
-    template <typename AccelCall, typename GyroCall>
-    void bulkRead(AccelCall &&processAccelSample, GyroCall &&processGyroSample) {
+    template <typename AccelCall, typename GyroCall, typename MagCall>
+    void bulkRead(AccelCall &&processAccelSample, GyroCall &&processGyroSample, MagCall &&processMagSample) {
         const auto status = i2c.readReg(Regs::IntStatus);
 
         if (status & (1 << MPU6050_INTERRUPT_FIFO_OFLOW_BIT)) {

--- a/src/sensors/softfusion/drivers/qmc5883l.h
+++ b/src/sensors/softfusion/drivers/qmc5883l.h
@@ -25,6 +25,7 @@ struct QMC5883L {
 
     template <typename WriteRegCall>
     bool initialize(WriteRegCall&& writeReg) {
+        delay(2);
         writeReg(Address, Regs::Reset::reg, Regs::Reset::value);
         delay(5);
         writeReg(Address, Regs::Control::reg, Regs::Control::value);

--- a/src/sensors/softfusion/drivers/qmc5883l.h
+++ b/src/sensors/softfusion/drivers/qmc5883l.h
@@ -1,0 +1,48 @@
+#include <span>
+#include <stdint.h>
+
+namespace SlimeVR::Sensors::SoftFusion::Drivers
+{
+
+struct QMC5883L {
+    static constexpr uint8_t Address = 0x0D;
+
+    struct Regs {
+        static constexpr uint8_t Data = 0x00;   // 3 x 2 bytes
+        static constexpr uint8_t Status = 0x06; // 1 byte
+        static constexpr uint8_t Temp = 0x07;   // 2 bytes
+
+        struct Control {
+            static constexpr uint8_t reg = 0x09;
+            static constexpr uint8_t value = (0b00011101); // 512 oversampling rate / 8 Gauss range / 200Hz ODR / Continuous mode
+        };
+        struct Reset {
+            static constexpr uint8_t reg = 0x0B;
+            static constexpr uint8_t value = 1;
+        };
+        static constexpr uint8_t Reset = 0x0B;
+    };
+
+    template <typename WriteRegCall>
+    bool initialize(WriteRegCall&& writeReg) {
+        writeReg(Address, Regs::Reset::reg, Regs::Reset::value);
+        delay(5);
+        writeReg(Address, Regs::Control::reg, Regs::Control::value);
+        return true;
+    }
+
+    uint8_t getAddress() { return Address; }
+    uint8_t getStartReg() { return Regs::Data; }
+    uint8_t getReadCount() { return 6; }
+
+    template <typename MagCall>
+    void unpackSample(std::span<uint8_t> sample, MagCall&& processMagSample) {
+        auto x = (int16_t)((int)sample[0] | sample[1] << 8);
+        auto y = (int16_t)((int)sample[2] | sample[3] << 8);
+        auto z = (int16_t)((int)sample[4] | sample[5] << 8);
+        processMagSample(x, y, z);
+    }
+
+};
+
+}

--- a/src/sensors/softfusion/empty_mag.h
+++ b/src/sensors/softfusion/empty_mag.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <span>
+#include <stdint.h>
+
+namespace SlimeVR::Sensors::SoftFusion::Drivers
+{
+
+struct NoMag {
+    template <typename WriteRegCall>
+    bool initialize(WriteRegCall&& writeReg) {
+        return false;
+    }
+
+    uint8_t getAddress() { return 0; }
+    uint8_t getStartReg() { return 0; }
+    uint8_t getReadCount() { return 0; }
+
+    template <typename MagCall>
+    void unpackSample(std::span<uint8_t> sample, MagCall&& processMagSample) { }
+};
+
+}

--- a/src/sensors/softfusion/softfusionsensor.h
+++ b/src/sensors/softfusion/softfusionsensor.h
@@ -288,7 +288,7 @@ public:
                 gravity = static_cast<sensor_real_t>(AScale * static_cast<sensor_real_t>(lastRawSample[2]));
                 if (gravity > 7.5f) {
                     m_Logger.debug("Starting calibration...");
-                    startCalibration(5);
+                    startCalibration(0);
                 }
                 else {
                     m_Logger.info("Flip not detected. Skipping calibration.");


### PR DESCRIPTION
Added magnetometer support for sfusion sensors
Currently, only LSM6DSR with QMC5883L via sensor hub is supported (LSM6DSO might work, DSV probably won't since I didn't even look at the datasheet lol)

Sensors that support magnetometers receive a driver for it as a template argument. That driver is structured pretty much like a normal sfusion driver. Later I want to also add an option to pass it directly to `SoftFusionSensor` (for mags that are directly connected to the main I2C bus)

### TODO:
- ~~Add axis remapping~~
- Support mag driver passed directly to `SoftFusionSensor`
- Check the registers and test LSM6DSO/DSV
- Disable mag calibartion when there's no driver
- Fine-tune magnetic disturbance rejection in VQF
- Detecting errors when I2C writes to mag fail 