### PR TITLE
Fix LSM* Accelerometer Sensitivity

### DIFF
--- a/src/sensors/softfusion/drivers/lsm6ds3trc.h
+++ b/src/sensors/softfusion/drivers/lsm6ds3trc.h
@@ -54,7 +54,7 @@ struct LSM6DS3TRC {
 	static constexpr float TempTs = 1.0 / TempFreq;
 
 	static constexpr float GyroSensitivity = 28.571428571f;
-	static constexpr float AccelSensitivity = 4098.360655738f;
+	static constexpr float AccelSensitivity = 1000 / 0.122f;
 
 	static constexpr float TemperatureBias = 25.0f;
 	static constexpr float TemperatureSensitivity = 256.0f;

--- a/src/sensors/softfusion/drivers/lsm6dso.h
+++ b/src/sensors/softfusion/drivers/lsm6dso.h
@@ -53,7 +53,7 @@ struct LSM6DSO : LSM6DSOutputHandler {
 	static constexpr float TempTs = 1.0 / TempFreq;
 
 	static constexpr float GyroSensitivity = 1000 / 35.0f;
-	static constexpr float AccelSensitivity = 1000 / 0.244f;
+	static constexpr float AccelSensitivity = 1000 / 0.122f;
 
 	static constexpr float TemperatureBias = 25.0f;
 	static constexpr float TemperatureSensitivity = 256.0f;

--- a/src/sensors/softfusion/drivers/lsm6dsr.h
+++ b/src/sensors/softfusion/drivers/lsm6dsr.h
@@ -51,7 +51,7 @@ struct LSM6DSR : LSM6DSOutputHandler {
 	static constexpr float TempTs = 1.0 / TempFreq;
 
 	static constexpr float GyroSensitivity = 1000 / 35.0f;
-	static constexpr float AccelSensitivity = 1000 / 0.244f;
+	static constexpr float AccelSensitivity = 1000 / 0.122f;
 
 	static constexpr float TemperatureBias = 25.0f;
 	static constexpr float TemperatureSensitivity = 256.0f;

--- a/src/sensors/softfusion/drivers/lsm6dsv.h
+++ b/src/sensors/softfusion/drivers/lsm6dsv.h
@@ -52,7 +52,7 @@ struct LSM6DSV : LSM6DSOutputHandler {
 	static constexpr float TempTs = 1.0 / TempFreq;
 
 	static constexpr float GyroSensitivity = 1000 / 35.0f;
-	static constexpr float AccelSensitivity = 1000 / 0.244f;
+	static constexpr float AccelSensitivity = 1000 / 0.122f;
 
 	static constexpr float TemperatureBias = 25.0f;
 	static constexpr float TemperatureSensitivity = 256.0f;


### PR DESCRIPTION
Fixes accelerometer sensitivity for LSM* IMUs since I broke it when changing scale to 4G