### PR TITLE
Fix applicationoffset for the firmware flasher

### DIFF
--- a/board-defaults.json
+++ b/board-defaults.json
@@ -307,7 +307,7 @@
 				}
 			},
 			"flashingRules": {
-				"applicationOffset": 0,
+				"applicationOffset": 65536,
 				"needBootPress": false,
 				"needManualReboot": false,
 				"shouldOnlyUseDefaults": false
@@ -346,7 +346,7 @@
 				}
 			},
 			"flashingRules": {
-				"applicationOffset": 0,
+				"applicationOffset": 65536,
 				"needBootPress": false,
 				"needManualReboot": false,
 				"shouldOnlyUseDefaults": false
@@ -385,7 +385,7 @@
 				}
 			},
 			"flashingRules": {
-				"applicationOffset": 0,
+				"applicationOffset": 65536,
 				"needBootPress": false,
 				"needManualReboot": false,
 				"shouldOnlyUseDefaults": false
@@ -424,7 +424,7 @@
 				}
 			},
 			"flashingRules": {
-				"applicationOffset": 0,
+				"applicationOffset": 65536,
 				"needBootPress": false,
 				"needManualReboot": false,
 				"shouldOnlyUseDefaults": false
@@ -463,7 +463,7 @@
 				}
 			},
 			"flashingRules": {
-				"applicationOffset": 0,
+				"applicationOffset": 65536,
 				"needBootPress": false,
 				"needManualReboot": false,
 				"shouldOnlyUseDefaults": false
@@ -502,7 +502,7 @@
 				}
 			},
 			"flashingRules": {
-				"applicationOffset": 0,
+				"applicationOffset": 65536,
 				"needBootPress": false,
 				"needManualReboot": false,
 				"shouldOnlyUseDefaults": false
@@ -541,7 +541,7 @@
 				}
 			},
 			"flashingRules": {
-				"applicationOffset": 0,
+				"applicationOffset": 65536,
 				"needBootPress": false,
 				"needManualReboot": false,
 				"shouldOnlyUseDefaults": false
@@ -580,7 +580,7 @@
 				}
 			},
 			"flashingRules": {
-				"applicationOffset": 0,
+				"applicationOffset": 65536,
 				"needBootPress": false,
 				"needManualReboot": false,
 				"shouldOnlyUseDefaults": false


### PR DESCRIPTION
fix flashing offset for esp32, esp32-c3 and esp32-c6 (well C6 is not supported to flash by the SlimeVR server)