### PR TITLE
Add IMU_USE_EXTERNAL_CLOCK to debug.h

### DIFF
--- a/src/debug.h
+++ b/src/debug.h
@@ -39,10 +39,6 @@
 		   // disable if problems. Server does nothing with value so disabled atm
 #define SEND_ACCELERATION true  // send linear acceleration to the server
 
-#ifndef IMU_USE_EXTERNAL_CLOCK
-#define IMU_USE_EXTERNAL_CLOCK true  // Use external clock for IMU (ICM-45686 only)
-#endif
-
 // Debug information
 
 #define LOG_LEVEL LOG_LEVEL_DEBUG

--- a/src/debug.h
+++ b/src/debug.h
@@ -39,6 +39,10 @@
 		   // disable if problems. Server does nothing with value so disabled atm
 #define SEND_ACCELERATION true  // send linear acceleration to the server
 
+#ifndef IMU_USE_EXTERNAL_CLOCK
+#define IMU_USE_EXTERNAL_CLOCK true  // Use external clock for IMU (ICM-45686 only)
+#endif
+
 // Debug information
 
 #define LOG_LEVEL LOG_LEVEL_DEBUG

--- a/src/globals.h
+++ b/src/globals.h
@@ -53,6 +53,10 @@
 #define EXPERIMENTAL_BNO_DISABLE_ACCEL_CALIBRATION true
 #endif
 
+#ifndef IMU_USE_EXTERNAL_CLOCK
+#define IMU_USE_EXTERNAL_CLOCK true  // Use external clock for IMU (ICM-45686 only)
+#endif
+
 #ifndef VENDOR_NAME
 #define VENDOR_NAME "Unknown"
 #endif

--- a/src/sensors/softfusion/drivers/icm45686.h
+++ b/src/sensors/softfusion/drivers/icm45686.h
@@ -75,8 +75,10 @@ struct ICM45686 : public ICM45Base {
 
 	bool initialize() {
 		ICM45Base::softResetIMU();
+#if IMU_USE_EXTERNAL_CLOCK
 		m_RegisterInterface.writeReg(Regs::Pin9Config::reg, Regs::Pin9Config::value);
 		m_RegisterInterface.writeReg(Regs::RtcConfig::reg, Regs::RtcConfig::value);
+#endif
 		return ICM45Base::initializeBase();
 	}
 };


### PR DESCRIPTION
Allows user to easily disable external IMU clock, if they are using a design which doesn't have one