### PR TITLE
add handling for not given pin (-1 or 255)

### DIFF
--- a/src/sensors/SensorManager.cpp
+++ b/src/sensors/SensorManager.cpp
@@ -94,6 +94,9 @@ void SensorManager::setup() {
 	std::map<std::tuple<int, int, int, int>, I2CPCASensorInterface*> pcaWireInterfaces;
 
 	auto directPin = [&](int pin) {
+		if (pin == 255 || pin == -1) {
+			return static_cast<DirectPinInterface*>(nullptr);
+		}
 		if (!directPinInterfaces.contains(pin)) {
 			auto ptr = new DirectPinInterface(pin);
 			directPinInterfaces[pin] = ptr;


### PR DESCRIPTION
This commit fixes the use case BNO08x whit out a interrupt pin.

This fix reflects the behavior till now where <uint8_t>255 was no int pin. 