### PR TITLE
Fix the order of vqf updates to the recommended order.

### DIFF
--- a/src/sensors/SensorFusion.cpp
+++ b/src/sensors/SensorFusion.cpp
@@ -7,8 +7,8 @@ void SensorFusion::update6D(
 	sensor_real_t Gxyz[3],
 	sensor_real_t deltat
 ) {
-	updateAcc(Axyz, deltat);
 	updateGyro(Gxyz, deltat);
+	updateAcc(Axyz, deltat);
 }
 
 void SensorFusion::update9D(
@@ -17,9 +17,9 @@ void SensorFusion::update9D(
 	sensor_real_t Mxyz[3],
 	sensor_real_t deltat
 ) {
-	updateMag(Mxyz, deltat);
-	updateAcc(Axyz, deltat);
 	updateGyro(Gxyz, deltat);
+	updateAcc(Axyz, deltat);
+	updateMag(Mxyz, deltat);
 }
 
 void SensorFusion::updateAcc(const sensor_real_t Axyz[3], sensor_real_t deltat) {


### PR DESCRIPTION
The text may be awkward due to the use of a translator.

Issue: If the order is wrong, this will cause an issue where it updateAcc with the gyrQuat of the previous sample.

Reference:
  - [[VQF DOC - VQF class]](https://vqf.readthedocs.io/en/stable/ref_cpp.html#)

~~# Test Setup~~
~~**Device:** Chest tracker (LSM6DSR + MMC5603NJ)~~
~~**Magnetometer: OFF**~~

~~Gyro bias calibration logs:~~
```
[INFO ] [LSM6DSR:0] Calibrated gyro bias at 22.921875C: 10.919210 -13.017056 2.500000
[INFO ] [LSM6DSR:0] Calibrated gyro bias at 36.132812C: 11.463371 -14.227714 5.920565
```

~~# Test Method~~
~~1. Prepare a chest tracker with 2-point temperature gyro bias calibration (22.9°C and 36.13°C as shown above).~~
~~2. Power on the tracker and leave it resting flat for 30 seconds~~
~~  - Purpose: allow “rest” handling and any remaining gyro bias calibration to settle.~~
~~3. Wear it directly on bare skin and stay active for 30 minutes~~
~~  - Purpose: stabilize strap tension and bring the tracker to a realistic operating temperature.~~
~~4. Perform Full Reset → Body Reset.~~
~~5. Record and observe drift for 30 minutes on the Body Proportions screen.~~

~~# Result~~
~~Compared to the previous behavior, drift was reduced by approximately 1–2 degrees.~~


~~This isn’t a perfectly controlled test (human-body bias, strap tension, environment, etc.), but even considering those factors, the improvement looked significant in my use case.~~

~~I’m sharing this because I think it could also be beneficial to apply the same fix to the SlimeVR Tracker firmware.~~

<img width="1446" height="722" alt="BEFORE FIX" src="https://github.com/user-attachments/assets/eca7cc99-74ed-406c-98c9-041d3bb2f766" />
<img width="1440" height="738" alt="AFTER FIX" src="https://github.com/user-attachments/assets/deb449bd-31e9-4488-84cf-4e09c538e607" />