### PR TITLE
Fix sampling rate miscalibration problem

### DIFF
--- a/src/sensors/softfusion/CalibrationBase.h
+++ b/src/sensors/softfusion/CalibrationBase.h
@@ -87,6 +87,7 @@ public:
 
 	virtual const uint8_t* getMotionlessCalibrationData() = 0;
 
+	virtual void signalOverwhelmed() {}
 	virtual void provideAccelSample(const RawSensorT accelSample[3]) {}
 	virtual void provideGyroSample(const RawSensorT gyroSample[3]) {}
 	virtual void provideTempSample(float tempSample) {}

--- a/src/sensors/softfusion/drivers/bmi160.h
+++ b/src/sensors/softfusion/drivers/bmi160.h
@@ -25,6 +25,7 @@
 
 #include <algorithm>
 #include <array>
+#include <cstddef>
 #include <cstdint>
 #include <cstring>
 #include <limits>
@@ -176,7 +177,7 @@ struct BMI160 {
 		return to_ret;
 	}
 
-	void bulkRead(DriverCallbacks<int16_t>&& callbacks) {
+	bool bulkRead(DriverCallbacks<int16_t>&& callbacks) {
 		const auto fifo_bytes = m_RegisterInterface.readReg16(Regs::FifoLength) & 0x7FF;
 
 		const auto bytes_to_read = std::min(
@@ -219,6 +220,7 @@ struct BMI160 {
 				}
 			}
 		}
+		return static_cast<size_t>(fifo_bytes) > static_cast<size_t>(bytes_to_read);
 	}
 };
 

--- a/src/sensors/softfusion/drivers/bmi270.h
+++ b/src/sensors/softfusion/drivers/bmi270.h
@@ -428,7 +428,7 @@ struct BMI270 {
 		return to_ret;
 	}
 
-	void bulkRead(DriverCallbacks<int16_t>&& callbacks) {
+	bool bulkRead(DriverCallbacks<int16_t>&& callbacks) {
 		const auto fifo_bytes = m_RegisterInterface.readReg16(Regs::FifoCount);
 
 		const auto bytes_to_read = std::min(
@@ -482,6 +482,8 @@ struct BMI270 {
 				}
 			}
 		}
+
+		return fifo_bytes > bytes_to_read;
 	}
 };
 

--- a/src/sensors/softfusion/drivers/icm42688.h
+++ b/src/sensors/softfusion/drivers/icm42688.h
@@ -152,7 +152,7 @@ struct ICM42688 {
 		return true;
 	}
 
-	void bulkRead(DriverCallbacks<int32_t>&& callbacks) {
+	bool bulkRead(DriverCallbacks<int32_t>&& callbacks) {
 		const auto fifo_bytes = m_RegisterInterface.readReg16(Regs::FifoCount);
 
 		std::array<uint8_t, FullFifoEntrySize * 8> read_buffer;  // max 8 readings
@@ -197,6 +197,8 @@ struct ICM42688 {
 				);
 			}
 		}
+
+		return fifo_bytes > bytes_to_read;
 	}
 };
 

--- a/src/sensors/softfusion/drivers/lsm6ds-common.h
+++ b/src/sensors/softfusion/drivers/lsm6ds-common.h
@@ -55,7 +55,7 @@ struct LSM6DSOutputHandler {
 	static constexpr size_t FullFifoEntrySize = sizeof(FifoEntryAligned) + 1;
 
 	template <typename Regs>
-	void bulkRead(
+	bool bulkRead(
 		DriverCallbacks<int16_t>&& callbacks,
 		float GyrTs,
 		float AccTs,
@@ -103,6 +103,7 @@ struct LSM6DSOutputHandler {
 					break;
 			}
 		}
+		return fifo_bytes > bytes_to_read;
 	}
 };
 

--- a/src/sensors/softfusion/drivers/lsm6dso.h
+++ b/src/sensors/softfusion/drivers/lsm6dso.h
@@ -117,8 +117,8 @@ struct LSM6DSO : LSM6DSOutputHandler {
 		return true;
 	}
 
-	void bulkRead(DriverCallbacks<int16_t>&& callbacks) {
-		LSM6DSOutputHandler::template bulkRead<Regs>(
+	bool bulkRead(DriverCallbacks<int16_t>&& callbacks) {
+		return LSM6DSOutputHandler::template bulkRead<Regs>(
 			std::move(callbacks),
 			GyrTs,
 			AccTs,

--- a/src/sensors/softfusion/drivers/lsm6dsr.h
+++ b/src/sensors/softfusion/drivers/lsm6dsr.h
@@ -115,8 +115,8 @@ struct LSM6DSR : LSM6DSOutputHandler {
 		return true;
 	}
 
-	void bulkRead(DriverCallbacks<int16_t>&& callbacks) {
-		LSM6DSOutputHandler::template bulkRead<Regs>(
+	bool bulkRead(DriverCallbacks<int16_t>&& callbacks) {
+		return LSM6DSOutputHandler::template bulkRead<Regs>(
 			std::move(callbacks),
 			GyrTs,
 			AccTs,

--- a/src/sensors/softfusion/drivers/lsm6dsv.h
+++ b/src/sensors/softfusion/drivers/lsm6dsv.h
@@ -131,8 +131,8 @@ struct LSM6DSV : LSM6DSOutputHandler {
 		return true;
 	}
 
-	void bulkRead(DriverCallbacks<int16_t>&& callbacks) {
-		LSM6DSOutputHandler::template bulkRead<Regs>(
+	bool bulkRead(DriverCallbacks<int16_t>&& callbacks) {
+		return LSM6DSOutputHandler::template bulkRead<Regs>(
 			std::move(callbacks),
 			GyrTs,
 			AccTs,

--- a/src/sensors/softfusion/runtimecalibration/CalibrationStep.h
+++ b/src/sensors/softfusion/runtimecalibration/CalibrationStep.h
@@ -46,6 +46,9 @@ public:
 	virtual void cancel() = 0;
 
 	virtual bool requiresRest() { return true; }
+	// Signals that the sensor had more packets than the MCU could read, which can
+	// compromise calibration
+	virtual void signalOverwhelmed() {}
 	virtual void processAccelSample(const SensorRawT accelSample[3]) {}
 	virtual void processGyroSample(const SensorRawT accelSample[3]) {}
 	virtual void processTempSample(float tempSample) {}

--- a/src/sensors/softfusion/runtimecalibration/SampleRateCalibrationStep.h
+++ b/src/sensors/softfusion/runtimecalibration/SampleRateCalibrationStep.h
@@ -67,6 +67,14 @@ public:
 	void cancel() override final { calibrationData.reset(); }
 	bool requiresRest() override final { return false; }
 
+	void signalOverwhelmed() override final {
+		// Not good, restart
+		calibrationData.value().accelSamples = 0;
+		calibrationData.value().gyroSamples = 0;
+		calibrationData.value().tempSamples = 0;
+		calibrationData.value().startMillis = millis();
+	}
+
 	void processAccelSample(const SensorRawT accelSample[3]) override final {
 		calibrationData.value().accelSamples++;
 	}

--- a/src/sensors/softfusion/softfusionsensor.h
+++ b/src/sensors/softfusion/softfusionsensor.h
@@ -241,7 +241,7 @@ public:
 		constexpr uint32_t sendInterval = 1.0f / maxSendRateHz * 1e6f;
 		elapsed = now - m_lastRotationPacketSent;
 		if (elapsed >= sendInterval) {
-			m_sensor.bulkRead({
+			auto overwhelmed = m_sensor.bulkRead({
 				[&](const auto sample[3], float AccTs) {
 					processAccelSample(sample, AccTs);
 				},
@@ -252,6 +252,9 @@ public:
 					processTempSample(sample, TempTs);
 				},
 			});
+			if (overwhelmed) {
+				calibrator.signalOverwhelmed();
+			}
 			if (!m_fusion.isUpdated()) {
 				checkSensorTimeout();
 				return;


### PR DESCRIPTION
In previous firmware versions, there is an issue, where the tracker miscalculates the sampling rate of the IMU, which causes sensitivity issues. This is caused by sudden spikes in calculation overhead, for example saving the configuration, wifi activity, or things like that. This creates a sudden burst of unread IMU samples. Since we read at a given max rate, but the calibration is real-time based, this can create a false representation of how many samples we receive each second.

To mitigate this issue, several steps were taken:
- Now the sampling rate calibration doesn't get saved by itself. Since this is redone each time the tracker is turned on, this isn't a huge issue, and as a side effect, this also reduces the number of EEPROM writes, albeit by a trivial amount.
- Now the IMU reading code can signal when the MCU is seemingly "overwhelmed", meaning it has more readings than it can handle in a single step. This is then used by the sampling rate calibration code to restart the step completely.

With these two solutions, the calibration is back to being functional. Other steps are unlikely to be affected by the same issue, since they are average based, not time based.