### PR TITLE
fix_sensorConfigData Magnetometer not avaliable on Server

### DIFF
--- a/src/consts.h
+++ b/src/consts.h
@@ -150,13 +150,13 @@ enum class SensorTypeID : uint8_t {
 #define MCU_HARITORA 8  // Used by Haritora/SlimeTora
 #define MCU_DEV_RESERVED 250  // Reserved, should not be used in any release firmware
 
-enum class SensorDataType {
+enum class SensorDataType : uint8_t {
 	SENSOR_DATATYPE_ROTATION = 0,
 	SENSOR_DATATYPE_FLEX_RESISTANCE,
 	SENSOR_DATATYPE_FLEX_ANGLE
 };
 
-enum class TrackerType {
+enum class TrackerType : uint8_t{
 	TRACKER_TYPE_SVR_ROTATION = 0,
 	TRACKER_TYPE_SVR_GLOVE_LEFT,
 	TRACKER_TYPE_SVR_GLOVE_RIGHT

--- a/src/consts.h
+++ b/src/consts.h
@@ -156,7 +156,7 @@ enum class SensorDataType : uint8_t {
 	SENSOR_DATATYPE_FLEX_ANGLE
 };
 
-enum class TrackerType : uint8_t{
+enum class TrackerType : uint8_t {
 	TRACKER_TYPE_SVR_ROTATION = 0,
 	TRACKER_TYPE_SVR_GLOVE_LEFT,
 	TRACKER_TYPE_SVR_GLOVE_RIGHT

--- a/src/network/connection.cpp
+++ b/src/network/connection.cpp
@@ -512,7 +512,8 @@ void Connection::maybeRequestFeatureFlags() {
 
 bool Connection::isSensorStateUpdated(int i, std::unique_ptr<Sensor>& sensor) {
 	return m_AckedSensorState[i] != sensor->getSensorState()
-		|| m_AckedSensorCalibration[i] != sensor->hasCompletedRestCalibration();
+		|| m_AckedSensorCalibration[i] != sensor->hasCompletedRestCalibration()
+		|| m_AckedSensorConfigData[i] != sensor->getSensorConfigData();
 }
 
 void Connection::searchForServer() {
@@ -589,6 +590,11 @@ void Connection::reset() {
 		m_AckedSensorCalibration,
 		m_AckedSensorCalibration + MAX_SENSORS_COUNT,
 		false
+	);
+	std::fill(
+		m_AckedSensorConfigData,
+		m_AckedSensorConfigData + MAX_SENSORS_COUNT,
+		0
 	);
 
 	m_UDP.begin(m_ServerPort);
@@ -684,6 +690,7 @@ void Connection::update() {
 					if (len < 12) {
 						m_AckedSensorCalibration[i]
 							= sensors[i]->hasCompletedRestCalibration();
+						m_AckedSensorConfigData[i] = sensors[i]->getSensorConfigData();
 						break;
 					}
 					m_AckedSensorCalibration[i]

--- a/src/network/connection.cpp
+++ b/src/network/connection.cpp
@@ -591,11 +591,7 @@ void Connection::reset() {
 		m_AckedSensorCalibration + MAX_SENSORS_COUNT,
 		false
 	);
-	std::fill(
-		m_AckedSensorConfigData,
-		m_AckedSensorConfigData + MAX_SENSORS_COUNT,
-		0
-	);
+	std::fill(m_AckedSensorConfigData, m_AckedSensorConfigData + MAX_SENSORS_COUNT, 0);
 
 	m_UDP.begin(m_ServerPort);
 

--- a/src/network/connection.h
+++ b/src/network/connection.h
@@ -225,6 +225,7 @@ private:
 	unsigned long m_LastPacketTimestamp;
 
 	SensorStatus m_AckedSensorState[MAX_SENSORS_COUNT] = {SensorStatus::SENSOR_OFFLINE};
+	uint16_t m_AckedSensorConfigData[MAX_SENSORS_COUNT] = {0};
 	bool m_AckedSensorCalibration[MAX_SENSORS_COUNT] = {false};
 	unsigned long m_LastSensorInfoPacketTimestamp = 0;
 

--- a/src/network/packets.h
+++ b/src/network/packets.h
@@ -135,7 +135,7 @@ struct SensorInfoPacket {
 	uint8_t sensorId{};
 	SensorStatus sensorState{};
 	SensorTypeID sensorType{};
-	uint16_t sensorConfigData{};
+	BigEndian<uint16_t> sensorConfigData{};
 	bool hasCompletedRestCalibration{};
 	SensorPosition sensorPosition{};
 	SensorDataType sensorDataType{};

--- a/src/sensors/sensorposition.h
+++ b/src/sensors/sensorposition.h
@@ -22,7 +22,7 @@
 */
 #pragma once
 
-enum class SensorPosition {
+enum class SensorPosition : uint8_t{
 	POSITION_NO = 0,
 	POSITION_HEAD = 1,
 	POSITION_NECK = 2,

--- a/src/sensors/sensorposition.h
+++ b/src/sensors/sensorposition.h
@@ -22,7 +22,7 @@
 */
 #pragma once
 
-enum class SensorPosition : uint8_t{
+enum class SensorPosition : uint8_t {
 	POSITION_NO = 0,
 	POSITION_HEAD = 1,
 	POSITION_NECK = 2,


### PR DESCRIPTION
When i did connect a BNO085 the server did not show the Magnetometer toggle.
This should fix it. Regression introduced by #402 

Also did define some missing sizes

Also added check to send changed SensorConfigData on change
