### PR TITLE
[BMI270] Fix bug in data frame size calculation

### DIFF
--- a/src/sensors/softfusion/drivers/bmi270.h
+++ b/src/sensors/softfusion/drivers/bmi270.h
@@ -405,10 +405,11 @@ struct BMI270 {
 				}
 				getFromFifo<uint8_t>(i, read_buffer);  // skip 1 byte
 			} else if ((header & Fifo::ModeMask) == Fifo::DataFrame) {
-				const uint8_t required_length
-					= (((header & Fifo::GyrDataBit) >> Fifo::GyrDataBit)
-					   + ((header & Fifo::AccelDataBit) >> Fifo::AccelDataBit))
-					* 6;
+				uint8_t gyro_data_length
+					= (header & Fifo::GyrDataBit) == Fifo::GyrDataBit ? 6 : 0;
+				uint8_t accel_data_length
+					= (header & Fifo::AccelDataBit) == Fifo::AccelDataBit ? 6 : 0;
+				uint8_t required_length = gyro_data_length + accel_data_length;
 				if (i + required_length > bytes_to_read) {
 					// incomplete frame, will be re-read next time
 					break;

--- a/src/sensors/softfusion/drivers/bmi270.h
+++ b/src/sensors/softfusion/drivers/bmi270.h
@@ -405,10 +405,8 @@ struct BMI270 {
 				}
 				getFromFifo<uint8_t>(i, read_buffer);  // skip 1 byte
 			} else if ((header & Fifo::ModeMask) == Fifo::DataFrame) {
-				uint8_t gyro_data_length
-					= (header & Fifo::GyrDataBit) == Fifo::GyrDataBit ? 6 : 0;
-				uint8_t accel_data_length
-					= (header & Fifo::AccelDataBit) == Fifo::AccelDataBit ? 6 : 0;
+				uint8_t gyro_data_length = header & Fifo::GyrDataBit ? 6 : 0;
+				uint8_t accel_data_length = header & Fifo::AccelDataBit ? 6 : 0;
 				uint8_t required_length = gyro_data_length + accel_data_length;
 				if (i + required_length > bytes_to_read) {
 					// incomplete frame, will be re-read next time


### PR DESCRIPTION
Previously, required_length was always 0 because we shifting by a huge number, rather than the bit position. So the check for incomplete frames would never trigger. The final data frame in a FIFO read is sometimes an incomplete frame, and therefore we would read garbage for the data frame. There are often incomplete frames when we call LEDManager to blink the LED, because the FIFO overruns.

1. During gyroscope calibration, we often read random gyroscope samples, which throws off the calibration results.
2. During 6-sided accelerometer calibration, we often read random acceleration samples which causes rest detection to move on to collecting the next side, even if we don't move the tracker.
3. During normal operation, we will rarely read random gyroscope and accelerometer samples. These are usually one-offs and probably don't affect tracking.

This change fixes the bounds check so that we correctly identify incomplete frames and discard them.