### PR TITLE
Add dependabot & update workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      # Check for updates to GitHub Actions every week
+      interval: "weekly"

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -13,8 +13,11 @@ jobs:
 
       - name: Set up Python
         uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: "pip"
 
-      - name: Install pio and its dependencies
+      - name: Install PlatformIO and its dependencies
         run: |
           python -m pip install --upgrade pip
           pip install platformio

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Install PlatformIO and its dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install platformio
+          pip install -r ./ci/requirements.txt
 
       - name: Run builds
         run: python ./ci/build.py

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -10,17 +10,22 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/pip
+            ~/.platformio/.cache
+          key: ${{ runner.os }}-pio
 
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
           python-version: "3.12"
-          cache: "pip"
 
       - name: Install PlatformIO and its dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r ./ci/requirements.txt
+          pip install --upgrade platformio
 
       - name: Run builds
         run: python ./ci/build.py

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -9,10 +9,10 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v5
 
       - name: Install pio and its dependencies
         run: |
@@ -23,7 +23,7 @@ jobs:
         run: python ./ci/build.py
 
       - name: Upload binaries
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: binaries
           path: ./build/*.bin

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,6 @@
 name: Releases
 
-on: 
+on:
   push:
     tags:
     - '*'
@@ -12,7 +12,7 @@ jobs:
     permissions:
       contents: write
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - uses: ncipollo/release-action@v1
       with:
         artifacts: "./build/*.bin"

--- a/ci/requirements.txt
+++ b/ci/requirements.txt
@@ -1,0 +1,1 @@
+platformio >= 6.1.15

--- a/ci/requirements.txt
+++ b/ci/requirements.txt
@@ -1,1 +1,0 @@
-platformio >= 6.1.15


### PR DESCRIPTION
GitHub Actions fails now because the versions are so old. This updates those and adds dependabot so it'll automatically update them. :3