### PR TITLE
Re-order SensorInfo packet

### DIFF
--- a/src/network/connection.cpp
+++ b/src/network/connection.cpp
@@ -297,9 +297,9 @@ void Connection::sendSensorInfo(Sensor& sensor) {
 	MUST(sendByte(static_cast<uint8_t>(sensor.getSensorState())));
 	MUST(sendByte(static_cast<uint8_t>(sensor.getSensorType())));
 	MUST(sendShort(sensor.getSensorConfigData()));
+	MUST(sendByte(sensor.hasCompletedRestCalibration()));
 	MUST(sendByte(static_cast<uint8_t>(sensor.getSensorPosition())));
 	MUST(sendByte(static_cast<uint8_t>(sensor.getDataType())));
-	MUST(sendByte(sensor.hasCompletedRestCalibration()));
 	// ADD NEW FILEDS ABOVE THIS COMMENT ^^^^^^^^
 	// WARNING! Only for debug purposes and SHOULD ALWAYS BE LAST IN THE PACKET.
 	// It WILL BE REMOVED IN THE FUTURE


### PR DESCRIPTION
This PR is to go with https://github.com/SlimeVR/SlimeVR-Server/pull/1317

From firmware v0.5.3 to v0.5.4, the SensorInfo packet has the rest calibration byte before the default position and data type, we should probably retain compatibility with the already released firmware and follow that packet order, otherwise we will be introducing some version-specific issues.