### PR TITLE
Initial ADS111x implementation

### DIFF
--- a/lib/bno080/BNO080.h
+++ b/lib/bno080/BNO080.h
@@ -50,7 +50,7 @@
 #include <Wire.h>
 #include <SPI.h>
 #include <memory>
-#include "PinInterface.h"
+#include <PinInterface.h>
 
 //The default I2C address for the BNO080 on the SparkX breakout is 0x4B. 0x4A is also possible.
 #define BNO080_DEFAULT_ADDRESS 0x4B

--- a/lib/bno080/PinInterface.h
+++ b/lib/bno080/PinInterface.h
@@ -1,34 +1,33 @@
 /*
-    SlimeVR Code is placed under the MIT license
-    Copyright (c) 2024 Eiren Rain & SlimeVR contributors
+	SlimeVR Code is placed under the MIT license
+	Copyright (c) 2024 Eiren Rain & SlimeVR contributors
 
-    Permission is hereby granted, free of charge, to any person obtaining a copy
-    of this software and associated documentation files (the "Software"), to deal
-    in the Software without restriction, including without limitation the rights
-    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-    copies of the Software, and to permit persons to whom the Software is
-    furnished to do so, subject to the following conditions:
+	Permission is hereby granted, free of charge, to any person obtaining a copy
+	of this software and associated documentation files (the "Software"), to deal
+	in the Software without restriction, including without limitation the rights
+	to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+	copies of the Software, and to permit persons to whom the Software is
+	furnished to do so, subject to the following conditions:
 
-    The above copyright notice and this permission notice shall be included in
-    all copies or substantial portions of the Software.
+	The above copyright notice and this permission notice shall be included in
+	all copies or substantial portions of the Software.
 
-    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-    THE SOFTWARE.
+	THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+	IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+	FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+	AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+	LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+	OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+	THE SOFTWARE.
 */
 #pragma once
 
 #include <cstdint>
 
-class PinInterface
-{
+class PinInterface {
 public:
-    virtual int digitalRead() = 0;
-    virtual void pinMode(uint8_t mode) = 0;
-    virtual void digitalWrite(uint8_t val) = 0;
-    
+	virtual int digitalRead() = 0;
+	virtual void pinMode(uint8_t mode) = 0;
+	virtual void digitalWrite(uint8_t val) = 0;
+	virtual float analogRead() = 0;
 };

--- a/src/batterymonitor.h
+++ b/src/batterymonitor.h
@@ -27,19 +27,9 @@
 #include <I2Cdev.h>
 #include <i2cscan.h>
 
+#include "consts.h"
 #include "globals.h"
 #include "logging/Logger.h"
-
-#if ESP8266
-#define ADCResolution 1023.0  // ESP8266 has 10bit ADC
-#define ADCVoltageMax 1.0  // ESP8266 input is 1.0 V = 1023.0
-#endif
-#ifndef ADCResolution
-#define ADCResolution 1023.0
-#endif
-#ifndef ADCVoltageMax
-#define ADCVoltageMax 1.0
-#endif
 
 #ifndef BATTERY_SHIELD_RESISTANCE
 #define BATTERY_SHIELD_RESISTANCE 180.0

--- a/src/consts.h
+++ b/src/consts.h
@@ -172,6 +172,21 @@ enum class TrackerType : uint8_t {
 
 #define CURRENT_CONFIGURATION_VERSION 1
 
+#if ESP8266
+#define ADCResolution 1023.0  // ESP8266 has 10bit ADC
+#define ADCVoltageMax 1.0  // ESP8266 input is 1.0 V = 1023.0
+#elif ESP32
+#define ADCResolution 4095.0  // ESP32 has 12bit ADC
+#define ADCVoltageMax 2.5  // ESP32 input is 2.5 V = 4095.0 by default
+#endif
+
+#ifndef ADCResolution
+#define ADCResolution 1023.0
+#endif
+#ifndef ADCVoltageMax
+#define ADCVoltageMax 1.0
+#endif
+
 #include "sensors/sensorposition.h"
 
 #endif  // SLIMEVR_CONSTS_H_

--- a/src/sensorinterface/ADS111xInterface.cpp
+++ b/src/sensorinterface/ADS111xInterface.cpp
@@ -1,0 +1,81 @@
+#include "ADS111xInterface.h"
+
+namespace SlimeVR {
+
+ADS111xInterface::ADS111xInterface(
+	uint8_t sclPin,
+	uint8_t sdaPin,
+	uint8_t drdyPin,
+	uint8_t address,
+	uint8_t channel
+)
+	: wire(sclPin, sdaPin)
+	, address(address)
+	, channel(channel)
+	, drdy(drdyPin) {}
+
+bool ADS111xInterface::init() {
+	wire.swapIn();
+	Wire.beginTransmission(address);
+	Wire.write(Registers::Config::Addr);
+	Registers::Config config{
+		.os = 0b0,  // Don't start read
+		.mux = 0b000,  // Doesn't matter
+		.pga = 0b010,  // Gain (FSR): 2.048V
+		.mode = 0b1,  // Single-shot
+		.dr = 0b100,  // Data-rate: 128 samples per second
+		.compMode = 0b0,  // Traditional comparator
+		.compPol = 0b0,  // Active low drdy
+		.compLat = 0b1,  // Latching drdy
+		.compQue = 0b00,  // Assert drdy after every sample
+	};
+	uint8_t* bytes = reinterpret_cast<uint8_t*>(&config);
+	Wire.write(bytes[1]);
+	Wire.write(bytes[0]);
+	Wire.endTransmission();
+	drdy.pinMode(INPUT_PULLUP);
+	return true;
+}
+
+int ADS111xInterface::digitalRead() { return analogRead() >= 0.5f; }
+
+void ADS111xInterface::pinMode(uint8_t mode) {}
+
+void ADS111xInterface::digitalWrite(uint8_t val) {}
+
+float ADS111xInterface::analogRead() {
+	wire.swapIn();
+	Wire.beginTransmission(address);
+	Wire.write(Registers::Config::Addr);
+	Registers::Config config{
+		.os = 0b1,  // Start read
+		.mux = static_cast<uint8_t>(0b100 | channel),  // Current channel
+		.pga = 0b010,  // Gain (FSR): 2.048V
+		.mode = 0b1,  // Single-shot
+		.dr = 0b100,  // Data-rate: 128 samples per second
+		.compMode = 0b0,  // Traditional comparator
+		.compPol = 0b0,  // Active low drdy
+		.compLat = 0b0,  // Non-latching drdy
+		.compQue = 0b11,  // Comparator disabled
+	};
+	uint8_t* bytes = reinterpret_cast<uint8_t*>(&config);
+	Wire.write(bytes[1]);
+	Wire.write(bytes[0]);
+	Wire.endTransmission();
+
+	// Wait for drdy signal
+	while (drdy.digitalRead())
+		;
+
+	Wire.beginTransmission(address);
+	Wire.write(Registers::ConversionAddr);
+	Wire.endTransmission();
+
+	uint8_t msb = Wire.read();
+	uint8_t lsb = Wire.read();
+
+	uint16_t value = (msb << 8) | lsb;
+	return static_cast<float>(value) / maxValue;
+}
+
+}  // namespace SlimeVR

--- a/src/sensorinterface/DirectPinInterface.cpp
+++ b/src/sensorinterface/DirectPinInterface.cpp
@@ -22,8 +22,18 @@
 */
 #include "DirectPinInterface.h"
 
+#include "../consts.h"
+
 int DirectPinInterface::digitalRead() { return ::digitalRead(_pinNum); }
 
 void DirectPinInterface::pinMode(uint8_t mode) { ::pinMode(_pinNum, mode); }
 
 void DirectPinInterface::digitalWrite(uint8_t val) { ::digitalWrite(_pinNum, val); }
+
+float DirectPinInterface::analogRead() {
+#if ESP8266
+	return static_cast<float>(::analogRead(_pinNum)) / ADCResolution;
+#elif ESP32
+	return static_cast<float>(::analogReadMilliVolts(_pinNum)) / 1000 / ADCVoltageMax;
+#endif
+}

--- a/src/sensorinterface/DirectPinInterface.h
+++ b/src/sensorinterface/DirectPinInterface.h
@@ -24,7 +24,8 @@
 #define _H_DIRECT_PIN_INTERFACE_
 
 #include <Arduino.h>
-#include <PinInterface.h>
+
+#include "PinInterface.h"
 
 /**
  * Pin interface using direct pins
@@ -38,6 +39,7 @@ public:
 	int digitalRead() override final;
 	void pinMode(uint8_t mode) override final;
 	void digitalWrite(uint8_t val) override final;
+	float analogRead() override final;
 
 private:
 	uint8_t _pinNum;

--- a/src/sensorinterface/MCP23X17PinInterface.cpp
+++ b/src/sensorinterface/MCP23X17PinInterface.cpp
@@ -29,3 +29,5 @@ void MCP23X17PinInterface::pinMode(uint8_t mode) { _mcp23x17->pinMode(_pinNum, m
 void MCP23X17PinInterface::digitalWrite(uint8_t val) {
 	_mcp23x17->digitalWrite(_pinNum, val);
 }
+
+float MCP23X17PinInterface::analogRead() { return digitalRead() ? 1.0f : 0.0f; }

--- a/src/sensorinterface/MCP23X17PinInterface.h
+++ b/src/sensorinterface/MCP23X17PinInterface.h
@@ -24,7 +24,8 @@
 #define _H_MCP23X17PinInterface_
 
 #include <Adafruit_MCP23X17.h>
-#include <PinInterface.h>
+
+#include "PinInterface.h"
 
 #define MCP_GPA0 0
 #define MCP_GPA1 1
@@ -55,6 +56,7 @@ public:
 	int digitalRead() override final;
 	void pinMode(uint8_t mode) override final;
 	void digitalWrite(uint8_t val) override final;
+	float analogRead() override final;
 
 private:
 	Adafruit_MCP23X17* _mcp23x17;

--- a/src/sensors/ADCResistanceSensor.cpp
+++ b/src/sensors/ADCResistanceSensor.cpp
@@ -25,15 +25,8 @@
 #include "GlobalVars.h"
 
 void ADCResistanceSensor::motionLoop() {
-#if ESP8266
-	float voltage = ((float)analogRead(m_Pin)) * ADCVoltageMax / ADCResolution;
-	m_Data = m_ResistanceDivider
-		   * (ADCVoltageMax / voltage - 1.0f);  // Convert voltage to resistance
-#elif ESP32
-	float voltage = ((float)analogReadMilliVolts(m_Pin)) / 1000;
-	m_Data = m_ResistanceDivider
-		   * (m_VCC / voltage - 1.0f);  // Convert voltage to resistance
-#endif
+	float value = m_PinInterface->analogRead();
+	m_Data = m_ResistanceDivider * (value - 1.0f);
 }
 
 void ADCResistanceSensor::sendData() {

--- a/src/sensors/bmi160sensor.h
+++ b/src/sensors/bmi160sensor.h
@@ -25,6 +25,7 @@
 #define SENSORS_BMI160SENSOR_H
 
 #include <BMI160.h>
+#include <PinInterface.h>
 
 #include "../motionprocessing/GyroTemperatureCalibrator.h"
 #include "../motionprocessing/RestDetection.h"

--- a/src/sensors/bno055sensor.h
+++ b/src/sensors/bno055sensor.h
@@ -25,6 +25,7 @@
 #define SENSORS_BNO055SENSOR_H
 
 #include <Adafruit_BNO055.h>
+#include <PinInterface.h>
 
 #include "sensor.h"
 

--- a/src/sensors/icm20948sensor.h
+++ b/src/sensors/icm20948sensor.h
@@ -24,6 +24,7 @@
 #define SLIMEVR_ICM20948SENSOR_H_
 
 #include <ICM_20948.h>
+#include <PinInterface.h>
 
 #include "SensorFusionDMP.h"
 #include "sensor.h"

--- a/src/sensors/mpu9250sensor.h
+++ b/src/sensors/mpu9250sensor.h
@@ -25,6 +25,7 @@
 #define SENSORS_MPU9250SENSOR_H
 
 #include <MPU9250_6Axis_MotionApps_V6_12.h>
+#include <PinInterface.h>
 
 #include "logging/Logger.h"
 #include "sensor.h"

--- a/src/sensors/sensor.cpp
+++ b/src/sensors/sensor.cpp
@@ -135,6 +135,8 @@ const char* getIMUNameByType(SensorTypeID imuType) {
 			return "ICM45686";
 		case SensorTypeID::ICM45605:
 			return "ICM45605";
+		case SensorTypeID::ADC_RESISTANCE:
+			return "Flex Sensor";
 		case SensorTypeID::Unknown:
 		case SensorTypeID::Empty:
 			return "UNKNOWN";

--- a/src/sensors/sensor.h
+++ b/src/sensors/sensor.h
@@ -30,7 +30,6 @@
 
 #include <memory>
 
-#include "PinInterface.h"
 #include "configuration/Configuration.h"
 #include "globals.h"
 #include "logging/Logger.h"


### PR DESCRIPTION
Disclaimer: I don't currently have this IC in my hand, and the lack of flex sensor implementation makes it theoretically impossible (or at least very hard) to test. As such this will stay a draft until it's actually working with a flex sensor.

This PR implements the ADS1114 and ADS1115 I2C analogue multiplexers. This is done through the recently created PinInterface virtual class. As a related change, it also implements the analogRead method on the PinInterface and rewrites the existing ADCResistanceSensor to use that instead of a regular pin.

In theory the ADS1113 could also be supported, but the lack of a drdy pin would mean that the config register would need to be polled constantly, which the author of this pull request found particularly ugly.