### PR TITLE
[ICM45*] Fix processing bad samples and stack overflow panics

### DIFF
--- a/src/sensors/softfusion/drivers/icm45base.h
+++ b/src/sensors/softfusion/drivers/icm45base.h
@@ -141,31 +141,41 @@ struct ICM45Base {
 		GyroCall&& processGyroSample,
 		TempCall&& processTemperatureSample
 	) {
-		const auto fifo_packets = i2c.readReg16(BaseRegs::FifoCount);
-		const auto fifo_bytes = (fifo_packets - 1) * FullFifoEntrySize;
+		// Allocate statically so that it does not take up stack space, which
+		// can result in stack overflow and panic
+		constexpr size_t MaxReadings = 8;
+		static std::array<uint8_t, FullFifoEntrySize * MaxReadings> read_buffer;
 
-		std::array<uint8_t, FullFifoEntrySize * 8> read_buffer;  // max 8 readings
-		const auto bytes_to_read = std::min(
-									   static_cast<size_t>(read_buffer.size()),
-									   static_cast<size_t>(fifo_bytes)
-								   )
-								 / FullFifoEntrySize * FullFifoEntrySize;
+		constexpr int16_t InvalidReading = -32768;
+
+		size_t fifo_packets = i2c.readReg16(BaseRegs::FifoCount);
+		fifo_packets = std::min(fifo_packets, MaxReadings);
+
+		size_t bytes_to_read = fifo_packets * FullFifoEntrySize;
 		i2c.readBytes(BaseRegs::FifoData, bytes_to_read, read_buffer.data());
+
 		for (auto i = 0u; i < bytes_to_read; i += FullFifoEntrySize) {
+			uint8_t header = read_buffer[i];
+			bool has_gyro = header & (1 << 5);
+			bool has_accel = header & (1 << 6);
+
 			FifoEntryAligned entry;
 			memcpy(
 				&entry,
 				&read_buffer[i + 0x1],
 				sizeof(FifoEntryAligned)
 			);  // skip fifo header
-			const int32_t gyroData[3]{
-				static_cast<int32_t>(entry.gyro[0]) << 4 | (entry.lsb[0] & 0xf),
-				static_cast<int32_t>(entry.gyro[1]) << 4 | (entry.lsb[1] & 0xf),
-				static_cast<int32_t>(entry.gyro[2]) << 4 | (entry.lsb[2] & 0xf),
-			};
-			processGyroSample(gyroData, GyrTs);
 
-			if (entry.accel[0] != -32768) {
+			if (has_gyro && entry.gyro[0] != InvalidReading) {
+				const int32_t gyroData[3]{
+					static_cast<int32_t>(entry.gyro[0]) << 4 | (entry.lsb[0] & 0xf),
+					static_cast<int32_t>(entry.gyro[1]) << 4 | (entry.lsb[1] & 0xf),
+					static_cast<int32_t>(entry.gyro[2]) << 4 | (entry.lsb[2] & 0xf),
+				};
+				processGyroSample(gyroData, GyrTs);
+			}
+
+			if (has_accel && entry.accel[0] != InvalidReading) {
 				const int32_t accelData[3]{
 					static_cast<int32_t>(entry.accel[0]) << 4
 						| (static_cast<int32_t>((entry.lsb[0]) & 0xf0) >> 4),


### PR DESCRIPTION
1. At startup, we were receiving invalid samples from the IMU and passing it to VQF. This causes huge initial rotations and accelerations that takes time for VQF to eliminate.

   Fix is to check the header to see if the data is present. Also had to add a check for invalid gyro samples even though it is present.

2. During play, the tracker would rarely go haywire and jump into a random position. I suspect this is caused by a stack overflow, which causes the tracker to panic. Combined with problem (1), whenever the tracker restarts, it would send huge rotations and accelerations to the server. This causes the jump.

   Fix is to make the read_buffer static, so that it's reserved on the BSS segment instead of the stack. I noticed this because I was getting panics when I tried to increase the size of the read buffer, or declared some new stack variables.

After implementing these two fixes, rotation and acceleration are stable at startup, and I am able to make modifications to the icm45base code without randomly encountering panics.