### PR TITLE
Ignore rest calibration ack if packet is too short

### DIFF
--- a/src/network/connection.cpp
+++ b/src/network/connection.cpp
@@ -749,6 +749,11 @@ void Connection::update() {
 			for (int i = 0; i < (int)sensors.size(); i++) {
 				if (m_Packet[4] == sensors[i]->getSensorId()) {
 					m_AckedSensorState[i] = (SensorStatus)m_Packet[5];
+					if (len < 10) {
+						m_AckedSensorCalibration[i]
+							= sensors[i]->hasCompletedRestCalibration();
+						break;
+					}
 					m_AckedSensorCalibration[i] = (bool)m_Packet[9];
 					break;
 				}

--- a/src/network/connection.cpp
+++ b/src/network/connection.cpp
@@ -749,12 +749,12 @@ void Connection::update() {
 			for (int i = 0; i < (int)sensors.size(); i++) {
 				if (m_Packet[4] == sensors[i]->getSensorId()) {
 					m_AckedSensorState[i] = (SensorStatus)m_Packet[5];
-					if (len < 10) {
+					if (len < 12) {
 						m_AckedSensorCalibration[i]
 							= sensors[i]->hasCompletedRestCalibration();
 						break;
 					}
-					m_AckedSensorCalibration[i] = (bool)m_Packet[9];
+					m_AckedSensorCalibration[i] = (bool)m_Packet[11];
 					break;
 				}
 			}

--- a/src/sensors/sensor.h
+++ b/src/sensors/sensor.h
@@ -141,7 +141,7 @@ protected:
 private:
 	void printTemperatureCalibrationUnsupported();
 
-	bool restCalibrationComplete;
+	bool restCalibrationComplete = false;
 };
 
 const char* getIMUNameByType(SensorTypeID imuType);


### PR DESCRIPTION
Sensor rest calibration ack needs to support old server versions, this PR checks the packet length first, acks by default if not returned, and fixes the packet ack byte index. Also C++ does not initialize the boolean to false, so this sets it to false by default.

Fixes #388.