### PR TITLE
Fix incorrect SensorFusion argument in CalibrationBase

### DIFF
--- a/src/sensors/softfusion/CalibrationBase.h
+++ b/src/sensors/softfusion/CalibrationBase.h
@@ -82,6 +82,8 @@ public:
 
 	virtual void scaleGyroSample(sensor_real_t gyroSample[3]) = 0;
 	virtual float getGyroTimestep() = 0;
+	
+	virtual float getMagTimestep() = 0;
 
 	virtual float getTempTimestep() = 0;
 
@@ -100,7 +102,7 @@ protected:
 			IMU::SensorVQFParams,
 			getGyroTimestep(),
 			getAccelTimestep(),
-			getTempTimestep()
+			getMagTimestep()
 		);
 	}
 

--- a/src/sensors/softfusion/CalibrationBase.h
+++ b/src/sensors/softfusion/CalibrationBase.h
@@ -82,7 +82,6 @@ public:
 
 	virtual void scaleGyroSample(sensor_real_t gyroSample[3]) = 0;
 	virtual float getGyroTimestep() = 0;
-	
 	virtual float getMagTimestep() = 0;
 
 	virtual float getTempTimestep() = 0;

--- a/src/sensors/softfusion/SoftfusionCalibration.h
+++ b/src/sensors/softfusion/SoftfusionCalibration.h
@@ -231,6 +231,8 @@ public:
 	}
 
 	float getGyroTimestep() final { return calibration.G_Ts; }
+	
+	float getMagTimestep() final { return calibration.M_Ts; }
 
 	float getTempTimestep() final { return calibration.T_Ts; }
 

--- a/src/sensors/softfusion/SoftfusionCalibration.h
+++ b/src/sensors/softfusion/SoftfusionCalibration.h
@@ -231,7 +231,6 @@ public:
 	}
 
 	float getGyroTimestep() final { return calibration.G_Ts; }
-	
 	float getMagTimestep() final { return calibration.M_Ts; }
 
 	float getTempTimestep() final { return calibration.T_Ts; }

--- a/src/sensors/softfusion/runtimecalibration/RuntimeCalibration.h
+++ b/src/sensors/softfusion/runtimecalibration/RuntimeCalibration.h
@@ -179,7 +179,6 @@ public:
 	}
 
 	float getGyroTimestep() final { return activeCalibration.G_Ts; }
-	
 	float getMagTimestep() final { return activeCalibration.M_Ts; }
 
 	float getTempTimestep() final { return activeCalibration.T_Ts; }

--- a/src/sensors/softfusion/runtimecalibration/RuntimeCalibration.h
+++ b/src/sensors/softfusion/runtimecalibration/RuntimeCalibration.h
@@ -179,6 +179,8 @@ public:
 	}
 
 	float getGyroTimestep() final { return activeCalibration.G_Ts; }
+	
+	float getMagTimestep() final { return activeCalibration.M_Ts; }
 
 	float getTempTimestep() final { return activeCalibration.T_Ts; }
 


### PR DESCRIPTION
This PR fixes an incorrect SensorFusion argument in the CalibrationBase header.

I found the issue while personally implementing magnetometer support. Since SensorFusion currently has no magnetometer integration, this mismatch likely didn’t cause any runtime issues, but it could become a problem once magnetometer support is added.

Tested: Builds successfully across environments and runs without issues.