### PR TITLE
ICM45*: Process accel sample LSB correctly

### DIFF
--- a/src/sensors/softfusion/drivers/icm45base.h
+++ b/src/sensors/softfusion/drivers/icm45base.h
@@ -168,11 +168,11 @@ struct ICM45Base {
 			if (entry.accel[0] != -32768) {
 				const int32_t accelData[3]{
 					static_cast<int32_t>(entry.accel[0]) << 4
-						| (static_cast<int32_t>(entry.lsb[0]) & 0xf0 >> 4),
+						| (static_cast<int32_t>((entry.lsb[0]) & 0xf0) >> 4),
 					static_cast<int32_t>(entry.accel[1]) << 4
-						| (static_cast<int32_t>(entry.lsb[1]) & 0xf0 >> 4),
+						| (static_cast<int32_t>((entry.lsb[1]) & 0xf0) >> 4),
 					static_cast<int32_t>(entry.accel[2]) << 4
-						| (static_cast<int32_t>(entry.lsb[2]) & 0xf0 >> 4),
+						| (static_cast<int32_t>((entry.lsb[2]) & 0xf0) >> 4),
 				};
 				processAccelSample(accelData, AccTs);
 			}


### PR DESCRIPTION
we were using the 4 lowest gyro bits for the LSB bits of the accel, instead of the 4 lowest accel bits lol oopsie