### PR TITLE
Refactor feature toggling into a class

### DIFF
--- a/src/configuration/Configuration.cpp
+++ b/src/configuration/Configuration.cpp
@@ -31,6 +31,7 @@
 
 #define DIR_CALIBRATIONS "/calibrations"
 #define DIR_TEMPERATURE_CALIBRATIONS "/tempcalibrations"
+#define DIR_TOGGLES "/toggles"
 
 namespace SlimeVR {
 namespace Configuration {
@@ -110,12 +111,20 @@ void Configuration::save() {
 		}
 
 		char path[17];
-		sprintf(path, DIR_CALIBRATIONS "/%d", i);
+		sprintf(path, DIR_CALIBRATIONS "/%zu", i);
 
 		m_Logger.trace("Saving sensor config data for %d", i);
 
 		File file = LittleFS.open(path, "w");
 		file.write((uint8_t*)&config, sizeof(SensorConfig));
+		file.close();
+
+		sprintf(path, DIR_TOGGLES "/%zu", i);
+
+		m_Logger.trace("Saving sensor toggle state for %d", i);
+
+		file = LittleFS.open(path, "w");
+		file.write((uint8_t*)&m_SensorToggles[i], sizeof(SensorToggleState));
 		file.close();
 	}
 
@@ -132,6 +141,7 @@ void Configuration::reset() {
 	LittleFS.format();
 
 	m_Sensors.clear();
+	m_SensorToggles.clear();
 	m_Config.version = 1;
 	save();
 
@@ -158,6 +168,24 @@ void Configuration::setSensor(size_t sensorID, const SensorConfig& config) {
 	}
 
 	m_Sensors[sensorID] = config;
+}
+
+SensorToggleState Configuration::getSensorToggles(size_t sensorId) const {
+	if (sensorId >= m_SensorToggles.size()) {
+		return {};
+	}
+
+	return m_SensorToggles.at(sensorId);
+}
+
+void Configuration::setSensorToggles(size_t sensorId, SensorToggleState state) {
+	size_t currentSensors = m_SensorToggles.size();
+
+	if (sensorId >= currentSensors) {
+		m_SensorToggles.resize(sensorId + 1);
+	}
+
+	m_SensorToggles[sensorId] = state;
 }
 
 void Configuration::eraseSensors() {
@@ -187,7 +215,26 @@ void Configuration::loadSensors() {
 			sensorId
 		);
 
+		if (sensorConfig.type == SensorConfigType::BNO0XX) {
+			SensorToggleState toggles;
+			toggles.setToggle(
+				SensorToggles::MagEnabled,
+				sensorConfig.data.bno0XX.magEnabled
+			);
+			setSensorToggles(sensorId, toggles);
+		}
+
 		setSensor(sensorId, sensorConfig);
+	});
+
+	SlimeVR::Utils::forEachFile(DIR_TOGGLES, [&](SlimeVR::Utils::File f) {
+		SensorToggleState sensorToggleState;
+		f.read((uint8_t*)&sensorToggleState, sizeof(SensorToggleState));
+
+		uint8_t sensorId = strtoul(f.name(), nullptr, 10);
+		m_Logger.debug("Found sensor toggle state at index %d", sensorId);
+
+		setSensorToggles(sensorId, sensorToggleState);
 	});
 }
 

--- a/src/configuration/Configuration.h
+++ b/src/configuration/Configuration.h
@@ -27,6 +27,7 @@
 #include <vector>
 
 #include "../motionprocessing/GyroTemperatureCalibrator.h"
+#include "../sensors/SensorToggles.h"
 #include "DeviceConfig.h"
 #include "logging/Logger.h"
 
@@ -46,6 +47,8 @@ public:
 	size_t getSensorCount() const;
 	SensorConfig getSensor(size_t sensorID) const;
 	void setSensor(size_t sensorID, const SensorConfig& config);
+	SensorToggleState getSensorToggles(size_t sensorId) const;
+	void setSensorToggles(size_t sensorId, SensorToggleState state);
 	void eraseSensors();
 
 	bool loadTemperatureCalibration(
@@ -65,6 +68,7 @@ private:
 
 	DeviceConfig m_Config{};
 	std::vector<SensorConfig> m_Sensors;
+	std::vector<SensorToggleState> m_SensorToggles;
 
 	Logging::Logger m_Logger = Logging::Logger("Configuration");
 };

--- a/src/configuration/SensorConfig.cpp
+++ b/src/configuration/SensorConfig.cpp
@@ -49,7 +49,11 @@ const char* calibrationConfigTypeToString(SensorConfigType type) {
 }
 
 bool SensorConfigBits::operator==(const SensorConfigBits& rhs) const {
-	return magEnabled == rhs.magEnabled && magSupported == rhs.magSupported;
+	return magEnabled == rhs.magEnabled && magSupported == rhs.magSupported
+		&& calibrationEnabled == rhs.calibrationEnabled
+		&& calibrationSupported == rhs.calibrationSupported
+		&& tempGradientCalibrationEnabled == rhs.tempGradientCalibrationEnabled
+		&& tempGradientCalibrationSupported == rhs.tempGradientCalibrationSupported;
 }
 
 bool SensorConfigBits::operator!=(const SensorConfigBits& rhs) const {

--- a/src/configuration/SensorConfig.cpp
+++ b/src/configuration/SensorConfig.cpp
@@ -48,22 +48,13 @@ const char* calibrationConfigTypeToString(SensorConfigType type) {
 	}
 }
 
-// 1st bit specifies if magnetometer is enabled or disabled
-// 2nd bit specifies if magnetometer is supported
-uint16_t configDataToNumber(SensorConfig* sensorConfig, bool magSupported) {
-	uint16_t data = 0;
-	data += magSupported << 1;
-	switch (sensorConfig->type) {
-		case SensorConfigType::BNO0XX: {
-			auto config = &sensorConfig->data.bno0XX;
-			data += config->magEnabled;
-			break;
-		}
-		case SensorConfigType::NONE:
-		default:
-			break;
-	}
-	return data;
+bool SensorConfigBits::operator==(const SensorConfigBits& rhs) const {
+	return magEnabled == rhs.magEnabled && magSupported == rhs.magSupported;
 }
+
+bool SensorConfigBits::operator!=(const SensorConfigBits& rhs) const {
+	return !(*this == rhs);
+}
+
 }  // namespace Configuration
 }  // namespace SlimeVR

--- a/src/configuration/SensorConfig.h
+++ b/src/configuration/SensorConfig.h
@@ -177,7 +177,19 @@ struct SensorConfig {
 	} data;
 };
 
-uint16_t configDataToNumber(SensorConfig* sensorConfig, bool magSupported);
+struct SensorConfigBits {
+	bool magEnabled : 1 = false;
+	bool magSupported : 1 = false;
+
+	// Remove if the above fields exceed a byte, necessary to make the struct 16
+	// bit
+	uint8_t padding;
+
+	bool operator==(const SensorConfigBits& rhs) const;
+	bool operator!=(const SensorConfigBits& rhs) const;
+};
+
+static_assert(sizeof(SensorConfigBits) == 2);
 }  // namespace Configuration
 }  // namespace SlimeVR
 

--- a/src/configuration/SensorConfig.h
+++ b/src/configuration/SensorConfig.h
@@ -178,8 +178,12 @@ struct SensorConfig {
 };
 
 struct SensorConfigBits {
-	bool magEnabled : 1 = false;
-	bool magSupported : 1 = false;
+	bool magEnabled : 1;
+	bool magSupported : 1;
+	bool calibrationEnabled : 1;
+	bool calibrationSupported : 1;
+	bool tempGradientCalibrationEnabled : 1;
+	bool tempGradientCalibrationSupported : 1;
 
 	// Remove if the above fields exceed a byte, necessary to make the struct 16
 	// bit
@@ -189,7 +193,9 @@ struct SensorConfigBits {
 	bool operator!=(const SensorConfigBits& rhs) const;
 };
 
+// If this fails, you forgot to do the above
 static_assert(sizeof(SensorConfigBits) == 2);
+
 }  // namespace Configuration
 }  // namespace SlimeVR
 

--- a/src/network/connection.h
+++ b/src/network/connection.h
@@ -28,6 +28,7 @@
 
 #include <optional>
 
+#include "../configuration/SensorConfig.h"
 #include "featureflags.h"
 #include "globals.h"
 #include "packets.h"
@@ -210,7 +211,7 @@ private:
 	// PACKET_SENSOR_INFO 15
 	void sendSensorInfo(Sensor& sensor);
 
-	void sendAcknowledgeConfigChange(uint8_t sensorId, uint16_t configType);
+	void sendAcknowledgeConfigChange(uint8_t sensorId, SensorToggles configType);
 
 	bool m_Connected = false;
 	SlimeVR::Logging::Logger m_Logger = SlimeVR::Logging::Logger("UDPConnection");
@@ -225,7 +226,8 @@ private:
 	unsigned long m_LastPacketTimestamp;
 
 	SensorStatus m_AckedSensorState[MAX_SENSORS_COUNT] = {SensorStatus::SENSOR_OFFLINE};
-	uint16_t m_AckedSensorConfigData[MAX_SENSORS_COUNT] = {0};
+	SlimeVR::Configuration::SensorConfigBits m_AckedSensorConfigData[MAX_SENSORS_COUNT]
+		= {};
 	bool m_AckedSensorCalibration[MAX_SENSORS_COUNT] = {false};
 	unsigned long m_LastSensorInfoPacketTimestamp = 0;
 

--- a/src/network/packets.h
+++ b/src/network/packets.h
@@ -135,7 +135,7 @@ struct SensorInfoPacket {
 	uint8_t sensorId{};
 	SensorStatus sensorState{};
 	SensorTypeID sensorType{};
-	BigEndian<uint16_t> sensorConfigData{};
+	BigEndian<SlimeVR::Configuration::SensorConfigBits> sensorConfigData{};
 	bool hasCompletedRestCalibration{};
 	SensorPosition sensorPosition{};
 	SensorDataType sensorDataType{};
@@ -174,7 +174,7 @@ struct TemperaturePacket {
 
 struct AcknowledgeConfigChangePacket {
 	uint8_t sensorId{};
-	BigEndian<uint16_t> configType;
+	BigEndian<SensorToggles> configType;
 };
 
 struct FlexDataPacket {
@@ -226,7 +226,7 @@ struct FloatRawImuDataInspectionPacket {
 
 struct SetConfigFlagPacket {
 	uint8_t sensorId{};
-	BigEndian<uint16_t> flagId;
+	BigEndian<SensorToggles> flag;
 	bool newState{};
 };
 

--- a/src/sensors/SensorToggles.cpp
+++ b/src/sensors/SensorToggles.cpp
@@ -1,0 +1,27 @@
+#include "SensorToggles.h"
+
+void SensorToggleState::setToggle(SensorToggles toggle, bool state) {
+	switch (toggle) {
+		case SensorToggles::MagEnabled:
+			magEnabled = state;
+			break;
+		case SensorToggles::CalibrationEnabled:
+			calibrationEnabled = state;
+			break;
+		case SensorToggles::TempGradientCalibrationEnabled:
+			tempGradientCalibrationEnabled = state;
+			break;
+	}
+}
+
+bool SensorToggleState::getToggle(SensorToggles toggle) const {
+	switch (toggle) {
+		case SensorToggles::MagEnabled:
+			return magEnabled;
+		case SensorToggles::CalibrationEnabled:
+			return calibrationEnabled;
+		case SensorToggles::TempGradientCalibrationEnabled:
+			return tempGradientCalibrationEnabled;
+	}
+	return false;
+}

--- a/src/sensors/SensorToggles.h
+++ b/src/sensors/SensorToggles.h
@@ -1,6 +1,6 @@
 /*
 	SlimeVR Code is placed under the MIT license
-	Copyright (c) 2024 Gorbit99 & SlimeVR Contributors
+	Copyright (c) 2025 Gorbit99 & SlimeVR Contributors
 
 	Permission is hereby granted, free of charge, to any person obtaining a copy
 	of this software and associated documentation files (the "Software"), to deal
@@ -23,26 +23,23 @@
 
 #pragma once
 
-#include "CalibrationStep.h"
+#include <cstdint>
 
-namespace SlimeVR::Sensors::RuntimeCalibration {
+#include "../debug.h"
 
-template <typename SensorRawT>
-class NullCalibrationStep : public CalibrationStep<SensorRawT> {
-	using CalibrationStep<SensorRawT>::sensorConfig;
-	using typename CalibrationStep<SensorRawT>::TickResult;
-
-public:
-	explicit NullCalibrationStep(
-		SlimeVR::Configuration::RuntimeCalibrationSensorConfig& sensorConfig
-	)
-		: CalibrationStep<SensorRawT>{sensorConfig} {}
-
-	void start() override final { CalibrationStep<SensorRawT>::start(); }
-
-	TickResult tick() override final { return TickResult::CONTINUE; }
-
-	void cancel() override final {}
+enum class SensorToggles : uint16_t {
+	MagEnabled = 1,
+	CalibrationEnabled = 2,
+	TempGradientCalibrationEnabled = 3,
 };
 
-}  // namespace SlimeVR::Sensors::RuntimeCalibration
+class SensorToggleState {
+public:
+	void setToggle(SensorToggles toggle, bool state);
+	[[nodiscard]] bool getToggle(SensorToggles toggle) const;
+
+private:
+	bool magEnabled = !USE_6_AXIS;
+	bool calibrationEnabled = true;
+	bool tempGradientCalibrationEnabled = true;
+};

--- a/src/sensors/bno080sensor.cpp
+++ b/src/sensors/bno080sensor.cpp
@@ -58,6 +58,8 @@ void BNO080Sensor::motionSetup() {
 
 	this->imu.enableLinearAccelerometer(10);
 
+	toggles = configuration.getSensorToggles(sensorId);
+
 	if (toggles.getToggle(SensorToggles::MagEnabled)) {
 		if ((sensorType == SensorTypeID::BNO085 || sensorType == SensorTypeID::BNO086)
 			&& BNO_USE_ARVR_STABILIZATION) {

--- a/src/sensors/bno080sensor.cpp
+++ b/src/sensors/bno080sensor.cpp
@@ -175,7 +175,7 @@ void BNO080Sensor::motionLoop() {
 		lastReset = 0;
 		lastData = millis();
 
-		if (toggles.getToggle(SensorToggles::MagEnabled)) {
+		if (!toggles.getToggle(SensorToggles::MagEnabled)) {
 			if (imu.hasNewGameQuat())  // New quaternion if context
 			{
 				Quat nRotation;

--- a/src/sensors/bno080sensor.cpp
+++ b/src/sensors/bno080sensor.cpp
@@ -60,7 +60,7 @@ void BNO080Sensor::motionSetup() {
 
 	toggles = configuration.getSensorToggles(sensorId);
 
-	if (toggles.getToggle(SensorToggles::MagEnabled)) {
+	if (!toggles.getToggle(SensorToggles::MagEnabled)) {
 		if ((sensorType == SensorTypeID::BNO085 || sensorType == SensorTypeID::BNO086)
 			&& BNO_USE_ARVR_STABILIZATION) {
 			imu.enableARVRStabilizedGameRotationVector(10);

--- a/src/sensors/bno080sensor.h
+++ b/src/sensors/bno080sensor.h
@@ -60,7 +60,7 @@ public:
 	void sendData() override final;
 	void startCalibration(int calibrationType) override final;
 	SensorStatus getSensorState() override final;
-	void setFlag(uint16_t flagId, bool state) override final;
+	bool isFlagSupported(SensorToggles toggle) const final;
 
 protected:
 	// forwarding constructor

--- a/src/sensors/sensor.cpp
+++ b/src/sensors/sensor.cpp
@@ -96,6 +96,12 @@ SlimeVR::Configuration::SensorConfigBits Sensor::getSensorConfigData() {
 	return SlimeVR::Configuration::SensorConfigBits{
 		.magEnabled = toggles.getToggle(SensorToggles::MagEnabled),
 		.magSupported = isFlagSupported(SensorToggles::MagEnabled),
+		.calibrationEnabled = toggles.getToggle(SensorToggles::CalibrationEnabled),
+		.calibrationSupported = isFlagSupported(SensorToggles::CalibrationEnabled),
+		.tempGradientCalibrationEnabled
+		= toggles.getToggle(SensorToggles::TempGradientCalibrationEnabled),
+		.tempGradientCalibrationSupported
+		= isFlagSupported(SensorToggles::TempGradientCalibrationEnabled),
 	};
 }
 

--- a/src/sensors/sensor.cpp
+++ b/src/sensors/sensor.cpp
@@ -90,13 +90,13 @@ void Sensor::resetTemperatureCalibrationState() {
 	printTemperatureCalibrationUnsupported();
 };
 
-uint16_t Sensor::getSensorConfigData() {
+SlimeVR::Configuration::SensorConfigBits Sensor::getSensorConfigData() {
 	SlimeVR::Configuration::SensorConfig sensorConfig
 		= configuration.getSensor(sensorId);
-	return SlimeVR::Configuration::configDataToNumber(
-		&sensorConfig,
-		magStatus != MagnetometerStatus::MAG_NOT_SUPPORTED
-	);
+	return SlimeVR::Configuration::SensorConfigBits{
+		.magEnabled = toggles.getToggle(SensorToggles::MagEnabled),
+		.magSupported = isFlagSupported(SensorToggles::MagEnabled),
+	};
 }
 
 const char* getIMUNameByType(SensorTypeID imuType) {
@@ -147,4 +147,15 @@ void Sensor::markRestCalibrationComplete(bool completed) {
 		m_Logger.info("Rest calibration completed");
 	}
 	restCalibrationComplete = completed;
+}
+
+void Sensor::setFlag(SensorToggles toggle, bool state) {
+	assert(isFlagSupported(toggle));
+
+	toggles.setToggle(toggle, state);
+
+	configuration.setSensorToggles(sensorId, toggles);
+	configuration.save();
+
+	motionSetup();
 }

--- a/src/sensors/sensor.h
+++ b/src/sensors/sensor.h
@@ -31,6 +31,7 @@
 #include <memory>
 
 #include "PinInterface.h"
+#include "SensorToggles.h"
 #include "configuration/Configuration.h"
 #include "globals.h"
 #include "logging/Logger.h"
@@ -87,19 +88,20 @@ public:
 	virtual void printDebugTemperatureCalibrationState();
 	virtual void resetTemperatureCalibrationState();
 	virtual void saveTemperatureCalibration();
-	virtual void setFlag(uint16_t flagId, bool state){};
-	virtual uint16_t getSensorConfigData();
 	bool isWorking() { return working; };
 	bool getHadData() const { return hadData; };
 	bool isValid() { return m_hwInterface != nullptr; };
-	bool isMagEnabled() { return magStatus == MagnetometerStatus::MAG_ENABLED; };
 	uint8_t getSensorId() { return sensorId; };
 	SensorTypeID getSensorType() { return sensorType; };
-	MagnetometerStatus getMagStatus() { return magStatus; };
 	const Vector3& getAcceleration() { return acceleration; };
 	const Quat& getFusedRotation() { return fusedRotation; };
 	bool hasNewDataToSend() { return newFusedRotation || newAcceleration; };
 	inline bool hasCompletedRestCalibration() { return restCalibrationComplete; }
+	void setFlag(SensorToggles toggle, bool state);
+	[[nodiscard]] virtual bool isFlagSupported(SensorToggles toggle) const {
+		return false;
+	}
+	SlimeVR::Configuration::SensorConfigBits getSensorConfigData();
 
 	virtual SensorDataType getDataType() {
 		return SensorDataType::SENSOR_DATATYPE_ROTATION;
@@ -122,7 +124,6 @@ protected:
 	bool working = false;
 	bool hadData = false;
 	uint8_t calibrationAccuracy = 0;
-	MagnetometerStatus magStatus = MagnetometerStatus::MAG_NOT_SUPPORTED;
 	Quat sensorOffset;
 
 	bool newFusedRotation = false;
@@ -133,6 +134,8 @@ protected:
 	Vector3 acceleration{};
 
 	SensorPosition m_SensorPosition = SensorPosition::POSITION_NO;
+
+	SensorToggleState toggles;
 
 	void markRestCalibrationComplete(bool completed = true);
 

--- a/src/sensors/sensor.h
+++ b/src/sensors/sensor.h
@@ -48,12 +48,6 @@ enum class SensorStatus : uint8_t {
 	SENSOR_ERROR = 2
 };
 
-enum class MagnetometerStatus : uint8_t {
-	MAG_NOT_SUPPORTED = 0,
-	MAG_DISABLED = 1,
-	MAG_ENABLED = 2,
-};
-
 class Sensor {
 public:
 	Sensor(

--- a/src/sensors/softfusion/CalibrationBase.h
+++ b/src/sensors/softfusion/CalibrationBase.h
@@ -43,7 +43,8 @@ public:
 		SlimeVR::Logging::Logger& logger,
 		float TempTs,
 		float AScale,
-		float GScale
+		float GScale,
+		SensorToggleState& toggles
 	)
 		: fusion{fusion}
 		, sensor{sensor}
@@ -51,7 +52,8 @@ public:
 		, logger{logger}
 		, TempTs{TempTs}
 		, AScale{AScale}
-		, GScale{GScale} {}
+		, GScale{GScale}
+		, toggles{toggles} {}
 
 	static constexpr bool HasMotionlessCalib
 		= requires(IMU& i) { typename IMU::MotionlessCalibrationData; };
@@ -117,6 +119,7 @@ protected:
 	float TempTs;
 	float AScale;
 	float GScale;
+	SensorToggleState& toggles;
 };
 
 }  // namespace SlimeVR::Sensor

--- a/src/sensors/softfusion/SoftfusionCalibration.h
+++ b/src/sensors/softfusion/SoftfusionCalibration.h
@@ -105,6 +105,22 @@ public:
 
 	void assignCalibration(const Configuration::SensorConfig& sensorCalibration) final {
 		calibration = sensorCalibration.data.sfusion;
+
+		if (!toggles.getToggle(SensorToggles::CalibrationEnabled)) {
+			for (size_t i = 0; i < 3; i++) {
+				calibration.A_B[i] = 0;
+				calibration.A_Ainv[i][0] = 0;
+				calibration.A_Ainv[i][1] = 0;
+				calibration.A_Ainv[i][2] = 0;
+				calibration.M_B[i] = 0;
+				calibration.M_Ainv[i][0] = 0;
+				calibration.M_Ainv[i][1] = 0;
+				calibration.M_Ainv[i][2] = 0;
+				calibration.G_off[i] = 0;
+				calibration.G_Sens[i] = 0;
+			}
+		}
+
 		Base::recalcFusion();
 	}
 

--- a/src/sensors/softfusion/SoftfusionCalibration.h
+++ b/src/sensors/softfusion/SoftfusionCalibration.h
@@ -50,9 +50,10 @@ public:
 		SlimeVR::Logging::Logger& logger,
 		float TempTs,
 		float AScale,
-		float GScale
+		float GScale,
+		SensorToggleState& toggles
 	)
-		: Base{fusion, sensor, sensorId, logger, TempTs, AScale, GScale} {
+		: Base{fusion, sensor, sensorId, logger, TempTs, AScale, GScale, toggles} {
 		calibration.T_Ts = TempTs;
 	}
 
@@ -169,6 +170,10 @@ private:
 	}
 
 	void calibrateGyroOffset(const Base::ReturnLastFn& eatSamplesReturnLast) {
+		if (!toggles.getToggle(SensorToggles::CalibrationEnabled)) {
+			return;
+		}
+
 		// Wait for sensor to calm down before calibration
 		logger.info(
 			"Put down the device and wait for baseline gyro reading calibration (%d "
@@ -224,6 +229,10 @@ private:
 	}
 
 	void calibrateAccel(const Base::EatSamplesFn& eatSamplesForSeconds) {
+		if (!toggles.getToggle(SensorToggles::CalibrationEnabled)) {
+			return;
+		}
+
 		auto magneto = std::make_unique<MagnetoCalibration>();
 		logger.info(
 			"Put the device into 6 unique orientations (all sides), leave it still and "
@@ -433,6 +442,7 @@ private:
 	using Base::logger;
 	using Base::sensor;
 	using Base::sensorId;
+	using Base::toggles;
 };
 
 }  // namespace SlimeVR::Sensor

--- a/src/sensors/softfusion/runtimecalibration/RuntimeCalibration.h
+++ b/src/sensors/softfusion/runtimecalibration/RuntimeCalibration.h
@@ -397,11 +397,13 @@ private:
 	SampleRateCalibrationStep<RawSensorT> sampleRateCalibrationStep{calibration};
 	MotionlessCalibrationStep<IMU, RawSensorT> motionlessCalibrationStep{
 		calibration,
-		sensor};
+		sensor
+	};
 	GyroBiasCalibrationStep<RawSensorT> gyroBiasCalibrationStep{calibration};
 	AccelBiasCalibrationStep<RawSensorT> accelBiasCalibrationStep{
 		calibration,
-		static_cast<float>(Base::AScale)};
+		static_cast<float>(Base::AScale)
+	};
 	NullCalibrationStep<RawSensorT> nullCalibrationStep{calibration};
 
 	CalibrationStep<RawSensorT>* currentStep = &nullCalibrationStep;

--- a/src/sensors/softfusion/runtimecalibration/RuntimeCalibration.h
+++ b/src/sensors/softfusion/runtimecalibration/RuntimeCalibration.h
@@ -47,6 +47,7 @@ public:
 	static constexpr bool HasUpsideDownCalibration = false;
 
 	using Base = Sensor::CalibrationBase<IMU, RawSensorT, RawVectorT>;
+	using Self = RuntimeCalibrator<IMU, RawSensorT, RawVectorT>;
 
 	RuntimeCalibrator(
 		SensorFusionRestDetect& fusion,
@@ -55,9 +56,10 @@ public:
 		Logging::Logger& logger,
 		float TempTs,
 		float AScale,
-		float GScale
+		float GScale,
+		SensorToggleState& toggles
 	)
-		: Base(fusion, imu, sensorId, logger, TempTs, AScale, GScale) {
+		: Base{fusion, imu, sensorId, logger, TempTs, AScale, GScale, toggles} {
 		calibration.T_Ts = TempTs;
 		activeCalibration.T_Ts = TempTs;
 	}
@@ -74,7 +76,22 @@ public:
 	void assignCalibration(const Configuration::SensorConfig& sensorCalibration) final {
 		calibration = sensorCalibration.data.runtimeCalibration;
 		activeCalibration = sensorCalibration.data.runtimeCalibration;
-		calculateZROChange();
+		if (!toggles.getToggle(SensorToggles::CalibrationEnabled)) {
+			activeCalibration.gyroPointsCalibrated = 0;
+			for (size_t i = 0; i < 3; i++) {
+				activeCalibration.G_off1[i] = 0;
+				activeCalibration.G_off2[i] = 0;
+			}
+
+			for (size_t i = 0; i < 3; i++) {
+				activeCalibration.accelCalibrated[i] = false;
+				activeCalibration.A_off[i] = 0;
+			}
+		} else {
+			calculateZROChange();
+		}
+
+		currentStep = &nullCalibrationStep;
 	}
 
 	void begin() final {
@@ -380,13 +397,11 @@ private:
 	SampleRateCalibrationStep<RawSensorT> sampleRateCalibrationStep{calibration};
 	MotionlessCalibrationStep<IMU, RawSensorT> motionlessCalibrationStep{
 		calibration,
-		sensor
-	};
+		sensor};
 	GyroBiasCalibrationStep<RawSensorT> gyroBiasCalibrationStep{calibration};
 	AccelBiasCalibrationStep<RawSensorT> accelBiasCalibrationStep{
 		calibration,
-		static_cast<float>(Base::AScale)
-	};
+		static_cast<float>(Base::AScale)};
 	NullCalibrationStep<RawSensorT> nullCalibrationStep{calibration};
 
 	CalibrationStep<RawSensorT>* currentStep = &nullCalibrationStep;
@@ -429,6 +444,7 @@ private:
 	using Base::logger;
 	using Base::sensor;
 	using Base::sensorId;
+	using Base::toggles;
 };
 
 }  // namespace SlimeVR::Sensors::RuntimeCalibration

--- a/src/sensors/softfusion/softfusionsensor.h
+++ b/src/sensors/softfusion/softfusionsensor.h
@@ -418,7 +418,8 @@ public:
 		getDefaultTempTs(),
 		AScale,
 		GScale,
-		toggles};
+		toggles
+	};
 
 	SensorStatus m_status = SensorStatus::SENSOR_OFFLINE;
 	uint32_t m_lastPollTime = micros();

--- a/src/sensors/softfusion/softfusionsensor.h
+++ b/src/sensors/softfusion/softfusionsensor.h
@@ -401,6 +401,11 @@ public:
 		);
 	}
 
+	bool isFlagSupported(SensorToggles toggle) const final {
+		return toggle == SensorToggles::CalibrationEnabled
+			|| toggle == SensorToggles::TempGradientCalibrationEnabled;
+	}
+
 	SensorStatus getSensorState() final { return m_status; }
 
 	SensorFusionRestDetect m_fusion;

--- a/src/sensors/softfusion/softfusionsensor.h
+++ b/src/sensors/softfusion/softfusionsensor.h
@@ -321,6 +321,8 @@ public:
 		SlimeVR::Configuration::SensorConfig sensorCalibration
 			= configuration.getSensor(sensorId);
 
+		toggles = configuration.getSensorToggles(sensorId);
+
 		// If no compatible calibration data is found, the calibration data will just be
 		// zero-ed out
 		if (calibrator.calibrationMatches(sensorCalibration)) {

--- a/src/sensors/softfusion/softfusionsensor.h
+++ b/src/sensors/softfusion/softfusionsensor.h
@@ -144,10 +144,12 @@ class SoftFusionSensor : public Sensor {
 												* (1.0 / imu::TemperatureSensitivity);
 
 			lastReadTemperature = scaledTemperature;
-			tempGradientCalculator.feedSample(
-				lastReadTemperature,
-				calibrator.getTempTimestep()
-			);
+			if (toggles.getToggle(SensorToggles::TempGradientCalibrationEnabled)) {
+				tempGradientCalculator.feedSample(
+					lastReadTemperature,
+					calibrator.getTempTimestep()
+				);
+			}
 
 			calibrator.provideTempSample(lastReadTemperature);
 		}
@@ -251,15 +253,21 @@ public:
 					= now
 					- (tempElapsed - static_cast<uint32_t>(DirectTempReadTs * 1e6));
 				lastReadTemperature = m_sensor.getDirectTemp();
+
 				calibrator.provideTempSample(lastReadTemperature);
-				tempGradientCalculator.feedSample(
-					lastReadTemperature,
-					DirectTempReadTs
-				);
+
+				if (toggles.getToggle(SensorToggles::TempGradientCalibrationEnabled)) {
+					tempGradientCalculator.feedSample(
+						lastReadTemperature,
+						DirectTempReadTs
+					);
+				}
 			}
 		}
 
-		tempGradientCalculator.tick();
+		if (toggles.getToggle(SensorToggles::TempGradientCalibrationEnabled)) {
+			tempGradientCalculator.tick();
+		}
 
 		constexpr uint32_t targetPollIntervalMicros = 6000;
 		uint32_t elapsed = now - m_lastPollTime;
@@ -402,8 +410,8 @@ public:
 		m_Logger,
 		getDefaultTempTs(),
 		AScale,
-		GScale
-	};
+		GScale,
+		toggles};
 
 	SensorStatus m_status = SensorStatus::SENSOR_OFFLINE;
 	uint32_t m_lastPollTime = micros();


### PR DESCRIPTION
This PR refactors feature toggling (previously only used for the magnetometer) to be more generic and easily extensible. Alongside this change it also introduces toggles for softfusion calibration and temperature gradient calibration.

Seemingly works for the magnetometer on the BNO085, the rest would likely need server implementation.