### PR TITLE
Reverse IMU I2C address from supplement to full

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,13 @@
+# Global code owner
+* @Eirenliel
+
+# Make Loucas code owner of the defines to keep fw tool compatibility
+/src/defines.h @loucass003
+/src/consts.h @loucass003
+/src/debug.h @loucass003
+
+# Sfusion framework
+/src/sensors/softfusion/ @gorbit99 @l0ud
+/srs/sensors/SensorFusion* @gorbit99 @l0ud
+/srs/sensors/motionprocessing/ @gorbit99 @l0ud
+/lib/vqf/

--- a/src/consts.h
+++ b/src/consts.h
@@ -83,9 +83,9 @@ enum class ImuID {
 #define BOARD_MOCOPI 15  // Used by mocopi/moslime
 #define BOARD_WEMOSWROOM02 16
 #define BOARD_XIAO_ESP32C3 17
-#define BOARD_HARITORA 18 // Used by Haritora/SlimeTora
+#define BOARD_HARITORA 18  // Used by Haritora/SlimeTora
 #define BOARD_ES32C6DEVKITC1 19
-#define BOARD_DEV_RESERVED 250 // Reserved, should not be used in any release firmware
+#define BOARD_DEV_RESERVED 250  // Reserved, should not be used in any release firmware
 
 #define BAT_EXTERNAL 1
 #define BAT_INTERNAL 2

--- a/src/defines.h
+++ b/src/defines.h
@@ -35,6 +35,10 @@
 #define PRIMARY_IMU_OPTIONAL false
 #define SECONDARY_IMU_OPTIONAL true
 
+// Set I2C address here or directly in IMU_DESC_ENTRY for each IMU used
+#define PRIMARY_IMU_ADDRESS_ONE 0x4a
+#define SECONDARY_IMU_ADDRESS_TWO 0x4b
+
 #define MAX_IMU_COUNT 2
 
 // Axis mapping example

--- a/src/defines.h
+++ b/src/defines.h
@@ -36,8 +36,9 @@
 #define SECONDARY_IMU_OPTIONAL true
 
 // Set I2C address here or directly in IMU_DESC_ENTRY for each IMU used
-#define PRIMARY_IMU_ADDRESS_ONE 0x4a
-#define SECONDARY_IMU_ADDRESS_TWO 0x4b
+// If not set, default address is used based on the IMU and Sensor ID
+// #define PRIMARY_IMU_ADDRESS_ONE 0x4a
+// #define SECONDARY_IMU_ADDRESS_TWO 0x4b
 
 #define MAX_IMU_COUNT 2
 

--- a/src/sensors/SensorManager.cpp
+++ b/src/sensors/SensorManager.cpp
@@ -29,7 +29,6 @@
 #include "icm20948sensor.h"
 #include "mpu6050sensor.h"
 #include "mpu9250sensor.h"
-#include "sensoraddresses.h"
 #include "softfusion/drivers/bmi270.h"
 #include "softfusion/drivers/icm42688.h"
 #include "softfusion/drivers/lsm6ds3trc.h"

--- a/src/sensors/SensorManager.h
+++ b/src/sensors/SensorManager.h
@@ -20,9 +20,16 @@
 	OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 	THE SOFTWARE.
 */
-
 #ifndef SLIMEVR_SENSORMANAGER
 #define SLIMEVR_SENSORMANAGER
+
+#ifndef PRIMARY_IMU_ADDRESS_ONE
+#define PRIMARY_IMU_ADDRESS_ONE std::nullopt
+#endif
+
+#ifndef SECONDARY_IMU_ADDRESS_TWO
+#define SECONDARY_IMU_ADDRESS_TWO std::nullopt
+#endif
 
 #include <i2cscan.h>
 
@@ -61,13 +68,14 @@ private:
 	template <typename ImuType>
 	std::unique_ptr<Sensor> buildSensor(
 		uint8_t sensorID,
-		uint8_t i2cAddress,
+		std::optional<uint8_t> imuAddress,
 		float rotation,
 		uint8_t sclPin,
 		uint8_t sdaPin,
 		bool optional = false,
 		int extraParam = 0
 	) {
+		uint8_t i2cAddress = imuAddress.value_or(ImuType::Address + sensorID);
 		m_Logger.trace(
 			"Building IMU with: id=%d,\n\
                                 address=0x%02X, rotation=%f,\n\

--- a/src/sensors/SensorManager.h
+++ b/src/sensors/SensorManager.h
@@ -61,20 +61,19 @@ private:
 	template <typename ImuType>
 	std::unique_ptr<Sensor> buildSensor(
 		uint8_t sensorID,
-		uint8_t addrSuppl,
+		uint8_t i2cAddress,
 		float rotation,
 		uint8_t sclPin,
 		uint8_t sdaPin,
 		bool optional = false,
 		int extraParam = 0
 	) {
-		const uint8_t address = ImuType::Address + addrSuppl;
 		m_Logger.trace(
 			"Building IMU with: id=%d,\n\
                                 address=0x%02X, rotation=%f,\n\
                                 sclPin=%d, sdaPin=%d, extraParam=%d, optional=%d",
 			sensorID,
-			address,
+			i2cAddress,
 			rotation,
 			sclPin,
 			sdaPin,
@@ -89,21 +88,21 @@ private:
 		I2CSCAN::clearBus(sdaPin, sclPin);
 		swapI2C(sclPin, sdaPin);
 
-		if (I2CSCAN::hasDevOnBus(address)) {
-			m_Logger.trace("Sensor %d found at address 0x%02X", sensorID + 1, address);
+		if (I2CSCAN::hasDevOnBus(i2cAddress)) {
+			m_Logger.trace("Sensor %d found at address 0x%02X", sensorID + 1, i2cAddress);
 		} else {
 			if (!optional) {
 				m_Logger.error(
 					"Mandatory sensor %d not found at address 0x%02X",
 					sensorID + 1,
-					address
+					i2cAddress
 				);
 				sensor = std::make_unique<ErroneousSensor>(sensorID, ImuType::TypeID);
 			} else {
 				m_Logger.debug(
 					"Optional sensor %d not found at address 0x%02X",
 					sensorID + 1,
-					address
+					i2cAddress
 				);
 				sensor = std::make_unique<EmptySensor>(sensorID);
 			}
@@ -113,7 +112,7 @@ private:
 		uint8_t intPin = extraParam;
 		sensor = std::make_unique<ImuType>(
 			sensorID,
-			addrSuppl,
+			i2cAddress,
 			rotation,
 			sclPin,
 			sdaPin,

--- a/src/sensors/SensorManager.h
+++ b/src/sensors/SensorManager.h
@@ -89,7 +89,8 @@ private:
 		swapI2C(sclPin, sdaPin);
 
 		if (I2CSCAN::hasDevOnBus(i2cAddress)) {
-			m_Logger.trace("Sensor %d found at address 0x%02X", sensorID + 1, i2cAddress);
+			m_Logger
+				.trace("Sensor %d found at address 0x%02X", sensorID + 1, i2cAddress);
 		} else {
 			if (!optional) {
 				m_Logger.error(

--- a/src/sensors/SensorManager.h
+++ b/src/sensors/SensorManager.h
@@ -34,6 +34,7 @@
 #include <i2cscan.h>
 
 #include <memory>
+#include <optional>
 
 #include "EmptySensor.h"
 #include "ErroneousSensor.h"

--- a/src/sensors/bmi160sensor.h
+++ b/src/sensors/bmi160sensor.h
@@ -138,7 +138,7 @@ public:
 
 	BMI160Sensor(
 		uint8_t id,
-		uint8_t addrSuppl,
+		uint8_t i2cAddress,
 		float rotation,
 		uint8_t sclPin,
 		uint8_t sdaPin,
@@ -148,7 +148,7 @@ public:
 			"BMI160Sensor",
 			ImuID::BMI160,
 			id,
-			Address + addrSuppl,
+			i2cAddress,
 			rotation,
 			sclPin,
 			sdaPin

--- a/src/sensors/bno055sensor.h
+++ b/src/sensors/bno055sensor.h
@@ -35,7 +35,7 @@ public:
 
 	BNO055Sensor(
 		uint8_t id,
-		uint8_t addrSuppl,
+		uint8_t i2cAddress,
 		float rotation,
 		uint8_t sclPin,
 		uint8_t sdaPin,
@@ -45,7 +45,7 @@ public:
 			"BNO055Sensor",
 			ImuID::BNO055,
 			id,
-			Address + addrSuppl,
+			i2cAddress,
 			rotation,
 			sclPin,
 			sdaPin

--- a/src/sensors/bno080sensor.h
+++ b/src/sensors/bno080sensor.h
@@ -37,7 +37,7 @@ public:
 
 	BNO080Sensor(
 		uint8_t id,
-		uint8_t addrSuppl,
+		uint8_t i2cAddress,
 		float rotation,
 		uint8_t sclPin,
 		uint8_t sdaPin,
@@ -47,7 +47,7 @@ public:
 			"BNO080Sensor",
 			ImuID::BNO080,
 			id,
-			Address + addrSuppl,
+			i2cAddress,
 			rotation,
 			sclPin,
 			sdaPin
@@ -69,13 +69,13 @@ protected:
 		const char* sensorName,
 		ImuID imuId,
 		uint8_t id,
-		uint8_t addrSuppl,
+		uint8_t i2cAddress,
 		float rotation,
 		uint8_t sclPin,
 		uint8_t sdaPin,
 		uint8_t intPin
 	)
-		: Sensor(sensorName, imuId, id, Address + addrSuppl, rotation, sclPin, sdaPin)
+		: Sensor(sensorName, imuId, id, i2cAddress, rotation, sclPin, sdaPin)
 		, m_IntPin(intPin){};
 
 private:
@@ -102,7 +102,7 @@ public:
 	static constexpr auto TypeID = ImuID::BNO085;
 	BNO085Sensor(
 		uint8_t id,
-		uint8_t address,
+		uint8_t i2cAddress,
 		float rotation,
 		uint8_t sclPin,
 		uint8_t sdaPin,
@@ -112,7 +112,7 @@ public:
 			"BNO085Sensor",
 			ImuID::BNO085,
 			id,
-			address,
+			i2cAddress,
 			rotation,
 			sclPin,
 			sdaPin,
@@ -125,7 +125,7 @@ public:
 	static constexpr auto TypeID = ImuID::BNO086;
 	BNO086Sensor(
 		uint8_t id,
-		uint8_t address,
+		uint8_t i2cAddress,
 		float rotation,
 		uint8_t sclPin,
 		uint8_t sdaPin,
@@ -135,7 +135,7 @@ public:
 			"BNO086Sensor",
 			ImuID::BNO086,
 			id,
-			address,
+			i2cAddress,
 			rotation,
 			sclPin,
 			sdaPin,

--- a/src/sensors/icm20948sensor.h
+++ b/src/sensors/icm20948sensor.h
@@ -35,7 +35,7 @@ public:
 
 	ICM20948Sensor(
 		uint8_t id,
-		uint8_t addrSuppl,
+		uint8_t i2cAddress,
 		float rotation,
 		uint8_t sclPin,
 		uint8_t sdaPin,
@@ -45,7 +45,7 @@ public:
 			"ICM20948Sensor",
 			ImuID::ICM20948,
 			id,
-			Address + addrSuppl,
+			i2cAddress,
 			rotation,
 			sclPin,
 			sdaPin

--- a/src/sensors/mpu6050sensor.h
+++ b/src/sensors/mpu6050sensor.h
@@ -36,7 +36,7 @@ public:
 
 	MPU6050Sensor(
 		uint8_t id,
-		uint8_t addrSuppl,
+		uint8_t i2cAddress,
 		float rotation,
 		uint8_t sclPin,
 		uint8_t sdaPin,
@@ -46,7 +46,7 @@ public:
 			"MPU6050Sensor",
 			ImuID::MPU6050,
 			id,
-			Address + addrSuppl,
+			i2cAddress,
 			rotation,
 			sclPin,
 			sdaPin

--- a/src/sensors/mpu9250sensor.h
+++ b/src/sensors/mpu9250sensor.h
@@ -49,7 +49,7 @@ public:
 
 	MPU9250Sensor(
 		uint8_t id,
-		uint8_t addrSuppl,
+		uint8_t i2cAddress,
 		float rotation,
 		uint8_t sclPin,
 		uint8_t sdaPin,
@@ -59,7 +59,7 @@ public:
 			"MPU9250Sensor",
 			ImuID::MPU9250,
 			id,
-			Address + addrSuppl,
+			i2cAddress,
 			rotation,
 			sclPin,
 			sdaPin

--- a/src/sensors/sensoraddresses.h
+++ b/src/sensors/sensoraddresses.h
@@ -1,7 +1,0 @@
-// those variables are used as "supplement" to base IMU address coming directly from IMU
-// driver they are remaining to keep backward compatibility with old style of defines.h
-
-#define PRIMARY_IMU_ADDRESS_ONE 0
-#define PRIMARY_IMU_ADDRESS_TWO 1
-#define SECONDARY_IMU_ADDRESS_ONE 0
-#define SECONDARY_IMU_ADDRESS_TWO 1

--- a/src/sensors/softfusion/softfusionsensor.h
+++ b/src/sensors/softfusion/softfusionsensor.h
@@ -187,15 +187,7 @@ public:
 		uint8_t sdaPin,
 		uint8_t
 	)
-		: Sensor(
-			imu::Name,
-			imu::Type,
-			id,
-			i2cAddress,
-			rotation,
-			sclPin,
-			sdaPin
-		)
+		: Sensor(imu::Name, imu::Type, id, i2cAddress, rotation, sclPin, sdaPin)
 		, m_fusion(imu::GyrTs, imu::AccTs, imu::MagTs)
 		, m_sensor(I2CImpl(i2cAddress), m_Logger) {}
 	~SoftFusionSensor() {}

--- a/src/sensors/softfusion/softfusionsensor.h
+++ b/src/sensors/softfusion/softfusionsensor.h
@@ -181,7 +181,7 @@ public:
 
 	SoftFusionSensor(
 		uint8_t id,
-		uint8_t addrSuppl,
+		uint8_t i2cAddress,
 		float rotation,
 		uint8_t sclPin,
 		uint8_t sdaPin,
@@ -191,13 +191,13 @@ public:
 			imu::Name,
 			imu::Type,
 			id,
-			imu::Address + addrSuppl,
+			i2cAddress,
 			rotation,
 			sclPin,
 			sdaPin
 		)
 		, m_fusion(imu::GyrTs, imu::AccTs, imu::MagTs)
-		, m_sensor(I2CImpl(imu::Address + addrSuppl), m_Logger) {}
+		, m_sensor(I2CImpl(i2cAddress), m_Logger) {}
 	~SoftFusionSensor() {}
 
 	void motionLoop() override final {

--- a/src/serial/serialcommands.cpp
+++ b/src/serial/serialcommands.cpp
@@ -173,7 +173,7 @@ void printState() {
 }
 
 #if ESP32
-char* getEncryptionTypeName(wifi_auth_mode_t type) {
+String getEncryptionTypeName(wifi_auth_mode_t type) {
 	switch (type) {
 		case WIFI_AUTH_OPEN:
 			return "OPEN";
@@ -197,7 +197,7 @@ char* getEncryptionTypeName(wifi_auth_mode_t type) {
 			return "WPA3_ENT_192";
 	}
 #else
-char* getEncryptionTypeName(uint8_t type) {
+String getEncryptionTypeName(uint8_t type) {
 	switch (type) {
 		case ENC_TYPE_NONE:
 			return "OPEN";


### PR DESCRIPTION
Reverses IMU address change in defines.h introduced in #322.

The change is reversed for compatibility with web flasher, as well as for future expandability with use cases with more than 2 IMUs. Directly inputing the addresses give flexibility in case any address shifters are involved, or IMUs are wired in different configurations.