### PR TITLE
Implement SensorInterfaceManager

### DIFF
--- a/lib/bno080/PinInterface.h
+++ b/lib/bno080/PinInterface.h
@@ -27,8 +27,8 @@
 class PinInterface
 {
 public:
-    virtual int digitalRead() = 0;
-    virtual void pinMode(uint8_t mode) = 0;
-    virtual void digitalWrite(uint8_t val) = 0;
-    
+	virtual bool init() { return true; };
+	virtual int digitalRead() = 0;
+	virtual void pinMode(uint8_t mode) = 0;
+	virtual void digitalWrite(uint8_t val) = 0;
 };

--- a/src/sensorinterface/I2CPCAInterface.cpp
+++ b/src/sensorinterface/I2CPCAInterface.cpp
@@ -22,7 +22,10 @@
 */
 #include "I2CPCAInterface.h"
 
-void SlimeVR::I2CPCASensorInterface::init() { m_Wire.init(); }
+bool SlimeVR::I2CPCASensorInterface::init() {
+	m_Wire.init();
+	return true;
+}
 
 void SlimeVR::I2CPCASensorInterface::swapIn() {
 	m_Wire.swapIn();

--- a/src/sensorinterface/I2CPCAInterface.h
+++ b/src/sensorinterface/I2CPCAInterface.h
@@ -43,7 +43,7 @@ public:
 		, m_Channel(channel){};
 	~I2CPCASensorInterface(){};
 
-	void init() override final;
+	bool init() override final;
 	void swapIn() override final;
 
 protected:

--- a/src/sensorinterface/I2CWireSensorInterface.h
+++ b/src/sensorinterface/I2CWireSensorInterface.h
@@ -45,7 +45,7 @@ public:
 		, _sclPin(sclpin){};
 	~I2CWireSensorInterface(){};
 
-	void init() override final {}
+	bool init() override final { return true; }
 	void swapIn() override final { swapI2C(_sclPin, _sdaPin); }
 	void disconnect() { disconnectI2C(); }
 

--- a/src/sensorinterface/SensorInterface.h
+++ b/src/sensorinterface/SensorInterface.h
@@ -34,7 +34,7 @@ public:
 class EmptySensorInterface : public SensorInterface {
 public:
 	EmptySensorInterface(){};
-	bool init() override final{};
+	bool init() override final { return true; };
 	void swapIn() override final{};
 };
 }  // namespace SlimeVR

--- a/src/sensorinterface/SensorInterface.h
+++ b/src/sensorinterface/SensorInterface.h
@@ -27,14 +27,14 @@
 namespace SlimeVR {
 class SensorInterface {
 public:
-	virtual void init() = 0;
+	virtual bool init() = 0;
 	virtual void swapIn() = 0;
 };
 
 class EmptySensorInterface : public SensorInterface {
 public:
 	EmptySensorInterface(){};
-	void init() override final{};
+	bool init() override final{};
 	void swapIn() override final{};
 };
 }  // namespace SlimeVR

--- a/src/sensorinterface/SensorInterfaceManager.h
+++ b/src/sensorinterface/SensorInterfaceManager.h
@@ -1,0 +1,84 @@
+/*
+	SlimeVR Code is placed under the MIT license
+	Copyright (c) 2025 Gorbit99 & SlimeVR Contributors
+
+	Permission is hereby granted, free of charge, to any person obtaining a copy
+	of this software and associated documentation files (the "Software"), to deal
+	in the Software without restriction, including without limitation the rights
+	to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+	copies of the Software, and to permit persons to whom the Software is
+	furnished to do so, subject to the following conditions:
+
+	The above copyright notice and this permission notice shall be included in
+	all copies or substantial portions of the Software.
+
+	THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+	IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+	FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+	AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+	LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+	OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+	THE SOFTWARE.
+*/
+
+#pragma once
+
+#include <functional>
+#include <map>
+#include <optional>
+
+#include "DirectPinInterface.h"
+#include "I2CPCAInterface.h"
+#include "I2CWireSensorInterface.h"
+#include "MCP23X17PinInterface.h"
+
+namespace SlimeVR {
+
+class SensorInterfaceManager {
+private:
+	template <typename InterfaceClass, typename... Args>
+	struct SensorInterface {
+		explicit SensorInterface(
+			std::function<bool(Args...)> validate = [](Args...) { return true; }
+		)
+			: validate{validate} {}
+
+		InterfaceClass* get(Args... args) {
+			if (validate && !validate(args...)) {
+				return static_cast<InterfaceClass*>(nullptr);
+			}
+
+			auto key = std::make_tuple(args...);
+
+			if (!cache.contains(key)) {
+				auto ptr = new InterfaceClass(args...);
+				if (!ptr->init()) {
+					cache[key] = nullptr;
+					return nullptr;
+				}
+
+				cache[key] = ptr;
+			}
+			return cache[key];
+		}
+
+	private:
+		std::map<std::tuple<Args...>, InterfaceClass*> cache;
+		std::function<bool(Args...)> validate;
+	};
+
+public:
+	inline auto& directPinInterface() { return directPinInterfaces; }
+	inline auto& mcpPinInterface() { return mcpPinInterfaces; }
+	inline auto& i2cWireInterface() { return i2cWireInterfaces; }
+	inline auto& pcaWireInterface() { return pcaWireInterfaces; }
+
+private:
+	SensorInterface<DirectPinInterface, int> directPinInterfaces{
+		[](int pin) { return pin != 255 && pin != -1; }};
+	SensorInterface<MCP23X17PinInterface, int> mcpPinInterfaces;
+	SensorInterface<I2CWireSensorInterface, int, int> i2cWireInterfaces;
+	SensorInterface<I2CPCASensorInterface, int, int, int, int> pcaWireInterfaces;
+};
+
+}  // namespace SlimeVR

--- a/src/sensorinterface/SensorInterfaceManager.h
+++ b/src/sensorinterface/SensorInterfaceManager.h
@@ -74,8 +74,9 @@ public:
 	inline auto& pcaWireInterface() { return pcaWireInterfaces; }
 
 private:
-	SensorInterface<DirectPinInterface, int> directPinInterfaces{
-		[](int pin) { return pin != 255 && pin != -1; }};
+	SensorInterface<DirectPinInterface, int> directPinInterfaces{[](int pin) {
+		return pin != 255 && pin != -1;
+	}};
 	SensorInterface<MCP23X17PinInterface, int> mcpPinInterfaces;
 	SensorInterface<I2CWireSensorInterface, int, int> i2cWireInterfaces;
 	SensorInterface<I2CPCASensorInterface, int, int, int, int> pcaWireInterfaces;

--- a/src/sensors/SensorManager.cpp
+++ b/src/sensors/SensorManager.cpp
@@ -32,8 +32,7 @@
 #include "icm20948sensor.h"
 #include "mpu6050sensor.h"
 #include "mpu9250sensor.h"
-#include "sensorinterface/I2CPCAInterface.h"
-#include "sensorinterface/MCP23X17PinInterface.h"
+#include "sensorinterface/SensorInterfaceManager.h"
 #include "sensors/softfusion/SoftfusionCalibration.h"
 #include "sensors/softfusion/runtimecalibration/RuntimeCalibration.h"
 #include "softfusion/drivers/bmi270.h"
@@ -88,47 +87,8 @@ using SoftFusionICM45605 = SoftFusionSensor<
 	SFCALIBRATOR>;
 
 void SensorManager::setup() {
-	std::map<int, DirectPinInterface*> directPinInterfaces;
-	std::map<int, MCP23X17PinInterface*> mcpPinInterfaces;
-	std::map<std::tuple<int, int>, I2CWireSensorInterface*> i2cWireInterfaces;
-	std::map<std::tuple<int, int, int, int>, I2CPCASensorInterface*> pcaWireInterfaces;
+	SensorInterfaceManager interfaceManager;
 
-	auto directPin = [&](int pin) {
-		if (pin == 255 || pin == -1) {
-			return static_cast<DirectPinInterface*>(nullptr);
-		}
-		if (!directPinInterfaces.contains(pin)) {
-			auto ptr = new DirectPinInterface(pin);
-			directPinInterfaces[pin] = ptr;
-		}
-		return directPinInterfaces[pin];
-	};
-
-	auto mcpPin = [&](int pin) {
-		if (!mcpPinInterfaces.contains(pin)) {
-			auto ptr = new MCP23X17PinInterface(&m_MCP, pin);
-			mcpPinInterfaces[pin] = ptr;
-		}
-		return mcpPinInterfaces[pin];
-	};
-
-	auto directWire = [&](int scl, int sda) {
-		auto pair = std::make_tuple(scl, sda);
-		if (!i2cWireInterfaces.contains(pair)) {
-			auto ptr = new I2CWireSensorInterface(scl, sda);
-			i2cWireInterfaces[pair] = ptr;
-		}
-		return i2cWireInterfaces[pair];
-	};
-
-	auto pcaWire = [&](int scl, int sda, int addr, int ch) {
-		auto pair = std::make_tuple(scl, sda, addr, ch);
-		if (!pcaWireInterfaces.contains(pair)) {
-			auto ptr = new I2CPCASensorInterface(scl, sda, addr, ch);
-			pcaWireInterfaces[pair] = ptr;
-		}
-		return pcaWireInterfaces[pair];
-	};
 	uint8_t sensorID = 0;
 	uint8_t activeSensorCount = 0;
 	if (m_MCP.begin_I2C()) {
@@ -136,10 +96,11 @@ void SensorManager::setup() {
 	}
 
 #define NO_PIN nullptr
-#define DIRECT_PIN(pin) directPin(pin)
-#define DIRECT_WIRE(scl, sda) directWire(scl, sda)
-#define MCP_PIN(pin) mcpPin(pin)
-#define PCA_WIRE(scl, sda, addr, ch) pcaWire(scl, sda, addr, ch)
+#define DIRECT_PIN(pin) interfaceManager.directPinInterface().get(pin)
+#define DIRECT_WIRE(scl, sda) interfaceManager.i2cWireInterface().get(scl, sda)
+#define MCP_PIN(pin) interfaceManager.mcpPinInterface().get(pin)
+#define PCA_WIRE(scl, sda, addr, ch) \
+	interfaceManager.pcaWireInterface().get(scl, sda, addr, ch);
 
 #define SENSOR_DESC_ENTRY(ImuType, ...)                            \
 	{                                                              \


### PR DESCRIPTION
This PR aims to simplify the code around sensor interface creation by generalizing it and pulling into a single manager class. This should make adding new sensor and pin interfaces only require adding a couple more lines instead of having to reimplement the caches from zero every time.