### PR TITLE
Allow multiple WHOAMI values per SoftFusion sensor

### DIFF
--- a/src/sensors/softfusion/drivers/bmi160.h
+++ b/src/sensors/softfusion/drivers/bmi160.h
@@ -76,7 +76,8 @@ struct BMI160 {
 	struct Regs {
 		struct WhoAmI {
 			static constexpr uint8_t reg = 0x00;
-			static constexpr uint8_t value = 0xD1;
+			static constexpr std::array<uint8_t, 2> values
+				= {0xD1, 0xD3};  // 0xD3 for rev3 (thanks bosch)
 		};
 		static constexpr uint8_t TempData = 0x20;
 

--- a/src/sensors/softfusion/drivers/lsm6ds3trc.h
+++ b/src/sensors/softfusion/drivers/lsm6ds3trc.h
@@ -73,7 +73,8 @@ struct LSM6DS3TRC {
 	struct Regs {
 		struct WhoAmI {
 			static constexpr uint8_t reg = 0x0f;
-			static constexpr uint8_t value = 0x6a;
+			static constexpr std::array<uint8_t, 2> values
+				= {0x6a, 0x69};  // 0x6a for LSM6DS3TR-C, 0x69 for LSM6DS3
 		};
 		struct Ctrl1XL {
 			static constexpr uint8_t reg = 0x10;

--- a/src/sensors/softfusion/softfusionsensor.h
+++ b/src/sensors/softfusion/softfusionsensor.h
@@ -462,7 +462,7 @@ public:
 		I2Cdev::readTimeout = 100;
 		auto value = imuInterface.readReg(SensorType::Regs::WhoAmI::reg);
 		I2Cdev::readTimeout = I2CDEV_DEFAULT_READ_TIMEOUT;
-		if constexpr (requires { SensorType::Regs::WhoAmi::values.size(); }) {
+		if constexpr (requires { SensorType::Regs::WhoAmI::values.size(); }) {
 			for (auto possible : SensorType::Regs::WhoAmI::values) {
 				if (value == possible) {
 					return true;


### PR DESCRIPTION
This PR adds the functionality of allowing multiple WHOAMI values per SoftFusion sensor. It is mainly for parity with the old BMI160 driver, which handled revision 3 chips properly (those have a value of 0xD3), but it also allows LSM6DS3 to work with the LSM6DS3TR-C driver.
