### PR TITLE
Enable caching to accelerate compilation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .vscode/*
 build/
 venv/
+cache/

--- a/platformio.ini
+++ b/platformio.ini
@@ -11,6 +11,9 @@
 ; https://docs.slimevr.dev/firmware/configuring-project.html#1-configuring-platformioini
 ; ================================================
 
+[platformio]
+build_cache_dir = cache
+
 [env]
 lib_deps=
   https://github.com/SlimeVR/CmdParser.git


### PR DESCRIPTION
This Pr utilizes PlatformIO's feature of enabling caching to speed up compilation, and each time the code is changed, only the changed part is compiled, which can greatly speed up development and verification.

Debug compilation time：
First time:
![First time](https://github.com/user-attachments/assets/265b2a8b-84e5-4b6a-b357-617b3c07b144)
After enabling caching:
![After enabling caching](https://github.com/user-attachments/assets/679e13b9-bf7a-4d1c-8fe0-e4b60ba7cdc5)

We can see that after enabling caching, except for the first time which takes a long time, subsequent compilations are very fast