### PR TITLE
Fix BNO SensorState when i2c disconnects while working

### DIFF
--- a/src/sensors/bno080sensor.cpp
+++ b/src/sensors/bno080sensor.cpp
@@ -319,9 +319,9 @@ void BNO080Sensor::motionLoop() {
 }
 
 SensorStatus BNO080Sensor::getSensorState() {
-	return lastReset > 0 ? SensorStatus::SENSOR_ERROR
-		 : isWorking()   ? SensorStatus::SENSOR_OK
-						 : SensorStatus::SENSOR_OFFLINE;
+	return ((lastReset > 0) || (!isWorking() && hadData)) ? SensorStatus::SENSOR_ERROR
+		 : isWorking()                                    ? SensorStatus::SENSOR_OK
+					   : SensorStatus::SENSOR_OFFLINE;
 }
 
 void BNO080Sensor::sendData() {


### PR DESCRIPTION
The BNO08x Sensor did not change its state when a i2c timeout is occurred, like losing connection to the extension.