### PR TITLE
More ICM45 fixes

### DIFF
--- a/src/sensors/SensorManager.h
+++ b/src/sensors/SensorManager.h
@@ -114,6 +114,9 @@ private:
 		if (I2CSCAN::hasDevOnBus(i2cAddress)) {
 			m_Logger
 				.trace("Sensor %d found at address 0x%02X", sensorID + 1, i2cAddress);
+		} else if (I2CSCAN::hasDevOnBus(i2cAddress)) { // scan again because ICM45* may not respond on first I2C transaction
+			m_Logger
+				.trace("Sensor %d found at address 0x%02X on second scan", sensorID + 1, i2cAddress);
 		} else {
 			if (!optional) {
 				m_Logger.error(

--- a/src/sensors/SensorManager.h
+++ b/src/sensors/SensorManager.h
@@ -114,9 +114,14 @@ private:
 		if (I2CSCAN::hasDevOnBus(i2cAddress)) {
 			m_Logger
 				.trace("Sensor %d found at address 0x%02X", sensorID + 1, i2cAddress);
-		} else if (I2CSCAN::hasDevOnBus(i2cAddress)) { // scan again because ICM45* may not respond on first I2C transaction
-			m_Logger
-				.trace("Sensor %d found at address 0x%02X on second scan", sensorID + 1, i2cAddress);
+		} else if (I2CSCAN::hasDevOnBus(i2cAddress
+				   )) {  // scan again because ICM45* may not respond on first I2C
+						 // transaction
+			m_Logger.trace(
+				"Sensor %d found at address 0x%02X on second scan",
+				sensorID + 1,
+				i2cAddress
+			);
 		} else {
 			if (!optional) {
 				m_Logger.error(

--- a/src/sensors/softfusion/drivers/icm45base.h
+++ b/src/sensors/softfusion/drivers/icm45base.h
@@ -142,7 +142,7 @@ struct ICM45Base {
 		TempCall&& processTemperatureSample
 	) {
 		const auto fifo_packets = i2c.readReg16(BaseRegs::FifoCount);
-		const auto fifo_bytes = fifo_packets * FullFifoEntrySize - 1;
+		const auto fifo_bytes = (fifo_packets - 1) * FullFifoEntrySize;
 
 		std::array<uint8_t, FullFifoEntrySize * 8> read_buffer;  // max 8 readings
 		const auto bytes_to_read = std::min(

--- a/src/sensors/softfusion/drivers/icm45base.h
+++ b/src/sensors/softfusion/drivers/icm45base.h
@@ -142,7 +142,7 @@ struct ICM45Base {
 		TempCall&& processTemperatureSample
 	) {
 		const auto fifo_packets = i2c.readReg16(BaseRegs::FifoCount);
-		const auto fifo_bytes = fifo_packets * FullFifoEntrySize;
+		const auto fifo_bytes = fifo_packets * FullFifoEntrySize - 1;
 
 		std::array<uint8_t, FullFifoEntrySize * 8> read_buffer;  // max 8 readings
 		const auto bytes_to_read = std::min(


### PR DESCRIPTION
This PR fixes 2 more issues with ICM45*: 

- SensorManager.h now scans for an IMU twice, since ICM45* [may not respond on the first I2C transaction](https://github.com/tdk-invn-oss/motion.mcu.icm45686.driver/blob/fb4275febca58596774cee0dc0654cdc058a640c/icm45686/imu/inv_imu_driver.c#L66C5-L69). No other IMUs have this issue, so the 2nd scan will never run and therefore have any effect on them.
- ICM45* will never fully empty the FIFO, instead leaving one packet at all times. Not sure why, but fully emptying it will eventually cause FIFO corruption. This might be documented in AN-000364, just like the first issue, but no one's found this document anywhere on the web yet.