### PR TITLE
Remove 100ms blocking blink

### DIFF
--- a/src/sensors/softfusion/runtimecalibration/RuntimeCalibration.h
+++ b/src/sensors/softfusion/runtimecalibration/RuntimeCalibration.h
@@ -316,8 +316,6 @@ private:
 		calibration.data.runtimeCalibration = this->calibration;
 		configuration.setSensor(sensorId, calibration);
 		configuration.save();
-
-		ledManager.blink(100);
 	}
 
 	enum class CalibrationPrintFlags {


### PR DESCRIPTION
I don't see a need for it during runtime calibration.