### PR TITLE
Change "PASS" to "PASSWD"

### DIFF
--- a/src/serial/serialcommands.cpp
+++ b/src/serial/serialcommands.cpp
@@ -250,7 +250,7 @@ namespace SerialCommands {
 				for (int i = 0; i < scanRes; i++) {
 					logger.info("[WSCAN] %d:\t%02d\t%s\t(%d)\t%s",
 						i, WiFi.SSID(i).length(), WiFi.SSID(i).c_str(), WiFi.RSSI(i),
-						((WiFi.encryptionType(i) == 0) ? "OPEN" : "PASS")
+						((WiFi.encryptionType(i) == 0) ? "OPEN" : "PASSWD")
 					);
 				}
 				WiFi.scanDelete();


### PR DESCRIPTION
People are confusing "PASS" with meaning that the WiFi passes something somehow, I think "PASSWD" should be more obvious, or maybe we should just say "PASSWORD"? We're not really limited on space here.