### PR TITLE
Fix: Print SDA and SCL of I2CSCAN

### DIFF
--- a/lib/i2cscan/i2cscan.cpp
+++ b/lib/i2cscan/i2cscan.cpp
@@ -97,15 +97,15 @@ namespace I2CSCAN
 
             if (error == 0)
             {
-                Serial.printf("[DBG] I2C (@ %s(%d) : %s(%d)): I2C device found at address 0x%02x  !\n", 
-                                portMap[i].c_str(), portArray[i], portMap[j].c_str(), portArray[j], address);
+                Serial.printf("[DBG] I2C SDA(%2d)SCL(%2d): I2C device found at address 0x%02x  !\n", 
+                               portArray[i], portArray[j], address);
                 nDevices++;
                 found = true;
             }
             else if (error == 4)
             {
-                Serial.printf("[ERR] I2C (@ %s(%d) : %s(%d)): Unknown error at address 0x%02x\n",
-                                portMap[i].c_str(), portArray[i], portMap[j].c_str(), portArray[j], address);
+                Serial.printf("[ERR] I2C SDA(%2d)SCL(%2d): Unknown error at address 0x%02x\n",
+                                portArray[i], portArray[j], address);
             }
         }
         return found;


### PR DESCRIPTION
Print SDA and SCL of I2CSCAN for easy debugging of I2C