### PR TITLE
Revert "Unfuck accelerometer"

### DIFF
--- a/src/debug.h
+++ b/src/debug.h
@@ -96,7 +96,7 @@
 // Not recommended for production
 #define ENABLE_INSPECTION false
 
-#define PROTOCOL_VERSION 21
+#define PROTOCOL_VERSION 22
 
 #ifndef FIRMWARE_VERSION
 #define FIRMWARE_VERSION "UNKNOWN"

--- a/src/sensors/sensor.cpp
+++ b/src/sensors/sensor.cpp
@@ -33,6 +33,7 @@ SensorStatus Sensor::getSensorState() {
 
 void Sensor::setAcceleration(Vector3 a) {
 	acceleration = a;
+	sensorOffset.sandwich(acceleration);
 	newAcceleration = true;
 }
 


### PR DESCRIPTION
This commit actually *did* unfuck the accelerometer, just the server side was so wrong that it was nearly impossible to tell. Let's fix that.

Bumped protocol version to 22 and added a check to the server: https://github.com/SlimeVR/SlimeVR-Server/pull/1706