### PR TITLE
Report rest calibration

### DIFF
--- a/src/network/connection.cpp
+++ b/src/network/connection.cpp
@@ -297,6 +297,7 @@ void Connection::sendSensorInfo(Sensor& sensor) {
 	MUST(sendByte(static_cast<uint8_t>(sensor.getSensorState())));
 	MUST(sendByte(static_cast<uint8_t>(sensor.getSensorType())));
 	MUST(sendShort(sensor.getSensorConfigData()));
+	MUST(sendByte(sensor.completedRestCalibration()));
 
 	MUST(endPacket());
 }

--- a/src/network/connection.cpp
+++ b/src/network/connection.cpp
@@ -297,7 +297,7 @@ void Connection::sendSensorInfo(Sensor& sensor) {
 	MUST(sendByte(static_cast<uint8_t>(sensor.getSensorState())));
 	MUST(sendByte(static_cast<uint8_t>(sensor.getSensorType())));
 	MUST(sendShort(sensor.getSensorConfigData()));
-	MUST(sendByte(sensor.completedRestCalibration()));
+	MUST(sendByte(sensor.hasCompletedRestCalibration()));
 
 	MUST(endPacket());
 }
@@ -556,7 +556,7 @@ void Connection::maybeRequestFeatureFlags() {
 
 bool Connection::isSensorStateUpdated(int i, std::unique_ptr<Sensor>& sensor) {
 	return m_AckedSensorState[i] != sensor->getSensorState()
-		|| m_AckedSensorCalibration[i] != sensor->completedRestCalibration();
+		|| m_AckedSensorCalibration[i] != sensor->hasCompletedRestCalibration();
 }
 
 void Connection::searchForServer() {

--- a/src/network/connection.h
+++ b/src/network/connection.h
@@ -125,6 +125,7 @@ public:
 private:
 	void updateSensorState(std::vector<std::unique_ptr<Sensor>>& sensors);
 	void maybeRequestFeatureFlags();
+	bool isSensorStateUpdated(int i, std::unique_ptr<Sensor>& sensor);
 
 	bool beginPacket();
 	bool endPacket();
@@ -171,6 +172,7 @@ private:
 	unsigned long m_LastPacketTimestamp;
 
 	SensorStatus m_AckedSensorState[MAX_IMU_COUNT] = {SensorStatus::SENSOR_OFFLINE};
+	bool m_AckedSensorCalibration[MAX_IMU_COUNT] = {false};
 	unsigned long m_LastSensorInfoPacketTimestamp = 0;
 
 	uint8_t m_FeatureFlagsRequestAttempts = 0;

--- a/src/sensors/RestCalibrationDetector.cpp
+++ b/src/sensors/RestCalibrationDetector.cpp
@@ -1,0 +1,53 @@
+/*
+	SlimeVR Code is placed under the MIT license
+	Copyright (c) 2025 Gorbit99 & SlimeVR Contributors
+
+	Permission is hereby granted, free of charge, to any person obtaining a copy
+	of this software and associated documentation files (the "Software"), to deal
+	in the Software without restriction, including without limitation the rights
+	to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+	copies of the Software, and to permit persons to whom the Software is
+	furnished to do so, subject to the following conditions:
+
+	The above copyright notice and this permission notice shall be included in
+	all copies or substantial portions of the Software.
+
+	THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+	IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+	FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+	AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+	LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+	OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+	THE SOFTWARE.
+*/
+
+#include "RestCalibrationDetector.h"
+
+namespace SlimeVR::Sensors {
+
+bool RestCalibrationDetector::update(SensorFusionRestDetect& fusion) {
+	if (state == CalibrationState::Done) {
+		return false;
+	}
+
+	if (!fusion.getRestDetected()) {
+		state = CalibrationState::NoRest;
+		return false;
+	}
+
+	if (state == CalibrationState::NoRest) {
+		state = CalibrationState::Calibrating;
+		lastRestStartedMillis = millis();
+		return false;
+	}
+
+	uint32_t elapsed = millis() - lastRestStartedMillis;
+	if (elapsed < static_cast<uint32_t>(restCalibrationSeconds * 1e3)) {
+		return false;
+	}
+
+	state = CalibrationState::Done;
+	return true;
+}
+
+}  // namespace SlimeVR::Sensors

--- a/src/sensors/RestCalibrationDetector.h
+++ b/src/sensors/RestCalibrationDetector.h
@@ -1,0 +1,49 @@
+/*
+	SlimeVR Code is placed under the MIT license
+	Copyright (c) 2025 Gorbit99 & SlimeVR Contributors
+
+	Permission is hereby granted, free of charge, to any person obtaining a copy
+	of this software and associated documentation files (the "Software"), to deal
+	in the Software without restriction, including without limitation the rights
+	to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+	copies of the Software, and to permit persons to whom the Software is
+	furnished to do so, subject to the following conditions:
+
+	The above copyright notice and this permission notice shall be included in
+	all copies or substantial portions of the Software.
+
+	THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+	IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+	FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+	AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+	LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+	OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+	THE SOFTWARE.
+*/
+
+#pragma once
+
+#include <cstdint>
+
+#include "SensorFusionRestDetect.h"
+
+namespace SlimeVR::Sensors {
+
+class RestCalibrationDetector {
+public:
+	bool update(SensorFusionRestDetect& fusion);
+
+private:
+	static constexpr float restCalibrationSeconds = 3.0f;
+
+	enum class CalibrationState {
+		NoRest,
+		Calibrating,
+		Done,
+	};
+
+	CalibrationState state = CalibrationState::NoRest;
+	uint32_t lastRestStartedMillis = 0;
+};
+
+}  // namespace SlimeVR::Sensors

--- a/src/sensors/bmi160sensor.cpp
+++ b/src/sensors/bmi160sensor.cpp
@@ -307,6 +307,10 @@ void BMI160Sensor::motionLoop() {
 	}
 #endif
 
+	if (calibrationDetector.update(sfusion)) {
+		markRestCalibrationComplete();
+	}
+
 	{
 		uint32_t now = micros();
 		constexpr uint32_t BMI160_TARGET_SYNC_INTERVAL_MICROS = 25000;

--- a/src/sensors/bmi160sensor.h
+++ b/src/sensors/bmi160sensor.h
@@ -29,6 +29,7 @@
 #include "../motionprocessing/GyroTemperatureCalibrator.h"
 #include "../motionprocessing/RestDetection.h"
 #include "../motionprocessing/types.h"
+#include "RestCalibrationDetector.h"
 #include "SensorFusionRestDetect.h"
 #include "magneto1.4.h"
 #include "sensor.h"
@@ -265,6 +266,8 @@ private:
 	bool isMagCalibrated = false;
 
 	SlimeVR::Configuration::BMI160SensorConfig m_Config = {};
+
+	SlimeVR::Sensors::RestCalibrationDetector calibrationDetector;
 };
 
 #endif

--- a/src/sensors/bno055sensor.cpp
+++ b/src/sensors/bno055sensor.cpp
@@ -22,6 +22,8 @@
 */
 #include "bno055sensor.h"
 
+#include <cstdint>
+
 #include "GlobalVars.h"
 #include "globals.h"
 
@@ -67,6 +69,12 @@ void BNO055Sensor::motionLoop() {
 		);
 	}
 #endif
+
+	uint8_t gyroCalibrationState;
+	imu.getCalibration(nullptr, &gyroCalibrationState, nullptr, nullptr);
+	if (gyroCalibrationState == 3) {
+		markRestCalibrationComplete();
+	}
 
 	// TODO Optimize a bit with setting rawQuat directly
 	setFusedRotation(imu.getQuat());

--- a/src/sensors/bno080sensor.cpp
+++ b/src/sensors/bno080sensor.cpp
@@ -97,6 +97,8 @@ void BNO080Sensor::motionSetup() {
 	imu.enableRawMagnetometer(10);
 #endif
 
+	imu.enableStabilityClassifier(500);
+
 	lastReset = 0;
 	lastData = millis();
 	working = true;
@@ -237,6 +239,10 @@ void BNO080Sensor::motionLoop() {
 			lastError.error_module,
 			lastError.error_code
 		);
+	}
+
+	if (imu.getStabilityClassifier() == 1) {
+		markRestCalibrationComplete();
 	}
 }
 

--- a/src/sensors/sensor.cpp
+++ b/src/sensors/sensor.cpp
@@ -139,8 +139,6 @@ const char* getIMUNameByType(ImuID imuType) {
 	return "Unknown";
 }
 
-bool Sensor::completedRestCalibration() { return restCalibrationComplete; }
-
 void Sensor::markRestCalibrationComplete(bool completed) {
 	restCalibrationComplete = completed;
 }

--- a/src/sensors/sensor.cpp
+++ b/src/sensors/sensor.cpp
@@ -140,5 +140,7 @@ const char* getIMUNameByType(ImuID imuType) {
 }
 
 void Sensor::markRestCalibrationComplete(bool completed) {
+	if(restCalibrationComplete != completed)
+		m_Logger.info("Rest calibration completed");
 	restCalibrationComplete = completed;
 }

--- a/src/sensors/sensor.cpp
+++ b/src/sensors/sensor.cpp
@@ -138,3 +138,9 @@ const char* getIMUNameByType(ImuID imuType) {
 	}
 	return "Unknown";
 }
+
+bool Sensor::completedRestCalibration() { return restCalibrationComplete; }
+
+void Sensor::markRestCalibrationComplete(bool completed) {
+	restCalibrationComplete = completed;
+}

--- a/src/sensors/sensor.h
+++ b/src/sensors/sensor.h
@@ -96,7 +96,7 @@ public:
 	const Vector3& getAcceleration() { return acceleration; };
 	const Quat& getFusedRotation() { return fusedRotation; };
 	bool hasNewDataToSend() { return newFusedRotation || newAcceleration; };
-	bool completedRestCalibration();
+	inline bool hasCompletedRestCalibration() { return restCalibrationComplete; }
 
 protected:
 	uint8_t addr = 0;

--- a/src/sensors/sensor.h
+++ b/src/sensors/sensor.h
@@ -96,6 +96,7 @@ public:
 	const Vector3& getAcceleration() { return acceleration; };
 	const Quat& getFusedRotation() { return fusedRotation; };
 	bool hasNewDataToSend() { return newFusedRotation || newAcceleration; };
+	bool completedRestCalibration();
 
 protected:
 	uint8_t addr = 0;
@@ -114,6 +115,8 @@ protected:
 	bool newAcceleration = false;
 	Vector3 acceleration{};
 
+	void markRestCalibrationComplete(bool completed = true);
+
 	mutable SlimeVR::Logging::Logger m_Logger;
 
 public:
@@ -122,6 +125,8 @@ public:
 
 private:
 	void printTemperatureCalibrationUnsupported();
+
+	bool restCalibrationComplete;
 };
 
 const char* getIMUNameByType(ImuID imuType);

--- a/src/sensors/softfusion/softfusionsensor.h
+++ b/src/sensors/softfusion/softfusionsensor.h
@@ -23,6 +23,7 @@
 
 #pragma once
 
+#include "../RestCalibrationDetector.h"
 #include "../SensorFusionRestDetect.h"
 #include "../sensor.h"
 #include "GlobalVars.h"
@@ -235,6 +236,10 @@ public:
 			setFusedRotation(m_fusion.getQuaternionQuat());
 			setAcceleration(m_fusion.getLinearAccVec());
 			optimistic_yield(100);
+		}
+
+		if (calibrationDetector.update(m_fusion)) {
+			markRestCalibrationComplete();
 		}
 	}
 
@@ -617,6 +622,8 @@ public:
 	uint32_t m_lastPollTime = micros();
 	uint32_t m_lastRotationPacketSent = 0;
 	uint32_t m_lastTemperaturePacketSent = 0;
+
+	RestCalibrationDetector calibrationDetector;
 };
 
 }  // namespace SlimeVR::Sensors


### PR DESCRIPTION
Adds rest calibration detection to the sensors, where it's possible to fetch this information in some shape or form, and includes it in the sensor info packet.

Solves #383 