### PR TITLE
Refactor network packets into structs

### DIFF
--- a/src/consts.h
+++ b/src/consts.h
@@ -25,7 +25,8 @@
 
 // List of constants used in other places
 
-enum class SensorTypeID {
+#include <cstdint>
+enum class SensorTypeID : uint8_t {
 	Unknown = 0,
 	MPU9250,
 	MPU6500,

--- a/src/network/connection.cpp
+++ b/src/network/connection.cpp
@@ -367,8 +367,9 @@ void Connection::sendTrackerDiscovery() {
 			MUST_TRANSFER_BOOL(sendShortString(FIRMWARE_VERSION));
 			// MAC address string
 			MUST_TRANSFER_BOOL(sendBytes(mac, 6));
-			MUST_TRANSFER_BOOL(sendByte(static_cast<uint8_t>(TRACKER_TYPE))
-			);  // Tracker type to hint the server if it's a glove or
+			// Tracker type to hint the server if it's a glove or normal tracker or
+			// something else
+			MUST_TRANSFER_BOOL(sendByte(static_cast<uint8_t>(TRACKER_TYPE)));
 			return true;
 		},
 		0

--- a/src/network/connection.cpp
+++ b/src/network/connection.cpp
@@ -359,6 +359,7 @@ void Connection::sendTrackerDiscovery() {
 			MUST_TRANSFER_BOOL(sendInt(static_cast<int>(sensorManager.getSensorType(0)))
 			);
 			MUST_TRANSFER_BOOL(sendInt(HARDWARE_MCU));
+			// Backwards compatibility, unused IMU data
 			MUST_TRANSFER_BOOL(sendInt(0));
 			MUST_TRANSFER_BOOL(sendInt(0));
 			MUST_TRANSFER_BOOL(sendInt(0));

--- a/src/network/connection.cpp
+++ b/src/network/connection.cpp
@@ -210,14 +210,6 @@ int Connection::getWriteError() { return m_UDP.getWriteError(); }
 // PACKET_HEARTBEAT 0
 void Connection::sendHeartbeat() {
 	sendPacketCallback(SendPacketType::HeartBeat, []() { return true; });
-	MUST(m_Connected);
-
-	MUST(beginPacket());
-
-	MUST(sendPacketType(SendPacketType::HeartBeat));
-	MUST(sendPacketNumber());
-
-	MUST(endPacket());
 }
 
 // PACKET_ACCEL 4

--- a/src/network/connection.cpp
+++ b/src/network/connection.cpp
@@ -32,7 +32,8 @@
 template <typename T>
 uint8_t* convert_to_chars(T src, uint8_t* target) {
 	auto* rawBytes = reinterpret_cast<uint8_t*>(&src);
-	std::reverse(rawBytes, rawBytes + sizeof(T));
+	std::memcpy(target, rawBytes, sizeof(T));
+	std::reverse(target, target + sizeof(T));
 	return target;
 }
 

--- a/src/network/connection.cpp
+++ b/src/network/connection.cpp
@@ -57,14 +57,6 @@ T convert_chars(unsigned char* const src) {
 namespace SlimeVR {
 namespace Network {
 
-#define MUST_TRANSFER_BOOL(b) \
-	if (!b)                   \
-		return false;
-
-#define MUST(b) \
-	if (!b)     \
-		return;
-
 bool Connection::beginPacket() {
 	if (m_IsBundle) {
 		m_BundlePacketPosition = 0;
@@ -91,7 +83,7 @@ bool Connection::endPacket() {
 		m_IsBundle = false;
 
 		if (m_BundlePacketInnerCount == 0) {
-			sendPacketType(PACKET_BUNDLE);
+			sendPacketType(SendPacketType::Bundle);
 			sendPacketNumber();
 		}
 		sendShort(innerPacketSize);
@@ -197,12 +189,12 @@ bool Connection::sendShortString(const char* str) {
 	return true;
 }
 
-bool Connection::sendPacketType(uint8_t type) {
+bool Connection::sendPacketType(SendPacketType type) {
 	MUST_TRANSFER_BOOL(sendByte(0));
 	MUST_TRANSFER_BOOL(sendByte(0));
 	MUST_TRANSFER_BOOL(sendByte(0));
 
-	return sendByte(type);
+	return sendByte(static_cast<uint8_t>(type));
 }
 
 bool Connection::sendLongString(const char* str) {
@@ -217,11 +209,12 @@ int Connection::getWriteError() { return m_UDP.getWriteError(); }
 
 // PACKET_HEARTBEAT 0
 void Connection::sendHeartbeat() {
+	sendPacketCallback(SendPacketType::HeartBeat, []() { return true; });
 	MUST(m_Connected);
 
 	MUST(beginPacket());
 
-	MUST(sendPacketType(PACKET_HEARTBEAT));
+	MUST(sendPacketType(SendPacketType::HeartBeat));
 	MUST(sendPacketNumber());
 
 	MUST(endPacket());
@@ -229,86 +222,67 @@ void Connection::sendHeartbeat() {
 
 // PACKET_ACCEL 4
 void Connection::sendSensorAcceleration(uint8_t sensorId, Vector3 vector) {
-	MUST(m_Connected);
-
-	MUST(beginPacket());
-
-	MUST(sendPacketType(PACKET_ACCEL));
-	MUST(sendPacketNumber());
-	MUST(sendFloat(vector.x));
-	MUST(sendFloat(vector.y));
-	MUST(sendFloat(vector.z));
-	MUST(sendByte(sensorId));
-
-	MUST(endPacket());
+	MUST(sendPacket(
+		SendPacketType::Accel,
+		AccelPacket{
+			.x = vector.x,
+			.y = vector.y,
+			.z = vector.z,
+			.sensorId = sensorId,
+		}
+	));
 }
 
 // PACKET_BATTERY_LEVEL 12
 void Connection::sendBatteryLevel(float batteryVoltage, float batteryPercentage) {
-	MUST(m_Connected);
-
-	MUST(beginPacket());
-
-	MUST(sendPacketType(PACKET_BATTERY_LEVEL));
-	MUST(sendPacketNumber());
-	MUST(sendFloat(batteryVoltage));
-	MUST(sendFloat(batteryPercentage));
-
-	MUST(endPacket());
+	MUST(sendPacket(
+		SendPacketType::BatteryLevel,
+		BatteryLevelPacket{
+			.batteryVoltage = batteryVoltage,
+			.batteryPercentage = batteryPercentage,
+		}
+	));
 }
 
 // PACKET_TAP 13
 void Connection::sendSensorTap(uint8_t sensorId, uint8_t value) {
-	MUST(m_Connected);
-
-	MUST(beginPacket());
-
-	MUST(sendPacketType(PACKET_TAP));
-	MUST(sendPacketNumber());
-	MUST(sendByte(sensorId));
-	MUST(sendByte(value));
-
-	MUST(endPacket());
+	MUST(sendPacket(
+		SendPacketType::Tap,
+		TapPacket{
+			.sensorId = sensorId,
+			.value = value,
+		}
+	));
 }
 
 // PACKET_ERROR 14
 void Connection::sendSensorError(uint8_t sensorId, uint8_t error) {
-	MUST(m_Connected);
-
-	MUST(beginPacket());
-
-	MUST(sendPacketType(PACKET_ERROR));
-	MUST(sendPacketNumber());
-	MUST(sendByte(sensorId));
-	MUST(sendByte(error));
-
-	MUST(endPacket());
+	sendPacket(
+		SendPacketType::Error,
+		ErrorPacket{
+			.sensorId = sensorId,
+			.error = error,
+		}
+	);
 }
 
 // PACKET_SENSOR_INFO 15
 void Connection::sendSensorInfo(Sensor& sensor) {
-	MUST(m_Connected);
+	MUST(sendPacket(
+		SendPacketType::SensorInfo,
+		SensorInfoPacket{
+			.sensorId = sensor.getSensorId(),
+			.sensorState = sensor.getSensorState(),
+			.sensorType = sensor.getSensorType(),
+			.sensorConfigData = sensor.getSensorConfigData(),
+			.hasCompletedRestCalibration = sensor.hasCompletedRestCalibration(),
+			.sensorPosition = sensor.getSensorPosition(),
+			.sensorDataType = sensor.getDataType(),
 
-	MUST(beginPacket());
-
-	MUST(sendPacketType(PACKET_SENSOR_INFO));
-	MUST(sendPacketNumber());
-	MUST(sendByte(sensor.getSensorId()));
-	MUST(sendByte(static_cast<uint8_t>(sensor.getSensorState())));
-	MUST(sendByte(static_cast<uint8_t>(sensor.getSensorType())));
-	MUST(sendShort(sensor.getSensorConfigData()));
-	MUST(sendByte(sensor.hasCompletedRestCalibration()));
-	MUST(sendByte(static_cast<uint8_t>(sensor.getSensorPosition())));
-	MUST(sendByte(static_cast<uint8_t>(sensor.getDataType())));
-	// ADD NEW FILEDS ABOVE THIS COMMENT ^^^^^^^^
-	// WARNING! Only for debug purposes and SHOULD ALWAYS BE LAST IN THE PACKET.
-	// It WILL BE REMOVED IN THE FUTURE
-	// ADD NEW FILEDS ABOVE THIS COMMENT ^^^^^^^^
-	// Send TPS
-	MUST(sendFloat(sensor.m_tpsCounter.getAveragedTPS()));
-	MUST(sendFloat(sensor.m_dataCounter.getAveragedTPS()));
-
-	MUST(endPacket());
+			.tpsCounterAveragedTps = sensor.m_tpsCounter.getAveragedTPS(),
+			.dataCounterAveragedTps = sensor.m_dataCounter.getAveragedTPS(),
+		}
+	));
 }
 
 // PACKET_ROTATION_DATA 17
@@ -318,136 +292,110 @@ void Connection::sendRotationData(
 	uint8_t dataType,
 	uint8_t accuracyInfo
 ) {
-	MUST(m_Connected);
-
-	MUST(beginPacket());
-
-	MUST(sendPacketType(PACKET_ROTATION_DATA));
-	MUST(sendPacketNumber());
-	MUST(sendByte(sensorId));
-	MUST(sendByte(dataType));
-	MUST(sendFloat(quaternion->x));
-	MUST(sendFloat(quaternion->y));
-	MUST(sendFloat(quaternion->z));
-	MUST(sendFloat(quaternion->w));
-	MUST(sendByte(accuracyInfo));
-
-	MUST(endPacket());
+	MUST(sendPacket(
+		SendPacketType::RotationData,
+		RotationDataPacket{
+			.sensorId = sensorId,
+			.dataType = dataType,
+			.x = quaternion->x,
+			.y = quaternion->y,
+			.z = quaternion->z,
+			.w = quaternion->w,
+			.accuracyInfo = accuracyInfo,
+		}
+	));
 }
 
 // PACKET_MAGNETOMETER_ACCURACY 18
 void Connection::sendMagnetometerAccuracy(uint8_t sensorId, float accuracyInfo) {
-	MUST(m_Connected);
-
-	MUST(beginPacket());
-
-	MUST(sendPacketType(PACKET_MAGNETOMETER_ACCURACY));
-	MUST(sendPacketNumber());
-	MUST(sendByte(sensorId));
-	MUST(sendFloat(accuracyInfo));
-
-	MUST(endPacket());
+	MUST(sendPacket(
+		SendPacketType::MagnetometerAccuracy,
+		MagnetometerAccuracyPacket{
+			.sensorId = sensorId,
+			.accuracyInfo = accuracyInfo,
+		}
+	));
 }
 
 // PACKET_SIGNAL_STRENGTH 19
 void Connection::sendSignalStrength(uint8_t signalStrength) {
-	MUST(m_Connected);
-
-	MUST(beginPacket());
-
-	MUST(sendPacketType(PACKET_SIGNAL_STRENGTH));
-	MUST(sendPacketNumber());
-	MUST(sendByte(255));
-	MUST(sendByte(signalStrength));
-
-	MUST(endPacket());
+	MUST(sendPacket(
+		SendPacketType::SignalStrength,
+		SignalStrengthPacket{
+			.sensorId = 255,
+			.signalStrength = signalStrength,
+		}
+	));
 }
 
 // PACKET_TEMPERATURE 20
 void Connection::sendTemperature(uint8_t sensorId, float temperature) {
-	MUST(m_Connected);
-
-	MUST(beginPacket());
-
-	MUST(sendPacketType(PACKET_TEMPERATURE));
-	MUST(sendPacketNumber());
-	MUST(sendByte(sensorId));
-	MUST(sendFloat(temperature));
-
-	MUST(endPacket());
+	MUST(sendPacket(
+		SendPacketType::Temperature,
+		TemperaturePacket{
+			.sensorId = sensorId,
+			.temperature = temperature,
+		}
+	));
 }
 
 // PACKET_FEATURE_FLAGS 22
 void Connection::sendFeatureFlags() {
-	MUST(m_Connected);
-
-	MUST(beginPacket());
-
-	MUST(sendPacketType(PACKET_FEATURE_FLAGS));
-	MUST(sendPacketNumber());
-	MUST(write(FirmwareFeatures::flags.data(), FirmwareFeatures::flags.size()));
-
-	MUST(endPacket());
+	sendPacketCallback(SendPacketType::FeatureFlags, [&]() {
+		return write(FirmwareFeatures::flags.data(), FirmwareFeatures::flags.size());
+	});
 }
 
 // PACKET_ACKNOWLEDGE_CONFIG_CHANGE 24
 
 void Connection::sendAcknowledgeConfigChange(uint8_t sensorId, uint16_t configType) {
-	MUST(m_Connected);
-
-	MUST(beginPacket());
-
-	MUST(sendPacketType(PACKET_ACKNOWLEDGE_CONFIG_CHANGE));
-	MUST(sendPacketNumber());
-	MUST(sendByte(sensorId));
-	MUST(sendShort(configType));
-
-	MUST(endPacket());
+	MUST(sendPacket(
+		SendPacketType::AcknowledgeConfigChange,
+		AcknowledgeConfigChangePacket{
+			.sensorId = sensorId,
+			.configType = configType,
+		}
+	));
 }
 
 void Connection::sendTrackerDiscovery() {
-	MUST(!m_Connected);
+	MUST(sendPacketCallback(
+		SendPacketType::Handshake,
+		[&]() {
+			uint8_t mac[6];
+			WiFi.macAddress(mac);
 
-	uint8_t mac[6];
-	WiFi.macAddress(mac);
-
-	MUST(beginPacket());
-
-	MUST(sendPacketType(PACKET_HANDSHAKE));
-	// Packet number is always 0 for handshake
-	MUST(sendLong(0));
-	MUST(sendInt(BOARD));
-	// This is kept for backwards compatibility,
-	// but the latest SlimeVR server will not initialize trackers
-	// with firmware build > 8 until it recieves a sensor info packet
-	MUST(sendInt(static_cast<int>(sensorManager.getSensorType(0))));
-	MUST(sendInt(HARDWARE_MCU));
-	MUST(sendInt(0));
-	MUST(sendInt(0));
-	MUST(sendInt(0));
-	MUST(sendInt(PROTOCOL_VERSION));
-	MUST(sendShortString(FIRMWARE_VERSION));
-	// MAC address string
-	MUST(sendBytes(mac, 6));
-	MUST(sendByte(static_cast<uint8_t>(TRACKER_TYPE))
-	);  // Tracker type to hint the server if it's a glove or
-		// normal tracker or something else
-
-	MUST(endPacket());
+			MUST_TRANSFER_BOOL(sendInt(BOARD));
+			// This is kept for backwards compatibility,
+			// but the latest SlimeVR server will not initialize trackers
+			// with firmware build > 8 until it recieves a sensor info packet
+			MUST_TRANSFER_BOOL(sendInt(static_cast<int>(sensorManager.getSensorType(0)))
+			);
+			MUST_TRANSFER_BOOL(sendInt(HARDWARE_MCU));
+			MUST_TRANSFER_BOOL(sendInt(0));
+			MUST_TRANSFER_BOOL(sendInt(0));
+			MUST_TRANSFER_BOOL(sendInt(0));
+			MUST_TRANSFER_BOOL(sendInt(PROTOCOL_VERSION));
+			MUST_TRANSFER_BOOL(sendShortString(FIRMWARE_VERSION));
+			// MAC address string
+			MUST_TRANSFER_BOOL(sendBytes(mac, 6));
+			MUST_TRANSFER_BOOL(sendByte(static_cast<uint8_t>(TRACKER_TYPE))
+			);  // Tracker type to hint the server if it's a glove or
+			return true;
+		},
+		0
+	));
 }
 
 // PACKET_FLEX_DATA 24
 void Connection::sendFlexData(uint8_t sensorId, float flexLevel) {
-	MUST(m_Connected);
-
-	MUST(beginPacket());
-
-	MUST(sendPacketType(PACKET_FLEX_DATA));
-	MUST(sendPacketNumber());
-	MUST(sendByte(sensorId));
-	MUST(sendFloat(flexLevel));
-
-	MUST(endPacket());
+	MUST(sendPacket(
+		SendPacketType::FlexData,
+		FlexDataPacket{
+			.sensorId = sensorId,
+			.flexLevel = flexLevel,
+		}
+	));
 }
 
 #if ENABLE_INSPECTION
@@ -466,34 +414,29 @@ void Connection::sendInspectionRawIMUData(
 	int16_t mZ,
 	uint8_t mA
 ) {
-	MUST(m_Connected);
+	MUST(sendPacket(
+		SendPacketType::Inspection,
+		IntRawImuDataInspectionPacket{
+			.inspectionPacketType = InspectionPacketType::RawImuData,
+			.sensorId = sensorId,
+			.inspectionDataType = InspectionDataType::Int,
 
-	MUST(beginPacket());
+			.rX = static_cast<uint32_t>(rX),
+			.rY = static_cast<uint32_t>(rY),
+			.rZ = static_cast<uint32_t>(rZ),
+			.rA = rA,
 
-	MUST(sendPacketType(PACKET_INSPECTION));
-	MUST(sendPacketNumber());
+			.aX = static_cast<uint32_t>(aX),
+			.aY = static_cast<uint32_t>(aY),
+			.aZ = static_cast<uint32_t>(aZ),
+			.aA = aA,
 
-	MUST(sendByte(PACKET_INSPECTION_PACKETTYPE_RAW_IMU_DATA));
-
-	MUST(sendByte(sensorId));
-	MUST(sendByte(PACKET_INSPECTION_DATATYPE_INT));
-
-	MUST(sendInt(rX));
-	MUST(sendInt(rY));
-	MUST(sendInt(rZ));
-	MUST(sendByte(rA));
-
-	MUST(sendInt(aX));
-	MUST(sendInt(aY));
-	MUST(sendInt(aZ));
-	MUST(sendByte(aA));
-
-	MUST(sendInt(mX));
-	MUST(sendInt(mY));
-	MUST(sendInt(mZ));
-	MUST(sendByte(mA));
-
-	MUST(endPacket());
+			.mX = static_cast<uint32_t>(mX),
+			.mY = static_cast<uint32_t>(mY),
+			.mZ = static_cast<uint32_t>(mZ),
+			.mA = mA,
+		}
+	))
 }
 
 void Connection::sendInspectionRawIMUData(
@@ -511,34 +454,29 @@ void Connection::sendInspectionRawIMUData(
 	float mZ,
 	uint8_t mA
 ) {
-	MUST(m_Connected);
+	MUST(sendPacket(
+		SendPacketType::Inspection,
+		FloatRawImuDataInspectionPacket{
+			.inspectionPacketType = InspectionPacketType::RawImuData,
+			.sensorId = sensorId,
+			.inspectionDataType = InspectionDataType::Float,
 
-	MUST(beginPacket());
+			.rX = rX,
+			.rY = rY,
+			.rZ = rZ,
+			.rA = rA,
 
-	MUST(sendPacketType(PACKET_INSPECTION));
-	MUST(sendPacketNumber());
+			.aX = aX,
+			.aY = aY,
+			.aZ = aZ,
+			.aA = aA,
 
-	MUST(sendByte(PACKET_INSPECTION_PACKETTYPE_RAW_IMU_DATA));
-
-	MUST(sendByte(sensorId));
-	MUST(sendByte(PACKET_INSPECTION_DATATYPE_FLOAT));
-
-	MUST(sendFloat(rX));
-	MUST(sendFloat(rY));
-	MUST(sendFloat(rZ));
-	MUST(sendByte(rA));
-
-	MUST(sendFloat(aX));
-	MUST(sendFloat(aY));
-	MUST(sendFloat(aZ));
-	MUST(sendByte(aA));
-
-	MUST(sendFloat(mX));
-	MUST(sendFloat(mY));
-	MUST(sendFloat(mZ));
-	MUST(sendByte(mA));
-
-	MUST(endPacket());
+			.mX = mX,
+			.mY = mY,
+			.mZ = mZ,
+			.mA = mA,
+		}
+	));
 }
 #endif
 
@@ -603,13 +541,12 @@ void Connection::searchForServer() {
 			m_UDP.remotePort()
 		);
 		m_Logger.traceArray("UDP packet contents: ", m_Packet, len);
-#else
-		(void)len;
 #endif
 
 		// Handshake is different, it has 3 in the first byte, not the 4th, and data
 		// starts right after
-		if (m_Packet[0] == PACKET_HANDSHAKE) {
+		if (static_cast<ReceivePacketType>(m_Packet[0])
+			== ReceivePacketType::Handshake) {
 			if (strncmp((char*)m_Packet + 1, "Hey OVR =D 5", 12) != 0) {
 				m_Logger.error("Received invalid handshake packet");
 				continue;
@@ -717,51 +654,55 @@ void Connection::update() {
 	(void)packetSize;
 #endif
 
-	switch (convert_chars<int>(m_Packet)) {
-		case PACKET_RECEIVE_HEARTBEAT:
+	switch (static_cast<ReceivePacketType>(m_Packet[3])) {
+		case ReceivePacketType::HeartBeat:
 			sendHeartbeat();
 			break;
 
-		case PACKET_RECEIVE_VIBRATE:
+		case ReceivePacketType::Vibrate:
 			break;
 
-		case PACKET_RECEIVE_HANDSHAKE:
+		case ReceivePacketType::Handshake:
 			// Assume handshake successful
 			m_Logger.warn("Handshake received again, ignoring");
 			break;
 
-		case PACKET_RECEIVE_COMMAND:
+		case ReceivePacketType::Command:
 			break;
 
-		case PACKET_CONFIG:
+		case ReceivePacketType::Config:
 			break;
 
-		case PACKET_PING_PONG:
+		case ReceivePacketType::PingPong:
 			returnLastPacket(len);
 			break;
 
-		case PACKET_SENSOR_INFO:
+		case ReceivePacketType::SensorInfo: {
 			if (len < 6) {
 				m_Logger.warn("Wrong sensor info packet");
 				break;
 			}
 
+			SensorInfoPacket sensorInfoPacket;
+			memcpy(&sensorInfoPacket, m_Packet + 4, sizeof(sensorInfoPacket));
+
 			for (int i = 0; i < (int)sensors.size(); i++) {
-				if (m_Packet[4] == sensors[i]->getSensorId()) {
-					m_AckedSensorState[i] = (SensorStatus)m_Packet[5];
+				if (sensorInfoPacket.sensorId == sensors[i]->getSensorId()) {
+					m_AckedSensorState[i] = sensorInfoPacket.sensorState;
 					if (len < 12) {
 						m_AckedSensorCalibration[i]
 							= sensors[i]->hasCompletedRestCalibration();
 						break;
 					}
-					m_AckedSensorCalibration[i] = (bool)m_Packet[11];
+					m_AckedSensorCalibration[i]
+						= sensorInfoPacket.hasCompletedRestCalibration;
 					break;
 				}
 			}
 
 			break;
-
-		case PACKET_FEATURE_FLAGS: {
+		}
+		case ReceivePacketType::FeatureFlags: {
 			// Packet type (4) + Packet number (8) + flags (len - 12)
 			if (len < 13) {
 				m_Logger.warn("Invalid feature flags packet: too short");
@@ -784,16 +725,20 @@ void Connection::update() {
 			break;
 		}
 
-		case PACKET_SET_CONFIG_FLAG: {
+		case ReceivePacketType::SetConfigFlag: {
 			// Packet type (4) + Packet number (8) + sensor_id(1) + flag_id (2) + state
 			// (1)
 			if (len < 16) {
 				m_Logger.warn("Invalid sensor config flag packet: too short");
 				break;
 			}
-			uint8_t sensorId = m_Packet[12];
-			uint16_t flagId = m_Packet[13] << 8 | m_Packet[14];
-			bool newState = m_Packet[15] > 0;
+
+			SetConfigFlagPacket setConfigFlagPacket;
+			memcpy(&setConfigFlagPacket, m_Packet + 12, sizeof(SetConfigFlagPacket));
+
+			uint8_t sensorId = setConfigFlagPacket.sensorId;
+			uint16_t flagId = setConfigFlagPacket.flagId;
+			bool newState = setConfigFlagPacket.newState;
 			if (sensorId == UINT8_MAX) {
 				for (auto& sensor : sensors) {
 					sensor->setFlag(flagId, newState);

--- a/src/network/connection.cpp
+++ b/src/network/connection.cpp
@@ -409,19 +409,19 @@ void Connection::sendInspectionRawIMUData(
 			.sensorId = sensorId,
 			.inspectionDataType = InspectionDataType::Int,
 
-			.rX = swapEndiannes(static_cast<uint32_t>(rX)),
-			.rY = swapEndiannes(static_cast<uint32_t>(rY)),
-			.rZ = swapEndiannes(static_cast<uint32_t>(rZ)),
+			.rX = static_cast<uint32_t>(rX),
+			.rY = static_cast<uint32_t>(rY),
+			.rZ = static_cast<uint32_t>(rZ),
 			.rA = rA,
 
-			.aX = swapEndiannes(static_cast<uint32_t>(aX)),
-			.aY = swapEndiannes(static_cast<uint32_t>(aY)),
-			.aZ = swapEndiannes(static_cast<uint32_t>(aZ)),
+			.aX = static_cast<uint32_t>(aX),
+			.aY = static_cast<uint32_t>(aY),
+			.aZ = static_cast<uint32_t>(aZ),
 			.aA = aA,
 
-			.mX = swapEndiannes(static_cast<uint32_t>(mX)),
-			.mY = swapEndiannes(static_cast<uint32_t>(mY)),
-			.mZ = swapEndiannes(static_cast<uint32_t>(mZ)),
+			.mX = static_cast<uint32_t>(mX),
+			.mY = static_cast<uint32_t>(mY),
+			.mZ = static_cast<uint32_t>(mZ),
 			.mA = mA,
 		}
 	))

--- a/src/network/connection.cpp
+++ b/src/network/connection.cpp
@@ -32,9 +32,7 @@
 template <typename T>
 uint8_t* convert_to_chars(T src, uint8_t* target) {
 	auto* rawBytes = reinterpret_cast<uint8_t*>(&src);
-	for (size_t i = 0; i < sizeof(T); i++) {
-		target[i] = rawBytes[sizeof(T) - i - 1];
-	}
+	std::reverse(rawBytes, rawBytes + sizeof(T));
 	return target;
 }
 

--- a/src/network/connection.h
+++ b/src/network/connection.h
@@ -163,8 +163,6 @@ private:
 		Packet packet,
 		std::optional<uint64_t> packetNumberOverride = std::nullopt
 	) {
-		MUST_TRANSFER_BOOL(m_Connected);
-
 		MUST_TRANSFER_BOOL(beginPacket());
 		MUST_TRANSFER_BOOL(sendPacketType(type));
 		if (packetNumberOverride) {
@@ -186,8 +184,6 @@ private:
 		Callback bodyCallback,
 		std::optional<uint64_t> packetNumberOverride = std::nullopt
 	) {
-		MUST_TRANSFER_BOOL(m_Connected);
-
 		MUST_TRANSFER_BOOL(beginPacket());
 		MUST_TRANSFER_BOOL(sendPacketType(type));
 		if (packetNumberOverride) {

--- a/src/network/packets.h
+++ b/src/network/packets.h
@@ -93,16 +93,32 @@ enum class PacketErrorCode : uint8_t {
 
 #pragma pack(push, 1)
 
+template <typename T>
+T swapEndianness(T value) {
+	auto* bytes = reinterpret_cast<uint8_t*>(&value);
+	std::reverse(bytes, bytes + sizeof(T));
+	return value;
+}
+
+template <typename T>
+struct BigEndian {
+	BigEndian() = default;
+	explicit(false) BigEndian(T val) { value = swapEndianness(val); }
+	explicit(false) operator T() const { return swapEndianness(value); }
+
+	T value{};
+};
+
 struct AccelPacket {
-	float x;
-	float y;
-	float z;
-	uint8_t sensorId;
+	BigEndian<float> x;
+	BigEndian<float> y;
+	BigEndian<float> z;
+	uint8_t sensorId{};
 };
 
 struct BatteryLevelPacket {
-	float batteryVoltage;
-	float batteryPercentage;
+	BigEndian<float> batteryVoltage;
+	BigEndian<float> batteryPercentage;
 };
 
 struct TapPacket {
@@ -116,34 +132,34 @@ struct ErrorPacket {
 };
 
 struct SensorInfoPacket {
-	uint8_t sensorId;
-	SensorStatus sensorState;
-	SensorTypeID sensorType;
-	uint16_t sensorConfigData;
-	bool hasCompletedRestCalibration;
-	SensorPosition sensorPosition;
-	SensorDataType sensorDataType;
+	uint8_t sensorId{};
+	SensorStatus sensorState{};
+	SensorTypeID sensorType{};
+	uint16_t sensorConfigData{};
+	bool hasCompletedRestCalibration{};
+	SensorPosition sensorPosition{};
+	SensorDataType sensorDataType{};
 	// ADD NEW FIELDS ABOVE THIS COMMENT ^^^^^^^^
 	// WARNING! Only for debug purposes and SHOULD ALWAYS BE LAST IN THE PACKET.
 	// It WILL BE REMOVED IN THE FUTURE
 	// Send TPS
-	float tpsCounterAveragedTps;
-	float dataCounterAveragedTps;
+	BigEndian<float> tpsCounterAveragedTps;
+	BigEndian<float> dataCounterAveragedTps;
 };
 
 struct RotationDataPacket {
-	uint8_t sensorId;
-	uint8_t dataType;
-	float x;
-	float y;
-	float z;
-	float w;
-	uint8_t accuracyInfo;
+	uint8_t sensorId{};
+	uint8_t dataType{};
+	BigEndian<float> x;
+	BigEndian<float> y;
+	BigEndian<float> z;
+	BigEndian<float> w;
+	uint8_t accuracyInfo{};
 };
 
 struct MagnetometerAccuracyPacket {
-	uint8_t sensorId;
-	float accuracyInfo;
+	uint8_t sensorId{};
+	BigEndian<float> accuracyInfo;
 };
 
 struct SignalStrengthPacket {
@@ -152,66 +168,66 @@ struct SignalStrengthPacket {
 };
 
 struct TemperaturePacket {
-	uint8_t sensorId;
-	float temperature;
+	uint8_t sensorId{};
+	BigEndian<float> temperature;
 };
 
 struct AcknowledgeConfigChangePacket {
-	uint8_t sensorId;
-	uint16_t configType;
+	uint8_t sensorId{};
+	BigEndian<uint16_t> configType;
 };
 
 struct FlexDataPacket {
-	uint8_t sensorId;
-	float flexLevel;
+	uint8_t sensorId{};
+	BigEndian<float> flexLevel;
 };
 
 struct IntRawImuDataInspectionPacket {
-	InspectionPacketType inspectionPacketType;
-	uint8_t sensorId;
-	InspectionDataType inspectionDataType;
+	InspectionPacketType inspectionPacketType{};
+	uint8_t sensorId{};
+	InspectionDataType inspectionDataType{};
 
-	uint32_t rX;
-	uint32_t rY;
-	uint32_t rZ;
-	uint8_t rA;
+	BigEndian<uint32_t> rX;
+	BigEndian<uint32_t> rY;
+	BigEndian<uint32_t> rZ;
+	uint8_t rA{};
 
-	uint32_t aX;
-	uint32_t aY;
-	uint32_t aZ;
-	uint8_t aA;
+	BigEndian<uint32_t> aX;
+	BigEndian<uint32_t> aY;
+	BigEndian<uint32_t> aZ;
+	uint8_t aA{};
 
-	uint32_t mX;
-	uint32_t mY;
-	uint32_t mZ;
-	uint8_t mA;
+	BigEndian<uint32_t> mX;
+	BigEndian<uint32_t> mY;
+	BigEndian<uint32_t> mZ;
+	uint8_t mA{};
 };
 
 struct FloatRawImuDataInspectionPacket {
-	InspectionPacketType inspectionPacketType;
-	uint8_t sensorId;
-	InspectionDataType inspectionDataType;
+	InspectionPacketType inspectionPacketType{};
+	uint8_t sensorId{};
+	InspectionDataType inspectionDataType{};
 
-	float rX;
-	float rY;
-	float rZ;
-	uint8_t rA;
+	BigEndian<float> rX;
+	BigEndian<float> rY;
+	BigEndian<float> rZ;
+	uint8_t rA{};
 
-	float aX;
-	float aY;
-	float aZ;
-	uint8_t aA;
+	BigEndian<float> aX;
+	BigEndian<float> aY;
+	BigEndian<float> aZ;
+	uint8_t aA{};
 
-	float mX;
-	float mY;
-	float mZ;
-	uint8_t mA;
+	BigEndian<float> mX;
+	BigEndian<float> mY;
+	BigEndian<float> mZ;
+	uint8_t mA{};
 };
 
 struct SetConfigFlagPacket {
-	uint8_t sensorId;
-	uint16_t flagId;
-	bool newState;
+	uint8_t sensorId{};
+	BigEndian<uint16_t> flagId;
+	bool newState{};
 };
 
 #pragma pack(pop)

--- a/src/network/packets.h
+++ b/src/network/packets.h
@@ -24,49 +24,62 @@
 #ifndef SLIMEVR_PACKETS_H_
 #define SLIMEVR_PACKETS_H_
 
-#define PACKET_HEARTBEAT 0
-// #define PACKET_ROTATION 1 // Deprecated
-// #define PACKET_GYRO 2 // Deprecated
-#define PACKET_HANDSHAKE 3
-#define PACKET_ACCEL 4
-// #define PACKET_MAG 5 // Deprecated
-// #define PACKET_RAW_CALIBRATION_DATA 6 // Deprecated
-// #define PACKET_CALIBRATION_FINISHED 7 // Deprecated
-#define PACKET_CONFIG 8
-// #define PACKET_RAW_MAGNETOMETER 9 // Deprecated
-#define PACKET_PING_PONG 10
-#define PACKET_SERIAL 11
-#define PACKET_BATTERY_LEVEL 12
-#define PACKET_TAP 13
-#define PACKET_ERROR 14
-#define PACKET_SENSOR_INFO 15
-// #define PACKET_ROTATION_2 16 // Deprecated
-#define PACKET_ROTATION_DATA 17
-#define PACKET_MAGNETOMETER_ACCURACY 18
-#define PACKET_SIGNAL_STRENGTH 19
-#define PACKET_TEMPERATURE 20
-// #define PACKET_USER_ACTION 21 // Joycon buttons only currently
-#define PACKET_FEATURE_FLAGS 22
-// #define PACKET_ROTATION_ACCELERATION 23 // Unification of rot and accel data in one
-// packet
-#define PACKET_ACKNOWLEDGE_CONFIG_CHANGE 24
-#define PACKET_SET_CONFIG_FLAG 25
-#define PACKET_FLEX_DATA 26
+#include <cstdint>
 
-#define PACKET_BUNDLE 100
+#include "../consts.h"
+#include "../sensors/sensor.h"
 
-#define PACKET_INSPECTION 105  // 0x69
+enum class SendPacketType : uint8_t {
+	HeartBeat = 0,
+	//  Rotation = 1,
+	//  Gyro = 2,
+	Handshake = 3,
+	Accel = 4,
+	// Mag = 5,
+	// RawCalibrationData = 6,
+	// CalibrationFinished = 7,
+	// RawMagnetometer = 9,
+	Serial = 11,
+	BatteryLevel = 12,
+	Tap = 13,
+	Error = 14,
+	SensorInfo = 15,
+	// Rotation2 = 16,
+	RotationData = 17,
+	MagnetometerAccuracy = 18,
+	SignalStrength = 19,
+	Temperature = 20,
+	// UserAction = 21,
+	FeatureFlags = 22,
+	// RotationAcceleration = 23,
+	AcknowledgeConfigChange = 24,
+	FlexData = 26,
+	Bundle = 100,
+	Inspection = 105,
+};
 
-#define PACKET_RECEIVE_HEARTBEAT 1
-#define PACKET_RECEIVE_VIBRATE 2
-#define PACKET_RECEIVE_HANDSHAKE 3
-#define PACKET_RECEIVE_COMMAND 4
+enum class ReceivePacketType : uint8_t {
+	HeartBeat = 1,
+	Vibrate = 2,
+	Handshake = 3,
+	Command = 4,
+	Config = 8,
+	PingPong = 10,
+	SensorInfo = 15,
+	FeatureFlags = 22,
+	SetConfigFlag = 25,
+};
 
-#define PACKET_INSPECTION_PACKETTYPE_RAW_IMU_DATA 1
-#define PACKET_INSPECTION_PACKETTYPE_FUSED_IMU_DATA 2
-#define PACKET_INSPECTION_PACKETTYPE_CORRECTION_DATA 3
-#define PACKET_INSPECTION_DATATYPE_INT 1
-#define PACKET_INSPECTION_DATATYPE_FLOAT 2
+enum class InspectionPacketType : uint8_t {
+	RawImuData = 1,
+	FusedImuData = 2,
+	CorrectionData = 3,
+};
+
+enum class InspectionDataType : uint8_t {
+	Int = 1,
+	Float = 2,
+};
 
 // From the SH-2 interface that BNO08x use.
 enum class PacketErrorCode : uint8_t {
@@ -77,5 +90,130 @@ enum class PacketErrorCode : uint8_t {
 	EXTERNAL_RESET = 4,
 	OTHER = 5,
 };
+
+#pragma pack(push, 1)
+
+struct AccelPacket {
+	float x;
+	float y;
+	float z;
+	uint8_t sensorId;
+};
+
+struct BatteryLevelPacket {
+	float batteryVoltage;
+	float batteryPercentage;
+};
+
+struct TapPacket {
+	uint8_t sensorId;
+	uint8_t value;
+};
+
+struct ErrorPacket {
+	uint8_t sensorId;
+	uint8_t error;
+};
+
+struct SensorInfoPacket {
+	uint8_t sensorId;
+	SensorStatus sensorState;
+	SensorTypeID sensorType;
+	uint16_t sensorConfigData;
+	bool hasCompletedRestCalibration;
+	SensorPosition sensorPosition;
+	SensorDataType sensorDataType;
+	// ADD NEW FIELDS ABOVE THIS COMMENT ^^^^^^^^
+	// WARNING! Only for debug purposes and SHOULD ALWAYS BE LAST IN THE PACKET.
+	// It WILL BE REMOVED IN THE FUTURE
+	// Send TPS
+	float tpsCounterAveragedTps;
+	float dataCounterAveragedTps;
+};
+
+struct RotationDataPacket {
+	uint8_t sensorId;
+	uint8_t dataType;
+	float x;
+	float y;
+	float z;
+	float w;
+	uint8_t accuracyInfo;
+};
+
+struct MagnetometerAccuracyPacket {
+	uint8_t sensorId;
+	float accuracyInfo;
+};
+
+struct SignalStrengthPacket {
+	uint8_t sensorId;
+	uint8_t signalStrength;
+};
+
+struct TemperaturePacket {
+	uint8_t sensorId;
+	float temperature;
+};
+
+struct AcknowledgeConfigChangePacket {
+	uint8_t sensorId;
+	uint16_t configType;
+};
+
+struct FlexDataPacket {
+	uint8_t sensorId;
+	float flexLevel;
+};
+
+struct IntRawImuDataInspectionPacket {
+	InspectionPacketType inspectionPacketType;
+	uint8_t sensorId;
+	InspectionDataType inspectionDataType;
+
+	uint32_t rX;
+	uint32_t rY;
+	uint32_t rZ;
+	uint8_t rA;
+
+	uint32_t aX;
+	uint32_t aY;
+	uint32_t aZ;
+	uint8_t aA;
+
+	uint32_t mX;
+	uint32_t mY;
+	uint32_t mZ;
+	uint8_t mA;
+};
+
+struct FloatRawImuDataInspectionPacket {
+	InspectionPacketType inspectionPacketType;
+	uint8_t sensorId;
+	InspectionDataType inspectionDataType;
+
+	float rX;
+	float rY;
+	float rZ;
+	uint8_t rA;
+
+	float aX;
+	float aY;
+	float aZ;
+	uint8_t aA;
+
+	float mX;
+	float mY;
+	float mZ;
+	uint8_t mA;
+};
+
+struct SetConfigFlagPacket {
+	uint8_t sensorId;
+	uint16_t flagId;
+	bool newState;
+};
+
+#pragma pack(pop)
 
 #endif  // SLIMEVR_PACKETS_H_

--- a/src/sensors/softfusion/drivers/icm45base.h
+++ b/src/sensors/softfusion/drivers/icm45base.h
@@ -168,11 +168,11 @@ struct ICM45Base {
 			if (entry.accel[0] != -32768) {
 				const int32_t accelData[3]{
 					static_cast<int32_t>(entry.accel[0]) << 4
-						| (static_cast<int32_t>(entry.lsb[0]) & 0xf0 >> 4),
+						| (static_cast<int32_t>((entry.lsb[0]) & 0xf0) >> 4),
 					static_cast<int32_t>(entry.accel[1]) << 4
-						| (static_cast<int32_t>(entry.lsb[1]) & 0xf0 >> 4),
+						| (static_cast<int32_t>((entry.lsb[1]) & 0xf0) >> 4),
 					static_cast<int32_t>(entry.accel[2]) << 4
-						| (static_cast<int32_t>(entry.lsb[2]) & 0xf0 >> 4),
+						| (static_cast<int32_t>((entry.lsb[2]) & 0xf0) >> 4),
 				};
 				processAccelSample(accelData, AccTs);
 			}


### PR DESCRIPTION
This PR aims to make changing packet code less error prone by introducing structs that describe most packets used for communication. Since communication is done using big endian data, steps are also taken, so that this is more or less automatically handled as well.

The only packets that didn't get turned into structs are the heartbeat packet (since it's empty, and 0 byte structs aren't supported by C++), the feature flags packet (since its length is complicated) and the handshake or tracker discovery packet (since this has a variable length string inside it).

The PR also cleans up some of the code surrounding these changes, for example by creating enum classes for the various packet values.