### PR TITLE
Small fixes

### DIFF
--- a/src/sensorinterface/I2CWireSensorInterface.cpp
+++ b/src/sensorinterface/I2CWireSensorInterface.cpp
@@ -23,12 +23,14 @@
 
 #include "I2CWireSensorInterface.h"
 
+#include <optional>
+
 #if ESP32
 #include "driver/i2c.h"
 #endif
 
-uint8_t activeSCLPin;
-uint8_t activeSDAPin;
+std::optional<uint8_t> activeSCLPin;
+std::optional<uint8_t> activeSDAPin;
 bool isI2CActive = false;
 
 namespace SlimeVR {
@@ -40,9 +42,12 @@ void swapI2C(uint8_t sclPin, uint8_t sdaPin) {
 			// Reset HWI2C to avoid being affected by I2CBUS reset
 			Wire.end();
 		}
-		// Disconnect pins from HWI2C
-		gpio_set_direction((gpio_num_t)activeSCLPin, GPIO_MODE_INPUT);
-		gpio_set_direction((gpio_num_t)activeSDAPin, GPIO_MODE_INPUT);
+
+		if (activeSCLPin && activeSCLPin) {
+			// Disconnect pins from HWI2C
+			gpio_set_direction((gpio_num_t)activeSCLPin, GPIO_MODE_INPUT);
+			gpio_set_direction((gpio_num_t)activeSDAPin, GPIO_MODE_INPUT);
+		}
 
 		if (isI2CActive) {
 			i2c_set_pin(I2C_NUM_0, sdaPin, sclPin, false, false, I2C_MODE_MASTER);

--- a/src/sensorinterface/I2CWireSensorInterface.cpp
+++ b/src/sensorinterface/I2CWireSensorInterface.cpp
@@ -45,8 +45,8 @@ void swapI2C(uint8_t sclPin, uint8_t sdaPin) {
 
 		if (activeSCLPin && activeSCLPin) {
 			// Disconnect pins from HWI2C
-			gpio_set_direction((gpio_num_t)activeSCLPin, GPIO_MODE_INPUT);
-			gpio_set_direction((gpio_num_t)activeSDAPin, GPIO_MODE_INPUT);
+			gpio_set_direction((gpio_num_t)*activeSCLPin, GPIO_MODE_INPUT);
+			gpio_set_direction((gpio_num_t)*activeSDAPin, GPIO_MODE_INPUT);
 		}
 
 		if (isI2CActive) {

--- a/src/sensors/softfusion/softfusionsensor.h
+++ b/src/sensors/softfusion/softfusionsensor.h
@@ -241,8 +241,6 @@ public:
 	void motionLoop() final {
 		calibrator.tick();
 
-		calibrator.tick();
-
 		// read fifo updating fusion
 		uint32_t now = micros();
 
@@ -404,8 +402,7 @@ public:
 		m_Logger,
 		getDefaultTempTs(),
 		AScale,
-		GScale
-	};
+		GScale};
 
 	SensorStatus m_status = SensorStatus::SENSOR_OFFLINE;
 	uint32_t m_lastPollTime = micros();

--- a/src/sensors/softfusion/softfusionsensor.h
+++ b/src/sensors/softfusion/softfusionsensor.h
@@ -402,7 +402,8 @@ public:
 		m_Logger,
 		getDefaultTempTs(),
 		AScale,
-		GScale};
+		GScale
+	};
 
 	SensorStatus m_status = SensorStatus::SENSOR_OFFLINE;
 	uint32_t m_lastPollTime = micros();


### PR DESCRIPTION
A couple of small issues left over from the runtime calibration merge.

The gpio_set_direction lines were originally called on a zero initialized value, which meant that pin 0 was always set to input.

Ticking calibrator twice probably doesn't cause huge issues, but I removed the second call just in case.