### PR TITLE
fix IMU Address missing in VS-Studio

### DIFF
--- a/src/sensors/SensorManager.cpp
+++ b/src/sensors/SensorManager.cpp
@@ -25,7 +25,7 @@
 
 #include <map>
 #include <type_traits>
-
+#include "sensoraddresses.h"
 #include "bmi160sensor.h"
 #include "bno055sensor.h"
 #include "bno080sensor.h"

--- a/src/sensors/SensorManager.cpp
+++ b/src/sensors/SensorManager.cpp
@@ -153,10 +153,8 @@ void SensorManager::setup() {
 	// Apply descriptor list and expand to entries
 	SENSOR_DESC_LIST;
 
-#define SENSOR_INFO_ENTRY(ImuID, ...)                        \
-	{                                                        \
-		m_Sensors[SensorTypeID]->setSensorInfo(__VA_ARGS__); \
-	}
+#define SENSOR_INFO_ENTRY(ImuID, ...) \
+	{ m_Sensors[SensorTypeID]->setSensorInfo(__VA_ARGS__); }
 	SENSOR_INFO_LIST;
 
 #undef SENSOR_DESC_ENTRY

--- a/src/sensors/SensorManager.cpp
+++ b/src/sensors/SensorManager.cpp
@@ -25,13 +25,14 @@
 
 #include <map>
 #include <type_traits>
-#include "sensoraddresses.h"
+
 #include "bmi160sensor.h"
 #include "bno055sensor.h"
 #include "bno080sensor.h"
 #include "icm20948sensor.h"
 #include "mpu6050sensor.h"
 #include "mpu9250sensor.h"
+#include "sensoraddresses.h"
 #include "sensorinterface/I2CPCAInterface.h"
 #include "sensorinterface/MCP23X17PinInterface.h"
 #include "sensors/softfusion/SoftfusionCalibration.h"
@@ -152,8 +153,10 @@ void SensorManager::setup() {
 	// Apply descriptor list and expand to entries
 	SENSOR_DESC_LIST;
 
-#define SENSOR_INFO_ENTRY(ImuID, ...) \
-	{ m_Sensors[SensorTypeID]->setSensorInfo(__VA_ARGS__); }
+#define SENSOR_INFO_ENTRY(ImuID, ...)                        \
+	{                                                        \
+		m_Sensors[SensorTypeID]->setSensorInfo(__VA_ARGS__); \
+	}
 	SENSOR_INFO_LIST;
 
 #undef SENSOR_DESC_ENTRY

--- a/src/sensors/sensoraddresses.h
+++ b/src/sensors/sensoraddresses.h
@@ -1,0 +1,62 @@
+// This is useful if you want to use an address shifter
+#ifndef DEFAULT_IMU_ADDRESS
+#define DEFAULT_IMU_ADDRESS true
+#endif  // DEFAULT_IMU_ADDRESS
+
+// We use fixed address values instead of scanning to keep the sensorID consistent and
+// to avoid issues with some breakout board with multiple active ic2 addresses
+#if DEFAULT_IMU_ADDRESS
+
+#ifndef PRIMARY_IMU_ADDRESS_ONE
+#if IMU == IMU_BNO080 || IMU == IMU_BNO085 || IMU == IMU_BNO086
+#define PRIMARY_IMU_ADDRESS_ONE 0x4A
+#elif IMU == IMU_BNO055
+#define PRIMARY_IMU_ADDRESS_ONE 0x29
+#elif IMU == IMU_MPU9250 || IMU == IMU_BMI160 || IMU == IMU_MPU6500 \
+	|| IMU == IMU_MPU6050 || IMU == IMU_ICM20948 || IMU == IMU_ICM42688
+#define PRIMARY_IMU_ADDRESS_ONE 0x68
+#endif
+#endif
+
+#ifndef PRIMARY_IMU_ADDRESS_TWO
+#if IMU == IMU_BNO080 || IMU == IMU_BNO085 || IMU == IMU_BNO086
+#define PRIMARY_IMU_ADDRESS_TWO 0x4B
+#elif IMU == IMU_BNO055
+#define PRIMARY_IMU_ADDRESS_TWO 0x28
+#elif IMU == IMU_MPU9250 || IMU == IMU_BMI160 || IMU == IMU_MPU6500 \
+	|| IMU == IMU_MPU6050 || IMU == IMU_ICM20948 || IMU == IMU_ICM42688
+#define PRIMARY_IMU_ADDRESS_TWO 0x69
+#endif
+#endif
+
+#ifndef SECONDARY_IMU_ADDRESS_ONE
+#if SECOND_IMU == IMU_BNO080 || SECOND_IMU == IMU_BNO085 || SECOND_IMU == IMU_BNO086
+#define SECONDARY_IMU_ADDRESS_ONE 0x4A
+#elif SECOND_IMU == IMU_BNO055
+#define SECONDARY_IMU_ADDRESS_ONE 0x29
+#elif SECOND_IMU == IMU_MPU9250 || SECOND_IMU == IMU_BMI160   \
+	|| SECOND_IMU == IMU_MPU6500 || SECOND_IMU == IMU_MPU6050 \
+	|| SECOND_IMU == IMU_ICM20948 || SECOND_IMU == IMU_ICM42688
+#define SECONDARY_IMU_ADDRESS_ONE 0x68
+#endif
+#endif
+
+#ifndef SECONDARY_IMU_ADDRESS_TWO
+#if SECOND_IMU == IMU_BNO080 || SECOND_IMU == IMU_BNO085 || SECOND_IMU == IMU_BNO086
+#define SECONDARY_IMU_ADDRESS_TWO 0x4B
+#elif SECOND_IMU == IMU_BNO055
+#define SECONDARY_IMU_ADDRESS_TWO 0x28
+#elif SECOND_IMU == IMU_MPU9250 || SECOND_IMU == IMU_BMI160   \
+	|| SECOND_IMU == IMU_MPU6500 || SECOND_IMU == IMU_MPU6050 \
+	|| SECOND_IMU == IMU_ICM20948 || SECOND_IMU == IMU_ICM42688
+#define SECONDARY_IMU_ADDRESS_TWO 0x69
+#endif
+#endif
+
+#else
+// If not using the default address you can set custom addresses here
+#define PRIMARY_IMU_ADDRESS_ONE 0x69
+#define PRIMARY_IMU_ADDRESS_TWO 0x68
+#define SECONDARY_IMU_ADDRESS_ONE 0x69
+#define SECONDARY_IMU_ADDRESS_TWO 0x68
+#endif


### PR DESCRIPTION
On Webflasher it does not build with swapped IMU-Address. On Visual Studio Code it is no longer easy to define IMU without changing manual addresses. This should fix both issues, and still allow the new flasher to work

Problem introduced by PR #372 