### PR TITLE
Use optimized VQFParams for ICM45, disable TempGradientCalibration by default

### DIFF
--- a/src/sensors/SensorToggles.h
+++ b/src/sensors/SensorToggles.h
@@ -50,5 +50,5 @@ private:
 
 	bool magEnabled = !USE_6_AXIS;
 	bool calibrationEnabled = true;
-	bool tempGradientCalibrationEnabled = true;
+	bool tempGradientCalibrationEnabled = false; // disable by default, it is not clear that it really helps
 };

--- a/src/sensors/softfusion/drivers/icm45686.h
+++ b/src/sensors/softfusion/drivers/icm45686.h
@@ -32,7 +32,7 @@ namespace SlimeVR::Sensors::SoftFusion::Drivers {
 // and gyroscope range at 4000dps
 // using high resolution mode
 // Uses 32.768kHz clock
-// Gyroscope ODR = 409.6Hz, accel ODR = 204.8Hz
+// Gyroscope ODR = 409.6Hz, accel ODR = 102.4Hz
 // Timestamps reading not used, as they're useless (constant predefined increment)
 
 struct ICM45686 : public ICM45Base {
@@ -40,11 +40,17 @@ struct ICM45686 : public ICM45Base {
 	static constexpr auto Type = SensorTypeID::ICM45686;
 
 	static constexpr VQFParams SensorVQFParams{
-		.motionBiasEstEnabled = true,
-		.biasSigmaInit = 0.5f,
-		.biasClip = 1.0f,
-		.restThGyr = 0.5f,
-		.restThAcc = 0.196f,
+		.tauAcc = 7.171490,
+		.biasSigmaInit = 0.337976,
+		.biasForgettingTime = 352.235500,
+		.biasClip = 5.0,
+		.biasSigmaMotion = 0.985346,
+		.biasVerticalForgettingFactor = 0.007959,
+		.biasSigmaRest = 0.028897,
+		.restMinT = 4.648680,
+		.restFilterTau = 1.900166,
+		.restThGyr = 2.620598,
+		.restThAcc = 2.142593,
 	};
 
 	ICM45686(RegisterInterface& registerInterface, SlimeVR::Logging::Logger& logger)


### PR DESCRIPTION
This PR:
- Replaces the previous VQFParams for ICM-45686 with the optimized ones. They're not perfect yet, but enough testing has been done by the community to determine that they're better than what we had previously.
- Fixes a comment in the ICM-45686 driver
- Disables 2-point temperature gradient calibration, as it's unclear whether it actually helps with anything (and makes the calibration process longer)