### PR TITLE
[sfusion, BMI270] Perform gryo motionless calibration before gyro offset calibration

### DIFF
--- a/src/sensors/softfusion/drivers/bmi270.h
+++ b/src/sensors/softfusion/drivers/bmi270.h
@@ -363,6 +363,11 @@ struct BMI270 {
 			gyroSensitivity.z = crt_values[2];
 		}
 
+		// CRT seems to leave some state behind which isn't persisted after
+		// restart. If we continue without restarting, the gyroscope will behave
+		// differently on this run compared to subsequent restarts.
+		restartAndInit();
+
 		setNormalConfig(gyroSensitivity);
 	}
 

--- a/src/sensors/softfusion/softfusionsensor.h
+++ b/src/sensors/softfusion/softfusionsensor.h
@@ -320,7 +320,6 @@ public:
 		if (calibrationType == 0) {
 			// ALL
 			calibrateSampleRate();
-			calibrateGyroOffset();
 			if constexpr (HasMotionlessCalib) {
 				typename imu::MotionlessCalibrationData calibData;
 				m_sensor.motionlessCalibration(calibData);
@@ -330,6 +329,10 @@ public:
 					sizeof(calibData)
 				);
 			}
+			// Gryoscope offset calibration can only happen after any motionless
+			// gyroscope calibration, otherwise we are calculating the offset based
+			// on an incorrect starting point
+			calibrateGyroOffset();
 			calibrateAccel();
 		} else if (calibrationType == 1) {
 			calibrateSampleRate();


### PR DESCRIPTION
On a normal reset, we set the CRT (motionless) registers at startup, and then apply the calibrated gryo offset to every gyro sample.

Previously, we performed gyro offset calibration before CRT calibration. This means that we are actually calculating the gyro offset based on a CRT of 0, instead of the actual CRT.

This change performs CRT calibration before gyro calibration, so that the gryo offset is based on the actual CRT.

Cherry-picked from:
https://github.com/l0ud/SlimeVR-Tracker-ESP-BMI270/commit/2424b2ff08197c6b2d236714d8ca6de929c6bbe9
https://github.com/l0ud/SlimeVR-Tracker-ESP-BMI270/commit/cf349886c1e1bf562ea033df31ec04e52e83358f