### PR TITLE
Validate sensor calibration files

### DIFF
--- a/src/FSHelper.h
+++ b/src/FSHelper.h
@@ -46,8 +46,8 @@ public:
 	size_t size() const { return m_File.size(); }
 	bool isDirectory() { return m_File.isDirectory(); }
 	bool seek(size_t pos) { return m_File.seek(pos); }
-	bool read(uint8_t* buffer, size_t size) { return m_File.read(buffer, size); }
-	bool write(const uint8_t* buffer, size_t size) {
+	size_t read(uint8_t* buffer, size_t size) { return m_File.read(buffer, size); }
+	size_t write(const uint8_t* buffer, size_t size) {
 		return m_File.write(buffer, size);
 	}
 	void close() { return m_File.close(); }

--- a/src/configuration/Configuration.cpp
+++ b/src/configuration/Configuration.cpp
@@ -233,7 +233,8 @@ void Configuration::loadSensors() {
 
 		if (f.size() != sizeof(SensorConfig)) {
 			m_Logger.warn(
-				"Skipping incompatible sensor calibration file index %d (size=%u expected=%u)",
+				"Skipping incompatible sensor calibration file index %d (size=%u "
+				"expected=%u)",
 				sensorId,
 				static_cast<unsigned>(f.size()),
 				static_cast<unsigned>(sizeof(SensorConfig))

--- a/src/configuration/Configuration.cpp
+++ b/src/configuration/Configuration.cpp
@@ -229,10 +229,40 @@ void Configuration::eraseSensors() {
 
 void Configuration::loadSensors() {
 	SlimeVR::Utils::forEachFile(DIR_CALIBRATIONS, [&](SlimeVR::Utils::File f) {
-		SensorConfig sensorConfig;
-		f.read((uint8_t*)&sensorConfig, sizeof(SensorConfig));
-
 		uint8_t sensorId = strtoul(f.name(), nullptr, 10);
+
+		if (f.size() != sizeof(SensorConfig)) {
+			m_Logger.warn(
+				"Skipping incompatible sensor calibration file index %d (size=%u expected=%u)",
+				sensorId,
+				static_cast<unsigned>(f.size()),
+				static_cast<unsigned>(sizeof(SensorConfig))
+			);
+			return;
+		}
+
+		SensorConfig sensorConfig{};
+		auto bytesRead = f.read((uint8_t*)&sensorConfig, sizeof(SensorConfig));
+		if (bytesRead != sizeof(SensorConfig)) {
+			m_Logger.warn(
+				"Skipping unreadable sensor calibration file index %d (read=%u "
+				"expected=%u)",
+				sensorId,
+				static_cast<unsigned>(bytesRead),
+				static_cast<unsigned>(sizeof(SensorConfig))
+			);
+			return;
+		}
+
+		if (sensorConfig.type > SensorConfigType::RUNTIME_CALIBRATION) {
+			m_Logger.warn(
+				"Skipping sensor calibration file index %d with invalid type=%d",
+				sensorId,
+				static_cast<int>(sensorConfig.type)
+			);
+			return;
+		}
+
 		m_Logger.debug(
 			"Found sensor calibration for %s at index %d",
 			calibrationConfigTypeToString(sensorConfig.type),


### PR DESCRIPTION
change FS I/O
Add stricter validation when loading sensor calibrations: skip files with unexpected size, warn and skip if the read bytes don't match the expected struct size, and validate the sensorConfig.type value before using it. Initialize SensorConfig to zeros prior to reading. Change FSHelper read/write signatures to return size_t (bytes read/written) instead of bool to accurately reflect I/O results.
Used copilot to help