### PR TITLE
Fix defines compatibility

### DIFF
--- a/src/sensors/SensorBuilder.h
+++ b/src/sensors/SensorBuilder.h
@@ -109,7 +109,7 @@ public:
 		SensorInterface* sensorInterface,
 		bool optional,
 		PinInterface* intPin,
-		int extraParam
+		int extraParam = 0
 	);
 
 	std::unique_ptr<::Sensor> buildSensorDynamically(
@@ -120,7 +120,7 @@ public:
 		SensorInterface* sensorInterface,
 		bool optional,
 		PinInterface* intPin,
-		int extraParam
+		int extraParam = 0
 	);
 
 	SensorTypeID findSensorType(
@@ -130,7 +130,7 @@ public:
 		SensorInterface* sensorInterface,
 		bool optional,
 		PinInterface* intPin,
-		int extraParam
+		int extraParam = 0
 	);
 
 	SensorTypeID findSensorType(
@@ -140,7 +140,7 @@ public:
 		SensorInterface* sensorInterface,
 		bool optional,
 		PinInterface* intPin,
-		int extraParam
+		int extraParam = 0
 	);
 
 	template <typename ImuType>


### PR DESCRIPTION
The rework during the SPI implementation left out a default value for a define, which causes incompatibility with the firmware tool. Adding this back fixes the issue.