### PR TITLE
fix icm42688

### DIFF
--- a/src/sensors/softfusion/drivers/icm42688.h
+++ b/src/sensors/softfusion/drivers/icm42688.h
@@ -56,10 +56,12 @@ struct ICM42688 {
 	// corresponding sensitivity scale factor values are 131 LSB/dps for gyroscope and
 	// 8192 LSB/g for accelerometer.
 	static constexpr float GyroSensitivity = (DEBUG_ICM42688_HIRES ? 131.0f : 32.8f);
-	static constexpr float AccelSensitivity = (DEBUG_ICM42688_HIRES ? 8192.0f : 4096.0f);
+	static constexpr float AccelSensitivity
+		= (DEBUG_ICM42688_HIRES ? 8192.0f : 4096.0f);
 
 	static constexpr float TemperatureBias = 25.0f;
-	static constexpr float TemperatureSensitivity = (DEBUG_ICM42688_HIRES ? 132.48f : 2.07f);
+	static constexpr float TemperatureSensitivity
+		= (DEBUG_ICM42688_HIRES ? 132.48f : 2.07f);
 	static constexpr float TemperatureZROChange = 20.0f;
 
 	static constexpr VQFParams SensorVQFParams{};
@@ -94,10 +96,9 @@ struct ICM42688 {
 			static constexpr uint8_t reg = 0x5f;
 			static constexpr uint8_t value
 				= 0b1 | (0b1 << 1) | (0b1 << 2)
-				| (DEBUG_ICM42688_HIRES
-					   ? (0b1 << 4)
-					   : (0b0 << 4));  // fifo accel en=1, gyro=1, temp=1,
-									   // hires=DEBUG_ICM42688_HIRES
+				| (DEBUG_ICM42688_HIRES ? (0b1 << 4) : (0b0 << 4));
+			// fifo accel en=1, gyro=1, temp=1,
+			// hires=DEBUG_ICM42688_HIRES
 		};
 		struct GyroConfig {
 			static constexpr uint8_t reg = 0x4f;
@@ -143,22 +144,19 @@ struct ICM42688 {
 			// https://invensense.tdk.com/wp-content/uploads/2020/04/ds-000347_icm-42688-p-datasheet.pdf
 			// When 20-bits data format is used, gyroscope data consists of 19-bits
 			// of actual data and the LSB is always set to 0
-			out[0] = static_cast<int32_t>(part.gyro[0]) << 3
-					| ((part.xlsb & 0xe) >> 1);
-			out[1] = static_cast<int32_t>(part.gyro[1]) << 3
-					| ((part.ylsb & 0xe) >> 1);
-			out[2] = static_cast<int32_t>(part.gyro[2]) << 3
-					| ((part.zlsb & 0xe) >> 1);
+			out[0] = static_cast<int32_t>(part.gyro[0]) << 3 | ((part.xlsb & 0xe) >> 1);
+			out[1] = static_cast<int32_t>(part.gyro[1]) << 3 | ((part.ylsb & 0xe) >> 1);
+			out[2] = static_cast<int32_t>(part.gyro[2]) << 3 | ((part.zlsb & 0xe) >> 1);
 		}
 		void getAccel(int32_t out[3]) {
 			// accelerometer data consists of 18-bits of actual data and the two
 			// lowest order bits are always set to 0
 			out[0] = static_cast<int32_t>(part.accel[0]) << 2
-							| (static_cast<int32_t>((part.xlsb) & 0xf0) >> 6);
+				   | (static_cast<int32_t>((part.xlsb) & 0xf0) >> 6);
 			out[1] = static_cast<int32_t>(part.accel[1]) << 2
-							| (static_cast<int32_t>((part.ylsb) & 0xf0) >> 6);
+				   | (static_cast<int32_t>((part.ylsb) & 0xf0) >> 6);
 			out[2] = static_cast<int32_t>(part.accel[2]) << 2
-							| (static_cast<int32_t>((part.zlsb) & 0xf0) >> 6);
+				   | (static_cast<int32_t>((part.zlsb) & 0xf0) >> 6);
 		}
 	};
 
@@ -190,7 +188,10 @@ struct ICM42688 {
 	static_assert(sizeof(FifoEntryAlignedHires) == 19);
 	static_assert(sizeof(FifoEntryAlignedDefault) == 15);
 
-	using FifoEntryAligned = std::conditional<DEBUG_ICM42688_HIRES, FifoEntryAlignedHires, FifoEntryAlignedDefault>::type;
+	using FifoEntryAligned = std::conditional<
+		DEBUG_ICM42688_HIRES,
+		FifoEntryAlignedHires,
+		FifoEntryAlignedDefault>::type;
 
 	static constexpr size_t FullFifoEntrySize = sizeof(FifoEntryAligned) + 1;
 	// max 4 readings in highres mode 8 readings delay too high 6 seems to be the


### PR DESCRIPTION
Try to fix the ICM42688
Currently with that configuration it still snaps around when printing stuff or saving calibration.