### PR TITLE
check if sensortoggle is populated

### DIFF
--- a/src/configuration/Configuration.cpp
+++ b/src/configuration/Configuration.cpp
@@ -123,14 +123,21 @@ void Configuration::save() {
 		file.write((uint8_t*)&config, sizeof(SensorConfig));
 		file.close();
 
-		sprintf(path, DIR_TOGGLES "/%zu", i);
+		if (i < m_SensorToggles.size()) {
+			sprintf(path, DIR_TOGGLES "/%zu", i);
 
-		m_Logger.trace("Saving sensor toggle state for %d", i);
+			m_Logger.trace("Saving sensor toggle state for %d", i);
 
-		file = LittleFS.open(path, "w");
-		auto toggleValues = m_SensorToggles[i].getValues();
-		file.write((uint8_t*)&toggleValues, sizeof(SensorToggleValues));
-		file.close();
+			file = LittleFS.open(path, "w");
+			auto toggleValues = m_SensorToggles[i].getValues();
+			file.write((uint8_t*)&toggleValues, sizeof(SensorToggleValues));
+			file.close();
+		} else {
+			m_Logger.trace(
+				"Skipping saving toggles for sensor %d, no toggles present",
+				i
+			);
+		}
 	}
 
 	{


### PR DESCRIPTION
Not sure if it will find any edge case.  The use of .getValues() should be programmed in a different way.
I open this as a daft for discussion / basis to work on.
I generaly dont like how the sensortoggles are done. (Saved in memory 2 times,...)

This could work as a quick fix for not to crash once after a factoryreset

@gorbit99 