### PR TITLE
Add compile_commands.json to the .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ build/
 venv/
 cache/
 .idea/
+compile_commands.json


### PR DESCRIPTION
The compile_commands.json file helps certain tools, for example clangd while locating symbols and the like, and platformio can helpfully generate one. Normally you wouldn't necessarily want to gitignore it, but since we have several different targets with several different toolchains and platforms, using it would often change it unnecessarily. Because of this I added it to the .gitignore file.