### PR TITLE
fix no broadcast after disconnect

### DIFF
--- a/src/network/connection.cpp
+++ b/src/network/connection.cpp
@@ -620,6 +620,9 @@ void Connection::reset() {
 
 	m_UDP.begin(m_ServerPort);
 
+	// Reset server address to broadcast if disconnected
+	m_ServerHost = IPAddress(255, 255, 255, 255);
+
 	statusManager.setStatus(SlimeVR::Status::SERVER_CONNECTING, true);
 }
 
@@ -649,6 +652,9 @@ void Connection::update() {
 			false
 		);
 		m_Logger.warn("Connection to server timed out");
+
+		// Reset server address to broadcast if disconnected
+		m_ServerHost = IPAddress(255, 255, 255, 255);
 
 		return;
 	}


### PR DESCRIPTION
After a disconnect the trackers did not send a broadcast to discover the server but did directly try to send it to the server. So if for some reason the server did change its IP address the tracker had to be rebooted.