### PR TITLE
Cleanup I2Cscan library

### DIFF
--- a/lib/i2cscan/i2cscan.cpp
+++ b/lib/i2cscan/i2cscan.cpp
@@ -1,116 +1,146 @@
 #include "i2cscan.h"
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <string>
+
 #include "../../src/globals.h"
 
+namespace {
 #ifdef ESP8266
-uint8_t portArray[] = {16, 5, 4, 2, 14, 12, 13};
-uint8_t portExclude[] = {LED_PIN};
-String portMap[] = {"D0", "D1", "D2", "D4", "D5", "D6", "D7"};
+	std::array<uint8_t, 7> portArray = {16, 5, 4, 2, 14, 12, 13};
+	std::array<std::string, 7> portMap = {"D0", "D1", "D2", "D4", "D5", "D6", "D7"};
+	std::array<uint8_t, 1> portExclude = {LED_PIN};
 #elif defined(ESP32C3)
-uint8_t portArray[] = {2, 3, 4, 5, 6, 7, 8, 9, 10};
-uint8_t portExclude[] = {18, 19, 20, 21, LED_PIN};
-String portMap[] = {"2", "3", "4", "5", "6", "7", "8", "9", "10"};
+	std::array<uint8_t, 9> portArray = {2, 3, 4, 5, 6, 7, 8, 9, 10};
+	std::array<std::string, 9> portMap = {"2", "3", "4", "5", "6", "7", "8", "9", "10"};
+	std::array<uint8_t, 5> portExclude = {18, 19, 20, 21, LED_PIN};
 #elif defined(ESP32C6)
-uint8_t portArray[] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 14, 15, 18, 19, 20, 21, 22, 23};
-String portMap[] = {"0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "14", "15", "18", "19", "20", "21", "22", "23"};
-uint8_t portExclude[] = {12, 13, 16, 17, LED_PIN};
+	std::array<uint8_t, 20> portArray = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 14, 15, 18, 19, 20, 21, 22, 23};
+	std::array<std::string, 20> portMap = {"0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "14", "15", "18", "19", "20", "21", "22", "23"};
+	std::array<uint8_t, 4> portExclude = {12, 13, 16, 17, LED_PIN};
 #elif defined(ESP32)
-uint8_t portArray[] = {4, 13, 14, 15, 16, 17, 18, 19, 21, 22, 23, 25, 26, 27, 32, 33};
-String portMap[] = {"4", "13", "14", "15", "16", "17", "18", "19", "21", "22", "23", "25", "26", "27", "32", "33"};
-uint8_t portExclude[] = {LED_PIN};
+	std::array<uint8_t, 16> portArray = {4, 13, 14, 15, 16, 17, 18, 19, 21, 22, 23, 25, 26, 27, 32, 33};
+	std::array<std::string, 16> portMap = {"4", "13", "14", "15", "16", "17", "18", "19", "21", "22", "23", "25", "26", "27", "32", "33"};
+	std::array<uint8_t, 1> portExclude = {LED_PIN};
 #endif
+}
 
-namespace I2CSCAN
-{
-    enum class ScanState {
+namespace I2CSCAN {
+    enum class ScanState : uint8_t {
         IDLE,
         SCANNING,
         DONE
     };
 
-    ScanState scanState = ScanState::IDLE;
-    uint8_t currentSDA = 0;
-    uint8_t currentSCL = 0;
-    uint8_t currentAddress = 1;
-    bool found = false;
-    std::vector<uint8_t> validPorts;
+	namespace {
+		ScanState scanState = ScanState::IDLE;
+    	uint8_t currentSDA = 0;
+    	uint8_t currentSCL = 0;
+    	uint8_t currentAddress = 1;
+    	bool found = false;
+		uint8_t busyHits = 0;
+    	std::vector<uint8_t> validPorts;
 
-    void scani2cports()
-    {
+		auto selectNextPort() -> bool {
+			currentSCL++;
+
+			if(validPorts[currentSCL] == validPorts[currentSDA]) currentSCL++;
+
+			if (currentSCL < validPorts.size()) {
+				Wire.begin((int)validPorts[currentSDA], (int)validPorts[currentSCL]); //NOLINT
+				return true;
+			}
+
+			currentSCL = 0;
+			currentSDA++;
+
+			if (currentSDA >= validPorts.size()) {
+				if (!found) {
+					Serial.println("[ERR] I2C: No I2C devices found"); //NOLINT
+				}
+	#ifdef ESP32
+				Wire.end();
+	#endif
+				Wire.begin(static_cast<int>(PIN_IMU_SDA), static_cast<int>(PIN_IMU_SCL));
+				scanState = ScanState::DONE;
+				return false;
+			}
+
+			Wire.begin((int)validPorts[currentSDA], (int)validPorts[currentSCL]);
+			return true;
+		}
+	}
+
+    void scani2cports() {
         if (scanState != ScanState::IDLE) {
-            return;
+			if (scanState == ScanState::DONE) {
+				Serial.println("[DBG] I2C scan finished previously, resetting and scanning again..."); //NOLINT
+			} else {
+				return; // Already scanning, do not start again
+			}
         }
 
         // Filter out excluded ports
-        for (size_t i = 0; i < sizeof(portArray); i++) {
-            if (!inArray(portArray[i], portExclude, sizeof(portExclude))) {
-                validPorts.push_back(portArray[i]);
-            }
-        }
+		validPorts.clear();
+		validPorts.reserve(portArray.size() - portExclude.size()); // Reserve space to avoid reallocations
 
+		for (const auto& port : portArray) {
+			bool isExcluded = false;
+
+			// Check if the port is in the excluded list
+			for (const auto& excluded : portExclude) {
+				if (port == excluded) {
+					isExcluded = true; // Port is excluded, break out of the loop
+					break;
+				}
+			}
+
+			if (!isExcluded) {
+				validPorts.push_back(port); // Port is valid, add it to the list
+			}
+		}
+
+		// Reset scan variables and start scanning
         found = false;
         currentSDA = 0;
         currentSCL = 1;
         currentAddress = 1;
         scanState = ScanState::SCANNING;
-    }
+	}
 
-    bool selectNextPort() {
-        currentSCL++;
-        if(validPorts[currentSCL] == validPorts[currentSDA])
-            currentSCL++;
-        if (currentSCL < validPorts.size()) {
-            Wire.begin((int)validPorts[currentSDA], (int)validPorts[currentSCL]);
-            return true;
-        }
-
-        currentSCL = 0;
-        currentSDA++;
-
-        if (currentSDA >= validPorts.size()) {
-            if (!found) {
-                Serial.println("[ERR] I2C: No I2C devices found");
-            }
-#ifdef ESP32
-            Wire.end();
-#endif
-            Wire.begin(static_cast<int>(PIN_IMU_SDA), static_cast<int>(PIN_IMU_SCL));
-            scanState = ScanState::DONE;
-            return false;
-        }
-
-        Wire.begin((int)validPorts[currentSDA], (int)validPorts[currentSCL]);
-        return true;
-    }
-
-    void update()
-    {
+    void update() {
         if (scanState != ScanState::SCANNING) {
             return;
         }
 
-        if (currentAddress == 1) {
 #ifdef ESP32
+		if (currentAddress == 1) {
             Wire.end();
+		}
 #endif
-        }
 
         Wire.beginTransmission(currentAddress);
-        byte error = Wire.endTransmission();
+        const uint8_t error = Wire.endTransmission();
 
-        if (error == 0)
-        {
+        if (error == 0) {
             Serial.printf("[DBG] I2C (@ %s(%d) : %s(%d)): I2C device found at address 0x%02x  !\n",
                             portMap[currentSDA].c_str(), validPorts[currentSDA], portMap[currentSCL].c_str(), validPorts[currentSCL], currentAddress);
             found = true;
-        }
-        else if (error == 4)
-        {
-            Serial.printf("[ERR] I2C (@ %s(%d) : %s(%d)): Unknown error at address 0x%02x\n",
+        } else if (error == 4) { // Address was busy, log and warn
+            Serial.printf("[WARN] I2C (@ %s(%d) : %s(%d)): Busy at address 0x%02x, skipping !\n",
                             portMap[currentSDA].c_str(), validPorts[currentSDA], portMap[currentSCL].c_str(), validPorts[currentSCL], currentAddress);
+            busyHits++;
         }
 
         currentAddress++;
+
         if (currentAddress <= 127) {
+			if (busyHits > 10) {
+				Serial.printf("[ERR] I2C: Too many busy hits (%d), power down tracker and check connections !\n", busyHits);
+			}
+
             return;
         }
 
@@ -118,12 +148,9 @@ namespace I2CSCAN
         selectNextPort();
     }
 
-    bool inArray(uint8_t value, uint8_t* array, size_t arraySize)
-    {
-        for (size_t i = 0; i < arraySize; i++)
-        {
-            if (value == array[i])
-            {
+    auto inArray(uint8_t value, const uint8_t *array, size_t arraySize) -> bool {
+        for (size_t i = 0; i < arraySize; i++) {
+            if (value == array[i]) {
                 return true;
             }
         }
@@ -131,7 +158,7 @@ namespace I2CSCAN
         return false;
     }
 
-    bool hasDevOnBus(uint8_t addr) {
+    auto hasDevOnBus(uint8_t addr) -> bool {
         byte error;
 #if ESP32C3
         int retries = 2;
@@ -164,10 +191,10 @@ namespace I2CSCAN
      * This code may be freely used for both private and commerical use
      */
 
-    int clearBus(uint8_t SDA, uint8_t SCL) {
-        #if defined(TWCR) && defined(TWEN)
+    auto clearBus(uint8_t SDA, uint8_t SCL) -> int {
+#if defined(TWCR) && defined(TWEN)
         TWCR &= ~(_BV(TWEN)); // Disable the Atmel 2-Wire interface so we can control the SDA and SCL pins directly
-        #endif
+#endif
 
         pinMode(SDA, INPUT_PULLUP);
         pinMode(SCL, INPUT_PULLUP);

--- a/lib/i2cscan/i2cscan.h
+++ b/lib/i2cscan/i2cscan.h
@@ -11,7 +11,7 @@ namespace I2CSCAN {
     bool hasDevOnBus(uint8_t addr);
     uint8_t pickDevice(uint8_t addr1, uint8_t addr2, bool scanIfNotFound);
     int clearBus(uint8_t SDA, uint8_t SCL);
-    boolean inArray(uint8_t value, uint8_t* arr, size_t arrSize);
+    bool inArray(uint8_t value, const uint8_t *array, size_t arraySize);
 }
 
 #endif // _I2CSCAN_H_

--- a/src/debug.h
+++ b/src/debug.h
@@ -39,6 +39,8 @@
 		   // disable if problems. Server does nothing with value so disabled atm
 #define SEND_ACCELERATION true  // send linear acceleration to the server
 
+#define EXT_SERIAL_COMMANDS false // Set to true to enable extra serial debug commands
+
 // Debug information
 
 #define LOG_LEVEL LOG_LEVEL_DEBUG

--- a/src/serial/serialcommands.cpp
+++ b/src/serial/serialcommands.cpp
@@ -35,10 +35,19 @@
 #include "nvs_flash.h"
 #endif
 
+#ifdef EXT_SERIAL_COMMANDS
+#define CALLBACK_SIZE 8 // Increase callback size to allow for debug commands
+#include "i2cscan.h"
+#endif
+
+#ifndef CALLBACK_SIZE
+#define CALLBACK_SIZE 6 // Default callback size
+#endif
+
 namespace SerialCommands {
 SlimeVR::Logging::Logger logger("SerialCommands");
 
-CmdCallback<6> cmdCallbacks;
+CmdCallback<CALLBACK_SIZE> cmdCallbacks;
 CmdParser cmdParser;
 CmdBuffer<256> cmdBuffer;
 
@@ -412,6 +421,17 @@ void cmdDeleteCalibration(CmdParser* parser) {
 	configuration.eraseSensors();
 }
 
+#if EXT_SERIAL_COMMANDS
+void cmdScanI2C(CmdParser* parser) {
+	logger.info("Forcing I2C scan...");
+	I2CSCAN::scani2cports();
+}
+
+void cmdPing(CmdParser* parser) {
+	logger.info("PONG!");
+}
+#endif
+
 void setUp() {
 	cmdCallbacks.addCmd("SET", &cmdSet);
 	cmdCallbacks.addCmd("GET", &cmdGet);
@@ -419,6 +439,10 @@ void setUp() {
 	cmdCallbacks.addCmd("REBOOT", &cmdReboot);
 	cmdCallbacks.addCmd("DELCAL", &cmdDeleteCalibration);
 	cmdCallbacks.addCmd("TCAL", &cmdTemperatureCalibration);
+#if EXT_SERIAL_COMMANDS
+	cmdCallbacks.addCmd("PING", &cmdPing);
+	cmdCallbacks.addCmd("SCANI2C", &cmdScanI2C);
+#endif
 }
 
 void update() { cmdCallbacks.updateCmdProcessing(&cmdParser, &cmdBuffer, &Serial); }


### PR DESCRIPTION
This is a simple cleanup of the I2Cscan library.

It wasn't the best formatted, and seemed like a good candidate for me to start tinkering with the firmware and learn how it works. I modernized the code, and it's functionally identical to the older code. It also throws a lot less linter warnings, and it's a bit more exact with possible issues.

I also added a way to send debug commands over the serial connection, if the tracker is configured to accept those commands. They default to disabled, but setting ```EXT_SERIAL_COMMANDS``` to true in ```debug.h``` will enable them. I used this to manually trigger I2C scans for testing, and thought it was useful enough to submit it upstream.