### PR TITLE
Wifiscan add channel to the output, format output

### DIFF
--- a/src/serial/serialcommands.cpp
+++ b/src/serial/serialcommands.cpp
@@ -350,7 +350,15 @@ void cmdGet(CmdParser* parser) {
 		int scanRes = WiFi.scanComplete();
 		if (scanRes >= 0) {
 			logger.info("[WSCAN] Found %d networks:", scanRes);
-			logger.info("[WSCAN] %-2s  %-3s  %-4s  %-34s  %-10s  %s", "ID", "Len", "chan", "SSID", "RSSI", "Encryption");
+			logger.info(
+				"[WSCAN] %-2s  %-3s  %-4s  %-34s  %-10s  %s",
+				"ID",
+				"Len",
+				"chan",
+				"SSID",
+				"RSSI",
+				"Encryption"
+			);
 			for (int i = 0; i < scanRes; i++) {
 				char ssidField[35];
 				snprintf(ssidField, sizeof(ssidField), "'%s'", WiFi.SSID(i).c_str());

--- a/src/serial/serialcommands.cpp
+++ b/src/serial/serialcommands.cpp
@@ -350,12 +350,16 @@ void cmdGet(CmdParser* parser) {
 		int scanRes = WiFi.scanComplete();
 		if (scanRes >= 0) {
 			logger.info("[WSCAN] Found %d networks:", scanRes);
+			logger.info("[WSCAN] %-2s  %-3s  %-4s  %-34s  %-10s  %s", "ID", "Len", "chan", "SSID", "RSSI", "Encryption");
 			for (int i = 0; i < scanRes; i++) {
+				char ssidField[35];
+				snprintf(ssidField, sizeof(ssidField), "'%s'", WiFi.SSID(i).c_str());
 				logger.info(
-					"[WSCAN] %d:\t%02d\t'%s'\t(%d dBm)\t%s",
+					"[WSCAN] %2d  %3u  %4u  %-34s  (%4d dBm)  %s",
 					i,
-					WiFi.SSID(i).length(),
-					WiFi.SSID(i).c_str(),
+					static_cast<unsigned int>(WiFi.SSID(i).length()),
+					static_cast<unsigned int>(WiFi.channel(i)),
+					ssidField,
 					WiFi.RSSI(i),
 					getEncryptionTypeName(WiFi.encryptionType(i)).c_str()
 				);


### PR DESCRIPTION
This might break some pr that try to read the SSID from the tracker over Serial as it does no longer use tab to hold the distance