### PR TITLE
fix SensorStateUpdate

### DIFF
--- a/src/network/connection.cpp
+++ b/src/network/connection.cpp
@@ -514,9 +514,11 @@ void Connection::maybeRequestFeatureFlags() {
 }
 
 bool Connection::isSensorStateUpdated(int i, std::unique_ptr<Sensor>& sensor) {
-	return m_AckedSensorState[i] != sensor->getSensorState()
-		|| m_AckedSensorCalibration[i] != sensor->hasCompletedRestCalibration()
-		|| m_AckedSensorConfigData[i] != sensor->getSensorConfigData();
+	return (m_AckedSensorState[i] != sensor->getSensorState()
+			|| m_AckedSensorCalibration[i] != sensor->hasCompletedRestCalibration()
+			|| m_AckedSensorConfigData[i] != sensor->getSensorConfigData())
+		&& sensor->getSensorType() != SensorTypeID::Unknown
+		&& sensor->getSensorType() != SensorTypeID::Empty;
 }
 
 void Connection::searchForServer() {


### PR DESCRIPTION
After a reboot of the tracker the optional sensor did show up on the server too. This is because a sensor packet was sent from all sensors including empty and unknown. This should hopefully fix the issue.
It is a fast fix. It probably would be better to move all this check to sensor. If the sensor has a change, set a flag, and reset the flag if the function gets called.