### PR TITLE
Fancy wifi provisioning

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -52,7 +52,7 @@ build_flags =
 
 build_unflags = -Os -std=gnu++11 -std=gnu++17
 
-; If you want to enable OTA Updates, uncomment and set OTA password here and in credentials.h
+; If you want to enable OTA Updates, uncomment and set OTA password here and in credentials.cpp
 ; You can set upload_port to device's ip after it's set up for the first time
 ; Use the same password in SlimeVR Server to let it OTA Update the device
 ;upload_protocol = espota

--- a/src/GlobalVars.h
+++ b/src/GlobalVars.h
@@ -31,6 +31,8 @@
 #include "configuration/Configuration.h"
 #include "network/connection.h"
 #include "network/manager.h"
+#include "network/wifihandler.h"
+#include "network/wifiprovisioning.h"
 #include "sensors/SensorManager.h"
 #include "status/StatusManager.h"
 
@@ -42,5 +44,7 @@ extern SlimeVR::Sensors::SensorManager sensorManager;
 extern SlimeVR::Network::Manager networkManager;
 extern SlimeVR::Network::Connection networkConnection;
 extern BatteryMonitor battery;
+extern SlimeVR::WiFiNetwork wifiNetwork;
+extern SlimeVR::WifiProvisioning wifiProvisioning;
 
 #endif

--- a/src/credentials.cpp
+++ b/src/credentials.cpp
@@ -1,6 +1,5 @@
-/*
-	SlimeVR Code is placed under the MIT license
-	Copyright (c) 2022 TheDevMinerTV
+/* SlimeVR Code is placed under the MIT license
+	Copyright (c) 2025 Gorbit99 & SlimeVR Contributors
 
 	Permission is hereby granted, free of charge, to any person obtaining a copy
 	of this software and associated documentation files (the "Software"), to deal
@@ -21,30 +20,9 @@
 	THE SOFTWARE.
 */
 
-#ifndef GLOBALVARS_H
-#define GLOBALVARS_H
+const char* otaPassword
+	= "SlimeVR-OTA";  // YOUR OTA PASSWORD HERE, LEAVE EMPTY TO DISABLE OTA UPDATES
 
-#include <arduino-timer.h>
-
-#include "LEDManager.h"
-#include "batterymonitor.h"
-#include "configuration/Configuration.h"
-#include "network/connection.h"
-#include "network/manager.h"
-#include "network/wifihandler.h"
-#include "network/wifiprovisioning.h"
-#include "sensors/SensorManager.h"
-#include "status/StatusManager.h"
-
-extern Timer<> globalTimer;
-extern SlimeVR::LEDManager ledManager;
-extern SlimeVR::Status::StatusManager statusManager;
-extern SlimeVR::Configuration::Configuration configuration;
-extern SlimeVR::Sensors::SensorManager sensorManager;
-extern SlimeVR::Network::Manager networkManager;
-extern SlimeVR::Network::Connection networkConnection;
-extern BatteryMonitor battery;
-extern SlimeVR::WiFiNetwork wifiNetwork;
-extern SlimeVR::WiFiProvisioning wifiProvisioning;
-
-#endif
+const char* provisioningPassword
+	= "SlimeVR-Provisioning";  // YOUR PROVISIONING PASSWORD HERE, LEAVE EMPTY TO
+							   // DISABLE PROVISIONING

--- a/src/credentials.h
+++ b/src/credentials.h
@@ -30,7 +30,8 @@
 // firmware. We don't have any hardware buttons for the user to confirm
 // OTA update, so this is the best way we have.
 // OTA is allowed only for the first 60 seconds after device startup.
-const char* otaPassword
-	= "SlimeVR-OTA";  // YOUR OTA PASSWORD HERE, LEAVE EMPTY TO DISABLE OTA UPDATES
+extern const char* otaPassword;
+
+extern const char* provisioningPassword;
 
 #endif  // SLIMEVR_CREDENTIALS_H_

--- a/src/defines.h
+++ b/src/defines.h
@@ -28,7 +28,7 @@
 // Set parameters of IMU and board used
 #define IMU IMU_AUTO
 #define SECOND_IMU IMU_AUTO
-#define BOARD BOARD_SLIMEVR_V1_2
+#define BOARD BOARD_SLIMEVR
 #define IMU_ROTATION DEG_270
 #define SECOND_IMU_ROTATION DEG_270
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -43,7 +43,7 @@ SlimeVR::Configuration::Configuration configuration;
 SlimeVR::Network::Manager networkManager;
 SlimeVR::Network::Connection networkConnection;
 SlimeVR::WiFiNetwork wifiNetwork;
-SlimeVR::WifiProvisioning wifiProvisioning;
+SlimeVR::WiFiProvisioning wifiProvisioning;
 
 #if DEBUG_MEASURE_SENSOR_TIME_TAKEN
 SlimeVR::Debugging::TimeTakenMeasurer sensorMeasurer{"Sensors"};

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -42,6 +42,8 @@ SlimeVR::Status::StatusManager statusManager;
 SlimeVR::Configuration::Configuration configuration;
 SlimeVR::Network::Manager networkManager;
 SlimeVR::Network::Connection networkConnection;
+SlimeVR::WiFiNetwork wifiNetwork;
+SlimeVR::WifiProvisioning wifiProvisioning;
 
 #if DEBUG_MEASURE_SENSOR_TIME_TAKEN
 SlimeVR::Debugging::TimeTakenMeasurer sensorMeasurer{"Sensors"};

--- a/src/network/connection.cpp
+++ b/src/network/connection.cpp
@@ -763,6 +763,21 @@ void Connection::update() {
 			configuration.save();
 			break;
 		}
+
+		case ReceivePacketType::WiFiProvisioning: {
+			WiFiProvisioningPacket wifiProvisioningPacket{};
+			memcpy(
+				&wifiProvisioningPacket,
+				m_Packet + 12,
+				sizeof(WiFiProvisioningPacket)
+			);
+
+			if (wifiProvisioningPacket.start) {
+				wifiProvisioning.startProvisioning();
+			} else {
+				wifiProvisioning.stopProvisioning();
+			}
+		}
 	}
 }
 

--- a/src/network/manager.cpp
+++ b/src/network/manager.cpp
@@ -27,14 +27,14 @@
 namespace SlimeVR {
 namespace Network {
 
-void Manager::setup() { ::WiFiNetwork::setUp(); }
+void Manager::setup() { wifiNetwork.setUp(); }
 
 void Manager::update() {
-	WiFiNetwork::upkeep();
+	wifiNetwork.upkeep();
 
 	auto wasConnected = m_IsConnected;
 
-	m_IsConnected = ::WiFiNetwork::isConnected();
+	m_IsConnected = wifiNetwork.isConnected();
 
 	if (!m_IsConnected) {
 		return;

--- a/src/network/packets.h
+++ b/src/network/packets.h
@@ -68,6 +68,7 @@ enum class ReceivePacketType : uint8_t {
 	SensorInfo = 15,
 	FeatureFlags = 22,
 	SetConfigFlag = 25,
+	WiFiProvisioning = 26,
 };
 
 enum class InspectionPacketType : uint8_t {
@@ -228,6 +229,10 @@ struct SetConfigFlagPacket {
 	uint8_t sensorId{};
 	BigEndian<SensorToggles> flag;
 	bool newState{};
+};
+
+struct WiFiProvisioningPacket {
+	bool start;
 };
 
 #pragma pack(pop)

--- a/src/network/packets.h
+++ b/src/network/packets.h
@@ -68,7 +68,7 @@ enum class ReceivePacketType : uint8_t {
 	SensorInfo = 15,
 	FeatureFlags = 22,
 	SetConfigFlag = 25,
-	WiFiProvisioning = 26,
+	WiFiProvisioning = 27,
 };
 
 enum class InspectionPacketType : uint8_t {

--- a/src/network/wifihandler.cpp
+++ b/src/network/wifihandler.cpp
@@ -22,29 +22,20 @@
 */
 #include "GlobalVars.h"
 #include "globals.h"
-#include "logging/Logger.h"
 #if !ESP8266
 #include "esp_wifi.h"
 #endif
 
-unsigned long lastWifiReportTime = 0;
-unsigned long wifiConnectionTimeout = millis();
-bool isWifiConnected = false;
-uint8_t wifiState = SLIME_WIFI_NOT_SETUP;
-bool hadWifi = false;
-unsigned long last_rssi_sample = 0;
+namespace SlimeVR {
 
-// TODO: Cleanup with proper classes
-SlimeVR::Logging::Logger wifiHandlerLogger("WiFiHandler");
-
-void reportWifiError() {
+void WiFiNetwork::reportWifiProgress() {
 	if (lastWifiReportTime + 1000 < millis()) {
 		lastWifiReportTime = millis();
 		Serial.print(".");
 	}
 }
 
-void setStaticIPIfDefined() {
+void WiFiNetwork::setStaticIPIfDefined() {
 #ifdef WIFI_USE_STATICIP
 	const IPAddress ip(WIFI_STATIC_IP);
 	const IPAddress gateway(WIFI_STATIC_GATEWAY);
@@ -53,43 +44,35 @@ void setStaticIPIfDefined() {
 #endif
 }
 
-bool WiFiNetwork::isConnected() { return isWifiConnected; }
+bool WiFiNetwork::isConnected() const {
+	return wifiState == WiFiReconnectionStatus::Success;
+}
 
 void WiFiNetwork::setWiFiCredentials(const char* SSID, const char* pass) {
-	stopProvisioning();
-	setStaticIPIfDefined();
-	WiFi.begin(SSID, pass);
+	wifiProvisioning.stopProvisioning();
+	WiFi.persistent(true);
+	tryConnecting(false, SSID, pass);
+	retriedOnG = false;
 	// Reset state, will get back into provisioning if can't connect
 	hadWifi = false;
-	wifiState = SLIME_WIFI_SERVER_CRED_ATTEMPT;
-	wifiConnectionTimeout = millis();
+	wifiState = WiFiReconnectionStatus::ServerCredAttempt;
 }
 
 IPAddress WiFiNetwork::getAddress() { return WiFi.localIP(); }
 
 void WiFiNetwork::setUp() {
+	// Don't need to save the already saved credentials or the hardcoded ones
+	WiFi.persistent(false);
 	wifiHandlerLogger.info("Setting up WiFi");
-	WiFi.persistent(true);
 	WiFi.mode(WIFI_STA);
-#if ESP8266
-#if USE_ATTENUATION
-	WiFi.setOutputPower(20.0 - ATTENUATION_N);
-#endif
-	WiFi.setPhyMode(WIFI_PHY_MODE_11N);
-#endif
 	WiFi.hostname("SlimeVR FBT Tracker");
 	wifiHandlerLogger.info(
 		"Loaded credentials for SSID '%s' and pass length %d",
 		WiFi.SSID().c_str(),
 		WiFi.psk().length()
 	);
-	setStaticIPIfDefined();
-	wl_status_t status = WiFi.begin(
-	);  // Should connect to last used access point, see
-		// https://arduino-esp8266.readthedocs.io/en/latest/esp8266wifi/station-class.html#begin
-	wifiHandlerLogger.debug("Status: %d", status);
-	wifiState = SLIME_WIFI_SAVED_ATTEMPT;
-	wifiConnectionTimeout = millis();
+
+	trySavedCredentials();
 
 #if ESP8266
 #if POWERSAVING_MODE == POWER_SAVING_NONE
@@ -121,156 +104,228 @@ void WiFiNetwork::setUp() {
 #endif
 }
 
-void onConnected() {
-	WiFiNetwork::stopProvisioning();
+void WiFiNetwork::onConnected() {
+	wifiState = WiFiReconnectionStatus::Success;
+	wifiProvisioning.stopProvisioning();
 	statusManager.setStatus(SlimeVR::Status::WIFI_CONNECTING, false);
-	isWifiConnected = true;
 	hadWifi = true;
 	wifiHandlerLogger.info(
 		"Connected successfully to SSID '%s', IP address %s",
 		WiFi.SSID().c_str(),
 		WiFi.localIP().toString().c_str()
 	);
+	// Reset it, in case we just connected with server creds
+	WiFi.persistent(false);
 }
 
-uint8_t WiFiNetwork::getWiFiState() { return wifiState; }
+WiFiNetwork::WiFiReconnectionStatus WiFiNetwork::getWiFiState() { return wifiState; }
 
 void WiFiNetwork::upkeep() {
-	upkeepProvisioning();
-	if (WiFi.status() != WL_CONNECTED) {
-		if (isWifiConnected) {
-			wifiHandlerLogger.warn("Connection to WiFi lost, reconnecting...");
-			isWifiConnected = false;
+	wifiProvisioning.upkeepProvisioning();
+	if (WiFi.status() == WL_CONNECTED) {
+		if (!isConnected()) {
+			onConnected();
+			return;
 		}
-		statusManager.setStatus(SlimeVR::Status::WIFI_CONNECTING, true);
-		reportWifiError();
-		if (wifiConnectionTimeout + 11000 < millis()) {
-			switch (wifiState) {
-				case SLIME_WIFI_NOT_SETUP:  // Wasn't set up
-					return;
-				case SLIME_WIFI_SAVED_ATTEMPT:  // Couldn't connect with first set of
-												// credentials
-#if ESP8266
-					// Try again but with 11G but only if there are credentials,
-					// otherwise we just waste time before switching to hardcoded
-					// credentials.
-					if (WiFi.SSID().length() > 0) {
-#if USE_ATTENUATION
-						WiFi.setOutputPower(20.0 - ATTENUATION_G);
-#endif
-						WiFi.setPhyMode(WIFI_PHY_MODE_11G);
-						setStaticIPIfDefined();
-						WiFi.begin();
-						wifiConnectionTimeout = millis();
-						wifiHandlerLogger.error(
-							"Can't connect from saved credentials, status: %d.",
-							WiFi.status()
-						);
-						wifiHandlerLogger.debug(
-							"Trying saved credentials with PHY Mode G..."
-						);
-					} else {
-						wifiHandlerLogger.debug(
-							"Skipping PHY Mode G attempt on 0-length SSID..."
-						);
-					}
-#endif
-					wifiState = SLIME_WIFI_SAVED_G_ATTEMPT;
-					return;
-				case SLIME_WIFI_SAVED_G_ATTEMPT:  // Couldn't connect with first set of
-												  // credentials with PHY Mode G
-#if defined(WIFI_CREDS_SSID) && defined(WIFI_CREDS_PASSWD)
-												  // Try hardcoded credentials now
-#if ESP8266
-#if USE_ATTENUATION
-					WiFi.setOutputPower(20.0 - ATTENUATION_N);
-#endif
-					WiFi.setPhyMode(WIFI_PHY_MODE_11N);
-#endif
-					setStaticIPIfDefined();
-					WiFi.begin(WIFI_CREDS_SSID, WIFI_CREDS_PASSWD);
-					wifiConnectionTimeout = millis();
-					wifiHandlerLogger.error(
-						"Can't connect from saved credentials, status: %d.",
-						WiFi.status()
-					);
-					wifiHandlerLogger.debug("Trying hardcoded credentials...");
-#endif
-					wifiState = SLIME_WIFI_HARDCODE_ATTEMPT;
-					return;
-				case SLIME_WIFI_HARDCODE_ATTEMPT:  // Couldn't connect with second set
-												   // of credentials
-#if defined(WIFI_CREDS_SSID) && defined(WIFI_CREDS_PASSWD) && ESP8266
-												   // Try hardcoded credentials again,
-												   // but with PHY Mode G
-#if USE_ATTENUATION
-					WiFi.setOutputPower(20.0 - ATTENUATION_G);
-#endif
-					WiFi.setPhyMode(WIFI_PHY_MODE_11G);
-					setStaticIPIfDefined();
-					WiFi.begin(WIFI_CREDS_SSID, WIFI_CREDS_PASSWD);
-					wifiConnectionTimeout = millis();
-					wifiHandlerLogger.error(
-						"Can't connect from saved credentials, status: %d.",
-						WiFi.status()
-					);
-					wifiHandlerLogger.debug(
-						"Trying hardcoded credentials with WiFi PHY Mode G..."
-					);
-#endif
-					wifiState = SLIME_WIFI_HARDCODE_G_ATTEMPT;
-					return;
-				case SLIME_WIFI_SERVER_CRED_ATTEMPT:  // Couldn't connect with
-													  // server-sent credentials.
-#if ESP8266
-													  // Try again silently but with 11G
-#if USE_ATTENUATION
-					WiFi.setOutputPower(20.0 - ATTENUATION_G);
-#endif
-					WiFi.setPhyMode(WIFI_PHY_MODE_11G);
-					setStaticIPIfDefined();
-					WiFi.begin();
-					wifiConnectionTimeout = millis();
-					wifiState = SLIME_WIFI_SERVER_CRED_G_ATTEMPT;
-#endif
-					return;
-				case SLIME_WIFI_HARDCODE_G_ATTEMPT:  // Couldn't connect with second set
-													 // of credentials with PHY Mode G.
-				case SLIME_WIFI_SERVER_CRED_G_ATTEMPT:  // Or if couldn't connect with
-														// server-sent credentials
-// Return to the default PHY Mode N.
-#if ESP8266
-#if USE_ATTENUATION
-					WiFi.setOutputPower(20.0 - ATTENUATION_N);
-#endif
-					WiFi.setPhyMode(WIFI_PHY_MODE_11N);
-#endif
-					// Start smart config
-					if (!hadWifi && !WiFi.smartConfigDone()
-						&& wifiConnectionTimeout + 11000 < millis()) {
-						if (WiFi.status() != WL_IDLE_STATUS) {
-							wifiHandlerLogger.error(
-								"Can't connect from any credentials, status: %d.",
-								WiFi.status()
-							);
-							wifiConnectionTimeout = millis();
-						}
-						startProvisioning();
-					}
-					return;
-			}
-		}
-		return;
-	}
-	if (!isWifiConnected) {
-		onConnected();
-		return;
-	} else {
-		if (millis() - last_rssi_sample >= 2000) {
-			last_rssi_sample = millis();
+
+		if (millis() - lastRssiSample >= 2000) {
+			lastRssiSample = millis();
 			uint8_t signalStrength = WiFi.RSSI();
 			networkConnection.sendSignalStrength(signalStrength);
 		}
+		return;
 	}
-	return;
+
+	if (isConnected()) {
+		wifiHandlerLogger.warn("Connection to WiFi lost, reconnecting...");
+		wifiState = WiFiReconnectionStatus::SavedAttempt;
+	}
+
+	statusManager.setStatus(SlimeVR::Status::WIFI_CONNECTING, true);
+	reportWifiProgress();
+	if (millis() - wifiConnectionTimeout
+			< static_cast<uint32_t>(WiFiTimeoutSeconds * 1000)
+		&& WiFi.status() == WL_DISCONNECTED) {
+		return;
+	}
+
+	switch (wifiState) {
+		case WiFiReconnectionStatus::NotSetup:  // Wasn't set up
+			return;
+		case WiFiReconnectionStatus::SavedAttempt:  // Couldn't connect with
+													// first set of
+													// credentials
+			if (!trySavedCredentials()) {
+				tryHardcodedCredentials();
+			}
+			return;
+		case WiFiReconnectionStatus::HardcodeAttempt:  // Couldn't connect with
+													   // second set of credentials
+			if (!tryHardcodedCredentials()) {
+				wifiState = WiFiReconnectionStatus::Failed;
+			}
+			return;
+		case WiFiReconnectionStatus::ServerCredAttempt:  // Couldn't connect with
+														 // server-sent credentials.
+			if (!tryServerCredentials()) {
+				wifiState = WiFiReconnectionStatus::Failed;
+			}
+			return;
+		case WiFiReconnectionStatus::Failed:  // Couldn't connect with second set of
+											  // credentials or server credentials
+// Return to the default PHY Mode N.
+#if ESP8266
+			if constexpr (USE_ATTENUATION) {
+				WiFi.setOutputPower(20.0 - ATTENUATION_N);
+			}
+			WiFi.setPhyMode(WIFI_PHY_MODE_11N);
+#endif
+			// Start smart config
+			if (!hadWifi && !WiFi.smartConfigDone()
+				&& millis() - wifiConnectionTimeout
+					   >= static_cast<uint32_t>(WiFiTimeoutSeconds * 1000)) {
+				if (WiFi.status() != WL_IDLE_STATUS) {
+					wifiHandlerLogger.error(
+						"Can't connect from any credentials, status: %d, reason: %s.",
+						WiFi.status(),
+						statusToReasonString(WiFi.status())
+					);
+					wifiConnectionTimeout = millis();
+				}
+				wifiProvisioning.startProvisioning();
+			}
+			return;
+	}
 }
+
+const char* WiFiNetwork::statusToReasonString(wl_status_t status) {
+	switch (status) {
+		case WL_DISCONNECTED:
+			return "Timeout";
+#ifdef ESP8266
+		case WL_WRONG_PASSWORD:
+			return "Wrong password";
+		case WL_CONNECT_FAILED:
+			return "Connection failed";
+#elif ESP32
+		case WL_CONNECT_FAILED:
+			return "Wrong password";
+#endif
+
+		case WL_NO_SSID_AVAIL:
+			return "SSID not found";
+		default:
+			return "Unknown";
+	}
+}
+
+void WiFiNetwork::showConnectionAttemptFailed(const char* type) const {
+	wifiHandlerLogger.error(
+		"Can't connect from %s credentials, status: %d, reason: %s.",
+		type,
+		WiFi.status(),
+		statusToReasonString(WiFi.status())
+	);
+}
+
+bool WiFiNetwork::trySavedCredentials() {
+	if (WiFi.SSID().length() == 0) {
+		wifiHandlerLogger.debug("Skipping saved credentials attempt on 0-length SSID..."
+		);
+		return false;
+	}
+
+	if (wifiState == WiFiReconnectionStatus::SavedAttempt) {
+		showConnectionAttemptFailed("saved");
+
+		if (WiFi.status() != WL_DISCONNECTED) {
+			return false;
+		}
+
+		if (retriedOnG) {
+			return false;
+		}
+
+		retriedOnG = true;
+		wifiHandlerLogger.debug("Trying saved credentials with PHY Mode G...");
+		return tryConnecting(true);
+	}
+
+	retriedOnG = false;
+
+	wifiState = WiFiReconnectionStatus::SavedAttempt;
+	return tryConnecting();
+}
+
+bool WiFiNetwork::tryHardcodedCredentials() {
+#if defined(WIFI_CREDS_SSID) && defined(WIFI_CREDS_PASSWD)
+	if (wifiState == WiFiReconnectionStatus::HardcodeAttempt) {
+		showConnectionAttemptFailed("hardcoded");
+
+		if (WiFi.status() != WL_DISCONNECTED) {
+			return false;
+		}
+
+		if (retriedOnG) {
+			return false;
+		}
+
+		retriedOnG = true;
+		wifiHandlerLogger.debug("Trying hardcoded credentials with PHY Mode G...");
+		return tryConnecting(true, WIFI_CREDS_SSID, WIFI_CREDS_PASSWD);
+	}
+
+	retriedOnG = false;
+
+	wifiState = WiFiReconnectionStatus::HardcodeAttempt;
+	return tryConnecting(false, WIFI_CREDS_SSID, WIFI_CREDS_PASSWD);
+#else
+	wifiState = WiFiReconnectionStatus::HardcodeAttempt;
+	return false;
+#endif
+}
+
+bool WiFiNetwork::tryServerCredentials() {
+	if (WiFi.status() != WL_DISCONNECTED) {
+		return false;
+	}
+
+	if (retriedOnG) {
+		return false;
+	}
+
+	retriedOnG = true;
+
+	return tryConnecting(true);
+}
+
+bool WiFiNetwork::tryConnecting(bool phyModeG, const char* SSID, const char* pass) {
+#if ESP8266
+	if (phyModeG) {
+		WiFi.setPhyMode(WIFI_PHY_MODE_11G);
+		if constexpr (USE_ATTENUATION) {
+			WiFi.setOutputPower(20.0 - ATTENUATION_G);
+		}
+	} else {
+		WiFi.setPhyMode(WIFI_PHY_MODE_11N);
+		if constexpr (USE_ATTENUATION) {
+			WiFi.setOutputPower(20.0 - ATTENUATION_N);
+		}
+	}
+#else
+	if (phyModeG) {
+		return false;
+	}
+#endif
+
+	setStaticIPIfDefined();
+	if (SSID == nullptr) {
+		WiFi.begin();
+	} else {
+		WiFi.begin(SSID, pass);
+	}
+	wifiConnectionTimeout = millis();
+	return true;
+}
+
+}  // namespace SlimeVR

--- a/src/network/wifihandler.cpp
+++ b/src/network/wifihandler.cpp
@@ -137,11 +137,12 @@ void WiFiNetwork::upkeep() {
 	}
 
 	if (isConnected()) {
+		statusManager.setStatus(SlimeVR::Status::WIFI_CONNECTING, true);
 		wifiHandlerLogger.warn("Connection to WiFi lost, reconnecting...");
-		wifiState = WiFiReconnectionStatus::SavedAttempt;
+		trySavedCredentials();
+		return;
 	}
 
-	statusManager.setStatus(SlimeVR::Status::WIFI_CONNECTING, true);
 	reportWifiProgress();
 	if (millis() - wifiConnectionTimeout
 			< static_cast<uint32_t>(WiFiTimeoutSeconds * 1000)

--- a/src/network/wifihandler.h
+++ b/src/network/wifihandler.h
@@ -55,6 +55,7 @@ public:
 	void setWiFiCredentials(const char* SSID, const char* pass);
 	static IPAddress getAddress();
 	WiFiReconnectionStatus getWiFiState();
+	bool startedProvisioning = false;
 
 private:
 	static constexpr float WiFiTimeoutSeconds = 11;

--- a/src/network/wifihandler.h
+++ b/src/network/wifihandler.h
@@ -42,6 +42,13 @@ public:
 		Success
 	};
 
+	enum class WiFiFailureReason {
+		Timeout = 0,
+		SSIDNotFound = 1,
+		WrongPassword = 2,
+		Unknown = 3,
+	};
+
 	[[nodiscard]] bool isConnected() const;
 	void setUp();
 	void upkeep();
@@ -68,6 +75,7 @@ private:
 	void showConnectionAttemptFailed(const char* type) const;
 
 	static const char* statusToReasonString(wl_status_t status);
+	static WiFiFailureReason statusToFailure(wl_status_t status);
 
 	unsigned long lastWifiReportTime = 0;
 	unsigned long wifiConnectionTimeout = millis();

--- a/src/network/wifiprovisioning.cpp
+++ b/src/network/wifiprovisioning.cpp
@@ -22,38 +22,307 @@
 */
 #include "wifiprovisioning.h"
 
+#if ESP8266
+#include <espnow.h>
+#elif ESP32
+#include <esp_now.h>
+#endif
+
+#include <vector>
+
+#include "GlobalVars.h"
+#include "credentials.h"
 #include "logging/Logger.h"
 #include "wifihandler.h"
 
-// TODO Currently provisioning implemented via SmartConfig
-// it sucks.
-// TODO: New implementation: https://github.com/SlimeVR/SlimeVR-Tracker-ESP/issues/71
+#ifndef MACSTR
+#define MACSTR "%02x:%02x:%02x:%02x:%02x:%02x"
+#endif
+
+#ifndef MAC2STR
+#define MAC2STR(a) (a)[0], (a)[1], (a)[2], (a)[3], (a)[4], (a)[5]
+#endif
 
 namespace SlimeVR {
 
-void WifiProvisioning::upkeepProvisioning() {
-	// Called even when not provisioning to do things like provide neighbours or other
-	// upkeep
+#if ESP8266
+void espnowReceiveCallback(uint8_t* macAddress, uint8_t* data, uint8_t length) {
+	wifiProvisioning.handleMessage(macAddress, data, length);
+}
+#elif ESP32
+void espnowReceiveCallback(
+	const esp_now_recv_info_t* senderInfo,
+	const uint8_t* data,
+	int dataLen
+) {
+	wifiProvisioning.handleMessage(senderInfo->src_addr, data, dataLen);
+}
+#endif
+
+bool WiFiProvisioning::startProvisioning() {
+	if (status != ProvisioningStatus::Idle) {
+		logger.error(
+			"Can't start new provisioning process when a previous one is in progress!"
+		);
+		return false;
+	}
+
+	if (!wifiNetwork.isConnected()) {
+		logger.error(
+			"Can't start provisioning without being connected to a wifi network!"
+		);
+		return false;
+	}
+
+	if (strlen(provisioningPassword) == 0) {
+		logger.error("No provisioning password set! Aborting");
+		return false;
+	}
+
+	if (!initEspnow()) {
+		return false;
+	}
+
+	logger.info("Starting wifi provisioning!");
+
+	status = ProvisioningStatus::Provisioning;
+	startMillis = millis();
+
+	return true;
 }
 
-void WifiProvisioning::startProvisioning() {
-	if (WiFi.beginSmartConfig()) {
-		provisioning = true;
-		wifiProvisioningLogger.info("SmartConfig started");
+void WiFiProvisioning::stopProvisioning() {
+	if (status != ProvisioningStatus::Provisioning) {
+		return;
+	}
+
+	logger.info("Stopped provisioning");
+	esp_now_deinit();
+	esp_now_unregister_recv_cb();
+	status = ProvisioningStatus::Idle;
+}
+
+bool WiFiProvisioning::startSearchForProvisioner() {
+	if (status != ProvisioningStatus::Idle) {
+		logger.error("Can't start new search when a previous one is in progress");
+		return false;
+	}
+
+	if (strlen(provisioningPassword) == 0) {
+		logger.info(
+			"No provisioning password set, won't start searching for a provisioner"
+		);
+		return false;
+	}
+
+	if (!initEspnow()) {
+		return false;
+	}
+
+	status = ProvisioningStatus::Searching;
+	lastSearchSentMillis = millis();
+	startMillis = millis();
+
+	return true;
+}
+
+void WiFiProvisioning::stopSearchForProvisioner() {
+	if (status != ProvisioningStatus::Searching) {
+		return;
+	}
+
+	logger.info("Stopped searching for provisioner");
+	esp_now_deinit();
+	esp_now_unregister_recv_cb();
+	status = ProvisioningStatus::Idle;
+}
+
+void WiFiProvisioning::tick() {
+	uint32_t elapsedMillis = millis() - startMillis;
+	if (status == ProvisioningStatus::Searching
+		&& elapsedMillis >= static_cast<uint32_t>(SearchTimeoutSeconds * 1000)) {
+		logger.info("Search timed out");
+		stopSearchForProvisioner();
+		return;
+	}
+	if (status == ProvisioningStatus::Provisioning
+		&& elapsedMillis >= static_cast<uint32_t>(ProvisioningTimeoutSeconds * 1000)) {
+		logger.info("Provisioning timed out");
+		stopProvisioning();
+		return;
+	}
+
+	if (status != ProvisioningStatus::Searching) {
+		return;
+	}
+
+	if (millis() - lastSearchSentMillis
+		< static_cast<uint32_t>(SearchIntervalSeconds * 1000)) {
+		return;
+	}
+
+#if ESP8266
+	esp_now_set_peer_channel(BroadcastMacAddress, nextSearchChannel);
+#elif ESP32
+	esp_now_peer_info_t peer;
+	esp_now_get_peer(BroadcastMacAddress, &peer);
+	peer.channel = nextSearchChannel;
+	esp_now_mod_peer(&peer);
+#endif
+
+	logger.info("Searching on channel %d", nextSearchChannel);
+	nextSearchChannel++;
+	if (nextSearchChannel > 14) {
+		nextSearchChannel = 1;
+	}
+
+	size_t passwordByteLength = strlen(provisioningPassword) + 1;
+	std::vector<uint8_t> data;
+	data.resize(1 + passwordByteLength);
+	data[0] = static_cast<uint8_t>(ProvisioningMessage::Search);
+	memcpy(data.data() + 1, provisioningPassword, passwordByteLength);
+	auto result = esp_now_send(
+		BroadcastMacAddress,
+		data.data(),
+		static_cast<uint8_t>(1 + passwordByteLength)
+	);
+
+	if (result != 0) {
+		logger.error("Couldn't send: %d", result);
+	}
+
+	lastSearchSentMillis = millis();
+}
+
+bool WiFiProvisioning::initEspnow() {
+	auto result = esp_now_init();
+	if (result != 0) {
+		logger.error("Couldn't start ESP-Now! Error: %d", result);
+		return false;
+	}
+
+#if ESP8266
+
+	result = esp_now_set_self_role(ESP_NOW_ROLE_COMBO);
+	if (result != 0) {
+		logger.error("Couldn't set ESP-Now role! Error: %d", result);
+		esp_now_deinit();
+		return false;
+	}
+
+#endif
+
+	result = addPeer(BroadcastMacAddress);
+	if (result != 0) {
+		logger.error("Couldn't register ESP-Now broadcast peer! Error: %d", result);
+		esp_now_deinit();
+		return false;
+	}
+
+	result = esp_now_register_recv_cb(espnowReceiveCallback);
+	if (result != 0) {
+		logger.error("Couldn't register ESP-Now receive callback! Error: %d", result);
+		esp_now_deinit();
+		return false;
+	}
+
+	return true;
+}
+
+bool WiFiProvisioning::isSearching() const {
+	return status == ProvisioningStatus::Searching;
+}
+
+void WiFiProvisioning::handleMessage(
+	uint8_t* macAddress,
+	const uint8_t* data,
+	uint8_t length
+) {
+	auto messageHeader = static_cast<ProvisioningMessage>(data[0]);
+
+	if (status == ProvisioningStatus::Provisioning
+		&& messageHeader == ProvisioningMessage::Search) {
+		handleSearchMessage(macAddress, data, length);
+		return;
+	}
+
+	if (status == ProvisioningStatus::Searching
+		&& messageHeader == ProvisioningMessage::Reply) {
+		handleReplyMessage(macAddress, data, length);
+		return;
 	}
 }
 
-void WifiProvisioning::stopProvisioning() {
-	WiFi.stopSmartConfig();
-	provisioning = false;
+void WiFiProvisioning::handleSearchMessage(
+	uint8_t* macAddress,
+	const uint8_t* data,
+	uint8_t length
+) {
+	const char* password = reinterpret_cast<const char*>(&data[1]);
+	if (strcmp(password, provisioningPassword) != 0) {
+		logger.error(
+			"Received a search message from " MACSTR " with an incorrect password!",
+			MAC2STR(macAddress)
+		);
+		return;
+	}
+
+	logger.info(
+		"Received a search message from " MACSTR ". Responding with WiFi credentials!",
+		MAC2STR(macAddress)
+	);
+
+	addPeer(macAddress);
+
+	String ssid = WiFi.SSID();
+	String pass = WiFi.psk();
+	size_t ssidByteLength = ssid.length() + 1;
+	size_t passwordByteLength = pass.length() + 1;
+	std::vector<uint8_t> sendData;
+	sendData.resize(1 + ssidByteLength + passwordByteLength);
+	sendData[0] = static_cast<uint8_t>(ProvisioningMessage::Reply);
+	memcpy(sendData.data() + 1, ssid.c_str(), ssidByteLength);
+	memcpy(sendData.data() + 1 + ssidByteLength, pass.c_str(), passwordByteLength);
+	esp_now_send(
+		macAddress,
+		sendData.data(),
+		static_cast<uint8_t>(1 + ssidByteLength + passwordByteLength)
+	);
+
+	delPeer(macAddress);
 }
 
-void WifiProvisioning::provideNeighbours() {
-	// TODO: SmartConfig can't do this, created for future
+void WiFiProvisioning::handleReplyMessage(
+	uint8_t* macAddress,
+	const uint8_t* data,
+	uint8_t length
+) {
+	auto* ssid = reinterpret_cast<const char*>(&data[1]);
+	auto* pass = reinterpret_cast<const char*>(&data[1 + strlen(ssid) + 1]);
+
+	logger.info(
+		"Received a reply from " MACSTR " with SSID %s and password length %zu",
+		MAC2STR(macAddress),
+		ssid,
+		strlen(pass)
+	);
+
+	wifiNetwork.setWiFiCredentials(ssid, pass);
 }
 
-bool WifiProvisioning::isProvisioning() const {
-	return provisioning && !WiFi.smartConfigDone();
+uint8_t WiFiProvisioning::addPeer(uint8_t* macAddress) {
+#if ESP8266
+	return esp_now_add_peer(macAddress, ESP_NOW_ROLE_COMBO, 0, nullptr, 0);
+#elif ESP32
+	esp_now_peer_info_t peer{};
+	memcpy(peer.peer_addr, macAddress, sizeof(uint8_t[6]));
+	peer.channel = 0;
+	peer.ifidx = WIFI_IF_STA;
+	peer.encrypt = false;
+	return esp_now_add_peer(&peer);
+#endif
 }
+
+void WiFiProvisioning::delPeer(uint8_t* macAddress) { esp_now_del_peer(macAddress); }
 
 }  // namespace SlimeVR

--- a/src/network/wifiprovisioning.cpp
+++ b/src/network/wifiprovisioning.cpp
@@ -29,29 +29,31 @@
 // it sucks.
 // TODO: New implementation: https://github.com/SlimeVR/SlimeVR-Tracker-ESP/issues/71
 
-// TODO: Cleanup with proper classes
-SlimeVR::Logging::Logger wifiProvisioningLogger("WiFiProvisioning");
-bool provisioning = false;
+namespace SlimeVR {
 
-void WiFiNetwork::upkeepProvisioning() {
+void WifiProvisioning::upkeepProvisioning() {
 	// Called even when not provisioning to do things like provide neighbours or other
 	// upkeep
 }
 
-void WiFiNetwork::startProvisioning() {
+void WifiProvisioning::startProvisioning() {
 	if (WiFi.beginSmartConfig()) {
 		provisioning = true;
 		wifiProvisioningLogger.info("SmartConfig started");
 	}
 }
 
-void WiFiNetwork::stopProvisioning() {
+void WifiProvisioning::stopProvisioning() {
 	WiFi.stopSmartConfig();
 	provisioning = false;
 }
 
-void WiFiNetwork::provideNeighbours() {
+void WifiProvisioning::provideNeighbours() {
 	// TODO: SmartConfig can't do this, created for future
 }
 
-bool WiFiNetwork::isProvisioning() { return provisioning && !WiFi.smartConfigDone(); }
+bool WifiProvisioning::isProvisioning() const {
+	return provisioning && !WiFi.smartConfigDone();
+}
+
+}  // namespace SlimeVR

--- a/src/network/wifiprovisioning.h
+++ b/src/network/wifiprovisioning.h
@@ -25,19 +25,60 @@
 
 #include "logging/Logger.h"
 
+#if ESP32
+#include <esp_now.h>
+#endif
+
 namespace SlimeVR {
 
-class WifiProvisioning {
+class WiFiProvisioning {
 public:
-	void upkeepProvisioning();
-	void startProvisioning();
+	bool startProvisioning();
 	void stopProvisioning();
-	bool isProvisioning() const;
-	void provideNeighbours();
+
+	bool startSearchForProvisioner();
+	void stopSearchForProvisioner();
+
+	void tick();
+
+	[[nodiscard]] bool isSearching() const;
 
 private:
-	SlimeVR::Logging::Logger wifiProvisioningLogger{"WiFiProvisioning"};
-	bool provisioning = false;
+	bool initEspnow();
+	void handleMessage(uint8_t* macAddress, const uint8_t* data, uint8_t length);
+	void handleSearchMessage(uint8_t* macAddress, const uint8_t* data, uint8_t length);
+	void handleReplyMessage(uint8_t* macAddress, const uint8_t* data, uint8_t length);
+
+	static uint8_t addPeer(uint8_t* macAddress);
+	static void delPeer(uint8_t* macAddress);
+
+	uint8_t BroadcastMacAddress[6]{0xff, 0xff, 0xff, 0xff, 0xff, 0xff};
+	static constexpr float SearchIntervalSeconds = 0.1f;
+	static constexpr float SearchTimeoutSeconds = 120.0f;
+	static constexpr float ProvisioningTimeoutSeconds = 60.0f;
+
+	enum class ProvisioningStatus { Idle, Provisioning, Searching };
+
+	enum class ProvisioningMessage : uint8_t {
+		Search = 0,
+		Reply = 1,
+	};
+
+	ProvisioningStatus status = ProvisioningStatus::Idle;
+	SlimeVR::Logging::Logger logger{"WiFiProvisioning"};
+	uint32_t startMillis = 0;
+	uint32_t lastSearchSentMillis = 0;
+	uint8_t nextSearchChannel = 1;
+
+#if ESP8266
+	friend void espnowReceiveCallback(uint8_t*, uint8_t*, uint8_t);
+#elif ESP32
+	friend void espnowReceiveCallback(
+		const esp_now_recv_info_t* senderInfo,
+		const uint8_t* data,
+		int dataLen
+	);
+#endif
 };
 
 }  // namespace SlimeVR

--- a/src/network/wifiprovisioning.h
+++ b/src/network/wifiprovisioning.h
@@ -23,12 +23,23 @@
 #ifndef SLIMEVR_WIFIPROVISIONING_H_
 #define SLIMEVR_WIFIPROVISIONING_H_
 
-namespace WiFiNetwork {
-void upkeepProvisioning();
-void startProvisioning();
-void stopProvisioning();
-bool isProvisioning();
-void provideNeighbours();
-}  // namespace WiFiNetwork
+#include "logging/Logger.h"
+
+namespace SlimeVR {
+
+class WifiProvisioning {
+public:
+	void upkeepProvisioning();
+	void startProvisioning();
+	void stopProvisioning();
+	bool isProvisioning() const;
+	void provideNeighbours();
+
+private:
+	SlimeVR::Logging::Logger wifiProvisioningLogger{"WiFiProvisioning"};
+	bool provisioning = false;
+};
+
+}  // namespace SlimeVR
 
 #endif  // SLIMEVR_WIFIPROVISIONING_H_

--- a/src/serial/serialcommands.cpp
+++ b/src/serial/serialcommands.cpp
@@ -38,7 +38,7 @@
 namespace SerialCommands {
 SlimeVR::Logging::Logger logger("SerialCommands");
 
-CmdCallback<6> cmdCallbacks;
+CmdCallback<7> cmdCallbacks;
 CmdParser cmdParser;
 CmdBuffer<256> cmdBuffer;
 
@@ -302,8 +302,8 @@ void cmdGet(CmdParser* parser) {
 		if (WiFi.status() != WL_CONNECTED) {
 			WiFi.disconnect();
 		}
-		if (wifiProvisioning.isProvisioning()) {
-			wifiProvisioning.stopProvisioning();
+		if (wifiProvisioning.isSearching()) {
+			wifiProvisioning.stopSearchForProvisioner();
 		}
 
 		WiFi.scanNetworks();
@@ -412,6 +412,18 @@ void cmdDeleteCalibration(CmdParser* parser) {
 	configuration.eraseSensors();
 }
 
+void cmdStart(CmdParser* parser) {
+	if (parser->getParamCount() == 1) {
+		logger.info("Usage:");
+		logger.info("  START PROVISION: start wifi provisioning");
+		return;
+	}
+
+	if (parser->equalCmdParam(1, "PROVISION")) {
+		wifiProvisioning.startProvisioning();
+	}
+}
+
 void setUp() {
 	cmdCallbacks.addCmd("SET", &cmdSet);
 	cmdCallbacks.addCmd("GET", &cmdGet);
@@ -419,6 +431,7 @@ void setUp() {
 	cmdCallbacks.addCmd("REBOOT", &cmdReboot);
 	cmdCallbacks.addCmd("DELCAL", &cmdDeleteCalibration);
 	cmdCallbacks.addCmd("TCAL", &cmdTemperatureCalibration);
+	cmdCallbacks.addCmd("START", &cmdStart);
 }
 
 void update() { cmdCallbacks.updateCmdProcessing(&cmdParser, &cmdBuffer, &Serial); }

--- a/src/serial/serialcommands.cpp
+++ b/src/serial/serialcommands.cpp
@@ -85,7 +85,7 @@ void cmdSet(CmdParser* parser) {
 					return;
 				}
 
-				WiFiNetwork::setWiFiCredentials(sc_ssid, sc_pw);
+				wifiNetwork.setWiFiCredentials(sc_ssid, sc_pw);
 				logger.info("CMD SET WIFI OK: New wifi credentials set, reconnecting");
 			}
 		} else if (parser->equalCmdParam(1, "BWIFI")) {
@@ -131,7 +131,7 @@ void cmdSet(CmdParser* parser) {
 					// set the pointer for pass to null for no password
 					ppass = NULL;
 				}
-				WiFiNetwork::setWiFiCredentials(ssid, ppass);
+				wifiNetwork.setWiFiCredentials(ssid, ppass);
 				logger.info("CMD SET BWIFI OK: New wifi credentials set, reconnecting");
 			}
 		} else {
@@ -150,10 +150,10 @@ void printState() {
 		HARDWARE_MCU,
 		PROTOCOL_VERSION,
 		FIRMWARE_VERSION,
-		WiFiNetwork::getAddress().toString().c_str(),
+		wifiNetwork.getAddress().toString().c_str(),
 		WiFi.macAddress().c_str(),
 		statusManager.getStatus(),
-		WiFiNetwork::getWiFiState()
+		wifiNetwork.getWiFiState()
 	);
 	for (auto& sensor : sensorManager.getSensors()) {
 		logger.info(
@@ -274,10 +274,10 @@ void cmdGet(CmdParser* parser) {
 			HARDWARE_MCU,
 			PROTOCOL_VERSION,
 			FIRMWARE_VERSION,
-			WiFiNetwork::getAddress().toString().c_str(),
+			wifiNetwork.getAddress().toString().c_str(),
 			WiFi.macAddress().c_str(),
 			statusManager.getStatus(),
-			WiFiNetwork::getWiFiState()
+			wifiNetwork.getWiFiState()
 		);
 		auto& sensor0 = sensorManager.getSensors()[0];
 		sensor0->motionLoop();
@@ -302,8 +302,8 @@ void cmdGet(CmdParser* parser) {
 		if (WiFi.status() != WL_CONNECTED) {
 			WiFi.disconnect();
 		}
-		if (WiFiNetwork::isProvisioning()) {
-			WiFiNetwork::stopProvisioning();
+		if (wifiProvisioning.isProvisioning()) {
+			wifiProvisioning.stopProvisioning();
 		}
 
 		WiFi.scanNetworks();


### PR DESCRIPTION
Depends on #435  

Attempts to implement #71

This PR reworks the wifi provisioning, which originally used SmartConfig, to instead use an ESP-Now based implemenation.

When a tracker can't connect to any of its credentials options, it starts sending out esp-now packets on all possible channels. If another tracker that's currently provisioning gets these packets, it will reply with the SSID and password of the wifi network it is connected to. The searching tracker then receive these and attempt to connect with the provided credentials.

A tracker can be put into provisioning mode by either sending it the "START PROVISION" serial command, or sending it a WifiProvisioning packet (packet id 27, only parameter a boolean saying if the provisioning should be started or stopped).

Caveats:
- Seems like the range on the esp-now packets - at least using official slime boards - isn't great. The tracker needs to be basically next to the provisioning one to catch the packets. From reading online, this might be somewhat determined by the 2.4ghz channel we use for sending (which needs to be the same as the channel of the WiFi network), and the attenuation might also play a role. I propose to call this a security feature.

TODO:
- [ ] Finetune timeout and interval parameters. Increasing the latter *might* make catching packets a bit more consistent
- [ ] Test extensively, both on ESP8266 and ESP32