### PR TITLE
Tostring fix

### DIFF
--- a/lib/bno080/PinInterface.h
+++ b/lib/bno080/PinInterface.h
@@ -23,6 +23,7 @@
 #pragma once
 
 #include <cstdint>
+#include <string>
 
 class PinInterface
 {
@@ -31,4 +32,6 @@ public:
 	virtual int digitalRead() = 0;
 	virtual void pinMode(uint8_t mode) = 0;
 	virtual void digitalWrite(uint8_t val) = 0;
+
+	[[nodiscard]] virtual std::string toString() const = 0;
 };

--- a/src/logging/Logger.h
+++ b/src/logging/Logger.h
@@ -27,12 +27,12 @@ public:
 
 	void setTag(const char* tag);
 
-	void trace(const char* str, ...) const;
-	void debug(const char* str, ...) const;
-	void info(const char* str, ...) const;
-	void warn(const char* str, ...) const;
-	void error(const char* str, ...) const;
-	void fatal(const char* str, ...) const;
+	void trace(const char* str, ...) const __attribute__((format(printf, 2, 3)));
+	void debug(const char* str, ...) const __attribute__((format(printf, 2, 3)));
+	void info(const char* str, ...) const __attribute__((format(printf, 2, 3)));
+	void warn(const char* str, ...) const __attribute__((format(printf, 2, 3)));
+	void error(const char* str, ...) const __attribute__((format(printf, 2, 3)));
+	void fatal(const char* str, ...) const __attribute__((format(printf, 2, 3)));
 
 	template <typename T>
 	inline void traceArray(const char* str, const T* array, size_t size) const {

--- a/src/sensorinterface/DirectPinInterface.h
+++ b/src/sensorinterface/DirectPinInterface.h
@@ -39,6 +39,11 @@ public:
 	void pinMode(uint8_t mode) override final;
 	void digitalWrite(uint8_t val) override final;
 
+	[[nodiscard]] std::string toString() const final {
+		using namespace std::string_literals;
+		return "Pin("s + std::to_string(_pinNum) + ")";
+	}
+
 private:
 	uint8_t _pinNum;
 };

--- a/src/sensorinterface/I2CPCAInterface.h
+++ b/src/sensorinterface/I2CPCAInterface.h
@@ -46,6 +46,11 @@ public:
 	bool init() override final;
 	void swapIn() override final;
 
+	[[nodiscard]] std::string toString() const final {
+		using namespace std::string_literals;
+		return "PCAWire("s + std::to_string(m_Channel) + ")";
+	}
+
 protected:
 	I2CWireSensorInterface m_Wire;
 	uint8_t m_Address;

--- a/src/sensorinterface/I2CWireSensorInterface.h
+++ b/src/sensorinterface/I2CWireSensorInterface.h
@@ -49,6 +49,12 @@ public:
 	void swapIn() override final { swapI2C(_sclPin, _sdaPin); }
 	void disconnect() { disconnectI2C(); }
 
+	[[nodiscard]] std::string toString() const final {
+		using namespace std::string_literals;
+		return "Wire("s + std::to_string(_sclPin) + ": " + std::to_string(_sdaPin)
+			 + ")"s;
+	}
+
 protected:
 	uint8_t _sdaPin;
 	uint8_t _sclPin;

--- a/src/sensorinterface/MCP23X17PinInterface.h
+++ b/src/sensorinterface/MCP23X17PinInterface.h
@@ -56,6 +56,11 @@ public:
 	void pinMode(uint8_t mode) override final;
 	void digitalWrite(uint8_t val) override final;
 
+	[[nodiscard]] std::string toString() const final {
+		using namespace std::string_literals;
+		return "MCPPin("s + std::to_string(_pinNum) + ")";
+	}
+
 private:
 	Adafruit_MCP23X17* _mcp23x17;
 	uint8_t _pinNum;

--- a/src/sensorinterface/SensorInterface.h
+++ b/src/sensorinterface/SensorInterface.h
@@ -24,11 +24,14 @@
 #ifndef SENSORINTERFACE_H
 #define SENSORINTERFACE_H
 
+#include <string>
+
 namespace SlimeVR {
 class SensorInterface {
 public:
 	virtual bool init() = 0;
 	virtual void swapIn() = 0;
+	[[nodiscard]] virtual std::string toString() const;
 };
 
 class EmptySensorInterface : public SensorInterface {
@@ -36,6 +39,8 @@ public:
 	EmptySensorInterface(){};
 	bool init() override final { return true; };
 	void swapIn() override final{};
+
+	[[nodiscard]] std::string toString() const final { return "None"; }
 };
 }  // namespace SlimeVR
 

--- a/src/sensors/SensorBuilder.h
+++ b/src/sensors/SensorBuilder.h
@@ -158,7 +158,7 @@ public:
 						address=%s, rotation=%f,\n\
 						interface=%s, int=%s, extraParam=%d, optional=%d",
 			sensorID,
-			imuInterface.toString(),
+			imuInterface.toString().c_str(),
 			rotation,
 			sensorInterface,
 			intPin,
@@ -178,14 +178,14 @@ public:
 				m_Manager->m_Logger.error(
 					"Mandatory sensor %d not found at address %s",
 					sensorID + 1,
-					imuInterface.toString()
+					imuInterface.toString().c_str()
 				);
 				return std::make_unique<ErroneousSensor>(sensorID, ImuType::TypeID);
 			} else {
 				m_Manager->m_Logger.debug(
 					"Optional sensor %d not found at address %s",
 					sensorID + 1,
-					imuInterface.toString()
+					imuInterface.toString().c_str()
 				);
 				return std::make_unique<EmptySensor>(sensorID);
 			}
@@ -194,7 +194,7 @@ public:
 		m_Manager->m_Logger.trace(
 			"Sensor %d found at address %s",
 			sensorID + 1,
-			imuInterface.toString()
+			imuInterface.toString().c_str()
 		);
 
 		sensor = std::make_unique<ImuType>(

--- a/src/sensors/SensorBuilder.h
+++ b/src/sensors/SensorBuilder.h
@@ -160,8 +160,8 @@ public:
 			sensorID,
 			imuInterface.toString().c_str(),
 			rotation,
-			sensorInterface,
-			intPin,
+			sensorInterface->toString().c_str(),
+			intPin->toString().c_str(),
 			extraParam,
 			optional
 		);

--- a/src/sensors/softfusion/softfusionsensor.h
+++ b/src/sensors/softfusion/softfusionsensor.h
@@ -164,7 +164,7 @@ class SoftFusionSensor : public Sensor {
 #endif
 			auto currentSecondsRemaining = (targetDelay - millis()) / 1000;
 			if (currentSecondsRemaining != lastSecondsRemaining) {
-				m_Logger.info("%d...", currentSecondsRemaining + 1);
+				m_Logger.info("%ld...", currentSecondsRemaining + 1);
 				lastSecondsRemaining = currentSecondsRemaining;
 			}
 			m_sensor.bulkRead(
@@ -430,8 +430,7 @@ public:
 		getDefaultTempTs(),
 		AScale,
 		GScale,
-		toggles
-	};
+		toggles};
 
 	SensorStatus m_status = SensorStatus::SENSOR_OFFLINE;
 	uint32_t m_lastPollTime = micros();

--- a/src/sensors/softfusion/softfusionsensor.h
+++ b/src/sensors/softfusion/softfusionsensor.h
@@ -430,7 +430,8 @@ public:
 		getDefaultTempTs(),
 		AScale,
 		GScale,
-		toggles};
+		toggles
+	};
 
 	SensorStatus m_status = SensorStatus::SENSOR_OFFLINE;
 	uint32_t m_lastPollTime = micros();

--- a/src/serial/serialcommands.cpp
+++ b/src/serial/serialcommands.cpp
@@ -318,7 +318,7 @@ void cmdGet(CmdParser* parser) {
 					WiFi.SSID(i).length(),
 					WiFi.SSID(i).c_str(),
 					WiFi.RSSI(i),
-					getEncryptionTypeName(WiFi.encryptionType(i))
+					getEncryptionTypeName(WiFi.encryptionType(i)).c_str()
 				);
 			}
 			WiFi.scanDelete();
@@ -402,7 +402,7 @@ void cmdTemperatureCalibration(CmdParser* parser) {
 	logger.info("Note:");
 	logger.info(
 		"  Temperature calibration config saves automatically when calibration percent "
-		"is at 100%"
+		"is at 100%%"
 	);
 }
 


### PR DESCRIPTION
I noticed that when the tracker serial console was reporting garbage data for the imu interface, because an std::string was passed to a %s format parameter expecing a cstring. I fixed this up and also added the format attribute to the logging methods, which tells gcc (and clang) that they are using the printf style format strings as params. Also fixed up any other warnings generated by this.