### PR TITLE
Esp32 fix defines

### DIFF
--- a/lib/i2cscan/i2cscan.cpp
+++ b/lib/i2cscan/i2cscan.cpp
@@ -70,7 +70,7 @@ namespace I2CSCAN
             if (!found) {
                 Serial.println("[ERR] I2C: No I2C devices found");
             }
-#if ESP32
+#ifdef ESP32
             Wire.end();
 #endif
             Wire.begin(static_cast<int>(PIN_IMU_SDA), static_cast<int>(PIN_IMU_SCL));
@@ -89,7 +89,7 @@ namespace I2CSCAN
         }
 
         if (currentAddress == 1) {
-#if ESP32
+#ifdef ESP32
             Wire.end();
 #endif
         }

--- a/src/batterymonitor.cpp
+++ b/src/batterymonitor.cpp
@@ -74,7 +74,7 @@ void BatteryMonitor::Loop() {
 		voltage = ((float)analogRead(PIN_BATTERY_LEVEL)) * ADCVoltageMax / ADCResolution
 				* ADCMultiplier;
 #endif
-#if ESP32 && BATTERY_MONITOR == BAT_EXTERNAL
+#if defined(ESP32) && BATTERY_MONITOR == BAT_EXTERNAL
 		voltage
 			= ((float)analogReadMilliVolts(PIN_BATTERY_LEVEL)) / 1000 * ADCMultiplier;
 #endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -83,7 +83,7 @@ void setup() {
 
 	// join I2C bus
 
-#if ESP32
+#ifdef ESP32
 	// For some unknown reason the I2C seem to be open on ESP32-C3 by default. Let's
 	// just close it before opening it again. (The ESP32-C3 only has 1 I2C.)
 	Wire.end();

--- a/src/sensorinterface/I2CPCAInterface.cpp
+++ b/src/sensorinterface/I2CPCAInterface.cpp
@@ -32,7 +32,7 @@ void SlimeVR::I2CPCASensorInterface::swapIn() {
 	Wire.beginTransmission(m_Address);
 	Wire.write(1 << m_Channel);
 	Wire.endTransmission();
-#if ESP32
+#ifdef ESP32
 	// On ESP32 we need to reconnect to I2C bus for some reason
 	m_Wire.disconnect();
 	m_Wire.swapIn();

--- a/src/sensorinterface/I2CWireSensorInterface.cpp
+++ b/src/sensorinterface/I2CWireSensorInterface.cpp
@@ -25,7 +25,7 @@
 
 #include <optional>
 
-#if ESP32
+#ifdef ESP32
 #include "driver/i2c.h"
 #endif
 
@@ -37,7 +37,7 @@ namespace SlimeVR {
 void swapI2C(uint8_t sclPin, uint8_t sdaPin) {
 	if (sclPin != activeSCLPin || sdaPin != activeSDAPin || !isI2CActive) {
 		Wire.flush();
-#if ESP32
+#ifdef ESP32
 		if (!isI2CActive) {
 			// Reset HWI2C to avoid being affected by I2CBUS reset
 			Wire.end();
@@ -68,7 +68,7 @@ void swapI2C(uint8_t sclPin, uint8_t sdaPin) {
 void disconnectI2C() {
 	Wire.flush();
 	isI2CActive = false;
-#if ESP32
+#ifdef ESP32
 	Wire.end();
 #endif
 }

--- a/src/sensorinterface/SensorInterface.h
+++ b/src/sensorinterface/SensorInterface.h
@@ -31,7 +31,7 @@ class SensorInterface {
 public:
 	virtual bool init() = 0;
 	virtual void swapIn() = 0;
-	[[nodiscard]] virtual std::string toString() const;
+	[[nodiscard]] virtual std::string toString() const = 0;
 };
 
 class EmptySensorInterface : public SensorInterface {

--- a/src/sensors/ADCResistanceSensor.cpp
+++ b/src/sensors/ADCResistanceSensor.cpp
@@ -30,7 +30,7 @@ void ADCResistanceSensor::motionLoop() {
 	float voltage = ((float)analogRead(m_Pin)) * ADCVoltageMax / ADCResolution;
 	m_Data = m_ResistanceDivider
 		   * (ADCVoltageMax / voltage - 1.0f);  // Convert voltage to resistance
-#elif ESP32
+#elif defined(ESP32)
 	float voltage = ((float)analogReadMilliVolts(m_Pin)) / 1000;
 	m_Data = m_ResistanceDivider
 		   * (m_VCC / voltage - 1.0f);  // Convert voltage to resistance

--- a/src/sensors/SensorBuilder.h
+++ b/src/sensors/SensorBuilder.h
@@ -78,7 +78,7 @@
 #define SFCALIBRATOR SlimeVR::Sensor::SoftfusionCalibrator
 #endif
 
-#if ESP32
+#ifdef ESP32
 #include "driver/i2c.h"
 #endif
 

--- a/src/sensors/SensorFusion.h
+++ b/src/sensors/SensorFusion.h
@@ -145,7 +145,7 @@ protected:
 	sensor_real_t vecGravity[3]{0.0f, 0.0f, 0.0f};
 	bool linaccelReady = false;
 	sensor_real_t linAccel[3]{0.0f, 0.0f, 0.0f};
-#if ESP32
+#ifdef ESP32
 	sensor_real_t linAccel_guard;  // Temporary patch for some weird ESP32 bug
 #endif
 };

--- a/src/sensors/SensorFusionDMP.h
+++ b/src/sensors/SensorFusionDMP.h
@@ -36,7 +36,7 @@ protected:
 	sensor_real_t vecGravity[3]{0.0f, 0.0f, 0.0f};
 	bool linaccelReady = false;
 	sensor_real_t linAccel[3]{0.0f, 0.0f, 0.0f};
-#if ESP32
+#ifdef ESP32
 	sensor_real_t linAccel_guard;  // Temporary patch for some weird ESP32 bug
 #endif
 };

--- a/src/serial/serialcommands.cpp
+++ b/src/serial/serialcommands.cpp
@@ -31,7 +31,7 @@
 #include "logging/Logger.h"
 #include "utils.h"
 
-#if ESP32
+#ifdef ESP32
 #include "nvs_flash.h"
 #endif
 
@@ -172,7 +172,7 @@ void printState() {
 	);
 }
 
-#if ESP32
+#ifdef ESP32
 String getEncryptionTypeName(wifi_auth_mode_t type) {
 	switch (type) {
 		case WIFI_AUTH_OPEN:
@@ -346,7 +346,7 @@ void cmdFactoryReset(CmdParser* parser) {
 	WiFi.disconnect(true);  // Clear WiFi credentials
 #if ESP8266
 	ESP.eraseConfig();  // Clear ESP config
-#elif ESP32
+#elif defined(ESP32)
 	nvs_flash_erase();
 #else
 #warning SERIAL COMMAND FACTORY RESET NOT SUPPORTED


### PR DESCRIPTION
make all esp32 define the same
only check if ESP32 is defined. The value changed from "1" to "ESP32" in pioarduino and tasmota in newer versions.
update esp32 to tasmota version