### PR TITLE
Send NOT_APPLICABLE Error to the server

### DIFF
--- a/lib/i2cscan/i2cscan.cpp
+++ b/lib/i2cscan/i2cscan.cpp
@@ -33,6 +33,9 @@ namespace I2CSCAN
     uint8_t currentAddress = 1;
     bool found = false;
     std::vector<uint8_t> validPorts;
+    bool isFound() {
+        return found;
+    }
 
     void scani2cports()
     {

--- a/lib/i2cscan/i2cscan.h
+++ b/lib/i2cscan/i2cscan.h
@@ -9,6 +9,7 @@ namespace I2CSCAN {
     void update();
     bool checkI2C(uint8_t i, uint8_t j);
     bool hasDevOnBus(uint8_t addr);
+    bool isFound();
     uint8_t pickDevice(uint8_t addr1, uint8_t addr2, bool scanIfNotFound);
     int clearBus(uint8_t SDA, uint8_t SCL);
     boolean inArray(uint8_t value, uint8_t* arr, size_t arrSize);

--- a/src/network/connection.cpp
+++ b/src/network/connection.cpp
@@ -492,7 +492,8 @@ void Connection::updateSensorState(std::vector<std::unique_ptr<Sensor>>& sensors
 	for (int i = 0; i < (int)sensors.size(); i++) {
 		if (isSensorStateUpdated(i, sensors[i])) {
 			sendSensorInfo(*sensors[i]);
-			if (I2CSCAN::isFound()) {
+			if (I2CSCAN::isFound()
+				&& sensors[i]->getSensorState() == SensorStatus::SENSOR_ERROR) {
 				sendSensorError(
 					static_cast<uint8_t>(sensors[i]->getSensorId()),
 					static_cast<uint8_t>(PacketErrorCode::NOT_APPLICABLE)

--- a/src/network/connection.cpp
+++ b/src/network/connection.cpp
@@ -492,6 +492,12 @@ void Connection::updateSensorState(std::vector<std::unique_ptr<Sensor>>& sensors
 	for (int i = 0; i < (int)sensors.size(); i++) {
 		if (isSensorStateUpdated(i, sensors[i])) {
 			sendSensorInfo(*sensors[i]);
+			if (I2CSCAN::isFound()) {
+				sendSensorError(
+					static_cast<uint8_t>(sensors[i]->getSensorId()),
+					static_cast<uint8_t>(PacketErrorCode::NOT_APPLICABLE)
+				);
+			}
 		}
 	}
 }


### PR DESCRIPTION
[SlimeVR-Tracker-ESP Issues#380](https://github.com/SlimeVR/SlimeVR-Tracker-ESP/issues/380)
Using PacketErrorCode in the packet.h [packets.h](https://github.com/SlimeVR/SlimeVR-Tracker-ESP/blob/main/src/network/packets.h)

- using PACKET_ERROR 14
- if I2CSCAN found an available IMU but not in the defines.h, Tracker will send PacketErrorCode::NOT_APPLICABLE to the server.

Server: [Receive ErrorData From Tracker And replace "Error" #1344](https://github.com/SlimeVR/SlimeVR-Server/pull/1344)
SolarXR-Protocol: [Error imformation show to the user #163](https://github.com/SlimeVR/SolarXR-Protocol/pull/163)