### PR TITLE
Reduce Temperature Pooling for ICM45 series IMUs

### DIFF
--- a/src/sensors/softfusion/drivers/icm45base.h
+++ b/src/sensors/softfusion/drivers/icm45base.h
@@ -39,7 +39,7 @@ struct ICM45Base {
 
 	static constexpr float GyrTs = 1.0 / 409.6;
 	static constexpr float AccTs = 1.0 / 102.4;
-	static constexpr float TempTs = 1.0 / 409.6;
+	static constexpr float TempTs = 1.0 / 204.8; // was 409.6, reduced for lowering CPU pressure.
 
 	static constexpr float MagTs = 1.0 / 100;
 


### PR DESCRIPTION
This change is to free up CPU time on EPS82xx series development boards for DIY trackers using dual ICM45 series IMUs.
The Accelerometer was previously reduced, however I found that the temp reporting was almost instantaneous when it didn't need to be, and also was partly to blame for trackers spinning when violently shaken, or other somewhat vigorous motions (including tapping).