### PR TITLE
fix i2c scann stalling on ESP32* boards

### DIFF
--- a/lib/i2cscan/i2cscan.cpp
+++ b/lib/i2cscan/i2cscan.cpp
@@ -18,10 +18,12 @@ namespace I2CSCAN {
 		ScanState scanState = ScanState::IDLE;
     	uint8_t currentSDA = 0;
     	uint8_t currentSCL = 0;
+		uint8_t currentSDAPortIndex = 0;
+		uint8_t currentSCLPortIndex = 0;
     	uint8_t currentAddress = 1;
     	bool found = false;
 		uint8_t txFails = 0;
-    	std::vector<uint8_t> validPorts;
+    	std::vector<uint8_t> validPortsIndex;
 
 #ifdef ESP8266
 		std::array<uint8_t, 7> portArray = {16, 5, 4, 2, 14, 12, 13};
@@ -34,7 +36,7 @@ namespace I2CSCAN {
 #elif defined(ESP32C6)
 		std::array<uint8_t, 20> portArray = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 14, 15, 18, 19, 20, 21, 22, 23};
 		std::array<std::string, 20> portMap = {"0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "14", "15", "18", "19", "20", "21", "22", "23"};
-		std::array<uint8_t, 5> portExclude = {12, 13, 16, 17, LED_PIN};
+		std::array<uint8_t, 7> portExclude = {0, 9, 12, 13, 16, 17, LED_PIN};
 #elif defined(ESP32)
 		std::array<uint8_t, 16> portArray = {4, 13, 14, 15, 16, 17, 18, 19, 21, 22, 23, 25, 26, 27, 32, 33};
 		std::array<std::string, 16> portMap = {"4", "13", "14", "15", "16", "17", "18", "19", "21", "22", "23", "25", "26", "27", "32", "33"};
@@ -42,21 +44,30 @@ namespace I2CSCAN {
 #endif
 
 		bool selectNextPort() {
-			currentSCL++;
+			currentSCLPortIndex++;
 
-			if(validPorts[currentSCL] == validPorts[currentSDA]) currentSCL++;
+			// we just need to compare the Indexes to be sure we are not on the same port
+			if(currentSCLPortIndex == currentSDAPortIndex) currentSCLPortIndex++;
 
-			if (currentSCL < validPorts.size()) {
-				Wire.begin((int)validPorts[currentSDA], (int)validPorts[currentSCL]); //NOLINT
+			if (currentSCLPortIndex < validPortsIndex.size()) {
+				// SCL changed and in index
+				currentSCL = validPortsIndex[currentSCLPortIndex];
+	#ifdef ESP32
+				Wire.end();
+	#endif
+				Wire.begin((int)portArray[currentSDA], (int)portArray[currentSCL]); //NOLINT
+//				Serial.printf_P(PSTR("[INFO ] [I2CSCAN] Change I2C to SDA: %d, SCL: %d\r\n"), (int)portArray[currentSDA], (int)portArray[currentSCL]);
 				return true;
 			}
 
-			currentSCL = 0;
-			currentSDA++;
+			currentSCLPortIndex = 0;
+			currentSCL = validPortsIndex[currentSCLPortIndex];
 
-			if (currentSDA >= validPorts.size()) {
+			currentSDAPortIndex++;
+
+			if (currentSDAPortIndex >= validPortsIndex.size()) {
 				if (!found) {
-					Serial.println("[ERROR] I2C: No I2C devices found"); //NOLINT
+					Serial.println(F("[ERROR] [I2CSCAN] I2C: No I2C devices found")); //NOLINT
 				}
 	#ifdef ESP32
 				Wire.end();
@@ -66,7 +77,8 @@ namespace I2CSCAN {
 				return false;
 			}
 
-			Wire.begin((int)validPorts[currentSDA], (int)validPorts[currentSCL]);
+			currentSDA = validPortsIndex[currentSDAPortIndex];
+			Wire.begin((int)portArray[currentSDA], (int)portArray[currentSCL]);
 			return true;
 		}
 		template <uint8_t size1, uint8_t size2>
@@ -90,27 +102,29 @@ namespace I2CSCAN {
     void scani2cports() {
         if (scanState != ScanState::IDLE) {
 			if (scanState == ScanState::DONE) {
-				Serial.println("[DEBUG] I2C scan finished previously, resetting and scanning again..."); //NOLINT
+				Serial.println(F("[DEBUG] [I2CSCAN] I2C scan finished previously, resetting and scanning again...")); //NOLINT
 			} else {
 				return; // Already scanning, do not start again
 			}
         }
 
         // Filter out excluded ports
-		validPorts.clear();
+		validPortsIndex.clear();
 		uint8_t excludes = countCommonElements<portArray.size(), portExclude.size()>(portArray, portExclude);
-		validPorts.reserve(portArray.size() - excludes); // Reserve space to avoid reallocations
+		validPortsIndex.reserve(portArray.size() - excludes); // Reserve space to avoid reallocations
 
-		for (const auto& port : portArray) {
-			if (std::find(portExclude.begin(), portExclude.end(), port) == portExclude.end()) {
-				validPorts.push_back(port); // Port is valid, add it to the list
+		for (uint8_t i; i < portArray.size(); i++) {
+			if (std::find(portExclude.begin(), portExclude.end(), i) == portExclude.end()) {
+				validPortsIndex.push_back(i); // Port is valid, add it to the list
 			}
 		}
 
 		// Reset scan variables and start scanning
         found = false;
-        currentSDA = 0;
-        currentSCL = 1;
+		currentSDAPortIndex = 0;
+		currentSCLPortIndex = 1;
+		currentSDA = validPortsIndex[currentSDAPortIndex];
+		currentSCL = validPortsIndex[currentSCLPortIndex];
         currentAddress = 1;
 		txFails = 0;
         scanState = ScanState::SCANNING;
@@ -121,22 +135,16 @@ namespace I2CSCAN {
             return;
         }
 
-#ifdef ESP32
-		if (currentAddress == 1) {
-            Wire.end();
-		}
-#endif
-
         Wire.beginTransmission(currentAddress);
         const uint8_t error = Wire.endTransmission();
 
         if (error == 0) {
-            Serial.printf("[INFO ] I2C (@ %s(%d) : %s(%d)): I2C device found at address 0x%02x!\n",
-                            portMap[currentSDA].c_str(), validPorts[currentSDA], portMap[currentSCL].c_str(), validPorts[currentSCL], currentAddress);
+            Serial.printf_P(PSTR("[INFO ] [I2CSCAN] I2C (@ %s(%d) : %s(%d)): I2C device found at address 0x%02x!\n"),
+                            portMap[currentSDA].c_str(), portArray[currentSDA], portMap[currentSCL].c_str(), portArray[currentSCL], currentAddress);
             found = true;
         } else if (error == 4) { // Unable to start transaction, log and warn
-            Serial.printf("[WARN ] I2C (@ %s(%d) : %s(%d)): Unable to start transaction at address 0x%02x!\n",
-                            portMap[currentSDA].c_str(), validPorts[currentSDA], portMap[currentSCL].c_str(), validPorts[currentSCL], currentAddress);
+            Serial.printf_P(PSTR("[WARN ] [I2CSCAN] I2C (@ %s(%d) : %s(%d)): Unable to start transaction at address 0x%02x!\n"),
+                            portMap[currentSDA].c_str(), portArray[currentSDA], portMap[currentSCL].c_str(), portArray[currentSCL], currentAddress);
             txFails++;
         }
 
@@ -145,9 +153,9 @@ namespace I2CSCAN {
         if (currentAddress <= 127) {
 			if (txFails > 5) {
 #if BOARD == BOARD_SLIMEVR_LEGACY || BOARD == BOARD_SLIMEVR_DEV || BOARD == BOARD_SLIMEVR || BOARD == BOARD_SLIMEVR_V1_2
-				Serial.printf("[ERROR] I2C: Too many transaction errors (%d), please power off the tracker and contact SlimeVR support!\n", txFails);
+				Serial.printf_P(PSTR("[ERROR] [I2CSCAN] I2C: Too many transaction errors (%d), please power off the tracker and contact SlimeVR support!\n"), txFails);
 #else
-				Serial.printf("[ERROR] I2C: Too many transaction errors (%d), please power off the tracker and check the IMU connections!\n", txFails);
+				Serial.printf_P(PSTR("[ERROR] [I2CSCAN] I2C: Too many transaction errors (%d), please power off the tracker and check the IMU connections!\n"), txFails);
 #endif
 			}
 

--- a/lib/i2cscan/i2cscan.cpp
+++ b/lib/i2cscan/i2cscan.cpp
@@ -199,11 +199,11 @@ namespace I2CSCAN {
         const uint8_t error = Wire.endTransmission();
 
         if (error == 0) {
-            Serial.printf_P(PSTR("[INFO ] [I2CSCAN] I2C (@ %s(%d) : %s(%d)): I2C device found at address 0x%02x!\n"),
+            Serial.printf_P(PSTR("[INFO ] [I2CSCAN] I2C (SDA: %s(%d) SCL: %s(%d)): I2C device found at address 0x%02x!\n"),
                             portMap[currentSDA].c_str(), portArray[currentSDA], portMap[currentSCL].c_str(), portArray[currentSCL], currentAddress);
             found = true;
         } else if (error == 4) { // Unable to start transaction, log and warn
-            Serial.printf_P(PSTR("[WARN ] [I2CSCAN] I2C (@ %s(%d) : %s(%d)): Unable to start transaction at address 0x%02x!\n"),
+            Serial.printf_P(PSTR("[WARN ] [I2CSCAN] I2C (SDA: %s(%d) SCL: %s(%d)): Unable to start transaction at address 0x%02x!\n"),
                             portMap[currentSDA].c_str(), portArray[currentSDA], portMap[currentSCL].c_str(), portArray[currentSCL], currentAddress);
             txFails++;
         }

--- a/lib/i2cscan/i2cscan.cpp
+++ b/lib/i2cscan/i2cscan.cpp
@@ -75,7 +75,7 @@ namespace I2CSCAN {
 			index = (index+1) % validPortsIndex.size();
 		}
 
-		bool incSDA(){
+		bool incrementSDA(){
 			incrementvalidPortsIndex(currentSDAPortIndex);
 			if (currentSDAPortIndex == startSDAPortIndex) {
 				// scan finished
@@ -94,7 +94,7 @@ namespace I2CSCAN {
 				incrementvalidPortsIndex(currentSCLPortIndex);
 				if (currentSCLPortIndex == startSCLPortIndex) {
 					// Point to increase SDA reached
-					if (!incSDA()) {
+					if (!incrementSDA()) {
 						return false;
 					}
 				}

--- a/lib/i2cscan/i2cscan.cpp
+++ b/lib/i2cscan/i2cscan.cpp
@@ -4,6 +4,10 @@
 #include <cstdint>
 #include <string>
 
+#ifdef ESP32
+#include "driver/i2c.h"
+#endif
+
 #include "../../src/globals.h"
 #include "../../src/consts.h"
 
@@ -15,6 +19,10 @@ namespace I2CSCAN {
     };
 
 	namespace {
+		static uint8_t defaultSDAPin =  static_cast<uint8_t>(PIN_IMU_SDA);
+		static uint8_t defaultSCLPin =  static_cast<uint8_t>(PIN_IMU_SCL);
+		uint8_t activeSDAPin = defaultSDAPin;
+		uint8_t activeSCLPin = defaultSCLPin;
 		ScanState scanState = ScanState::IDLE;
     	uint8_t currentSDA = 0;
     	uint8_t currentSCL = 0;
@@ -26,8 +34,7 @@ namespace I2CSCAN {
     	bool found = false;
 		uint8_t txFails = 0;
     	std::vector<uint8_t> validPortsIndex;
-		static uint8_t defaultSDAPin =  static_cast<uint8_t>(PIN_IMU_SDA);
-		static uint8_t defaultSCLPin =  static_cast<uint8_t>(PIN_IMU_SCL);
+
 
 #ifdef ESP8266
 		std::array<uint8_t, 7> portArray = {16, 5, 4, 2, 14, 12, 13};
@@ -49,9 +56,18 @@ namespace I2CSCAN {
 
 		void switchPort(uint8_t sdaPortIndex, uint8_t sclPortIndex) {
 #ifdef ESP32
+			// code from I2CWireSensorInterface.cpp
 			Wire.end();
+			// Reset the Pins to not map
+			gpio_set_direction((gpio_num_t)activeSCLPin, GPIO_MODE_INPUT);
+			gpio_set_direction((gpio_num_t)activeSDAPin, GPIO_MODE_INPUT);
+			// this line seems not to be needed
+			//i2c_set_pin(I2C_NUM_0, (int)portArray[sdaPortIndex], (int)portArray[sclPortIndex], false, false, I2C_MODE_MASTER);
 #endif
 			Wire.begin((int)portArray[sdaPortIndex], (int)portArray[sclPortIndex]);
+
+			activeSDAPin = portArray[sdaPortIndex];
+			activeSCLPin = portArray[sclPortIndex];
 //			Serial.printf_P(PSTR("[INFO ] [I2CSCAN] Change I2C to SDA: %d, SCL: %d\r\n"), (int)portArray[sdaPortIndex], (int)portArray[sclPortIndex]);
 		}
 
@@ -164,6 +180,8 @@ namespace I2CSCAN {
 		currentSCLPortIndex = startSCLPortIndex;
 		currentSDA = validPortsIndex[currentSDAPortIndex];
 		currentSCL = validPortsIndex[currentSCLPortIndex];
+		activeSDAPin = portArray[currentSDA];
+		activeSCLPin = portArray[currentSCL];
         currentAddress = 1;
 		txFails = 0;
         scanState = ScanState::SCANNING;

--- a/lib/i2cscan/i2cscan.cpp
+++ b/lib/i2cscan/i2cscan.cpp
@@ -71,12 +71,12 @@ namespace I2CSCAN {
 //			Serial.printf_P(PSTR("[INFO ] [I2CSCAN] Change I2C to SDA: %d, SCL: %d\r\n"), (int)portArray[sdaPortIndex], (int)portArray[sclPortIndex]);
 		}
 
-		void incvalidPortsIndex(uint8_t &index) {
+		void incrementvalidPortsIndex(uint8_t &index) {
 			index = (index+1) % validPortsIndex.size();
 		}
 
 		bool incSDA(){
-			incvalidPortsIndex(currentSDAPortIndex);
+			incrementvalidPortsIndex(currentSDAPortIndex);
 			if (currentSDAPortIndex == startSDAPortIndex) {
 				// scan finished
 				switchPort(startSDAPortIndex, startSCLPortIndex);
@@ -91,7 +91,7 @@ namespace I2CSCAN {
 
 		bool selectNextPort(){
 			while (1) {
-				incvalidPortsIndex(currentSCLPortIndex);
+				incrementvalidPortsIndex(currentSCLPortIndex);
 				if (currentSCLPortIndex == startSCLPortIndex) {
 					// Point to increase SDA reached
 					if (!incSDA()) {

--- a/lib/i2cscan/i2cscan.cpp
+++ b/lib/i2cscan/i2cscan.cpp
@@ -20,10 +20,14 @@ namespace I2CSCAN {
     	uint8_t currentSCL = 0;
 		uint8_t currentSDAPortIndex = 0;
 		uint8_t currentSCLPortIndex = 0;
+		uint8_t startSDAPortIndex = 255;
+		uint8_t startSCLPortIndex = 255;
     	uint8_t currentAddress = 1;
     	bool found = false;
 		uint8_t txFails = 0;
     	std::vector<uint8_t> validPortsIndex;
+		static uint8_t defaultSDAPin =  static_cast<uint8_t>(PIN_IMU_SDA);
+		static uint8_t defaultSCLPin =  static_cast<uint8_t>(PIN_IMU_SCL);
 
 #ifdef ESP8266
 		std::array<uint8_t, 7> portArray = {16, 5, 4, 2, 14, 12, 13};
@@ -43,44 +47,53 @@ namespace I2CSCAN {
 		std::array<uint8_t, 1> portExclude = {LED_PIN};
 #endif
 
-		bool selectNextPort() {
-			currentSCLPortIndex++;
+		void switchPort(uint8_t sdaPortIndex, uint8_t sclPortIndex) {
+#ifdef ESP32
+			Wire.end();
+#endif
+			Wire.begin((int)portArray[sdaPortIndex], (int)portArray[sclPortIndex]);
+//			Serial.printf_P(PSTR("[INFO ] [I2CSCAN] Change I2C to SDA: %d, SCL: %d\r\n"), (int)portArray[sdaPortIndex], (int)portArray[sclPortIndex]);
+		}
 
-			// we just need to compare the Indexes to be sure we are not on the same port
-			if(currentSCLPortIndex == currentSDAPortIndex) currentSCLPortIndex++;
+		void incvalidPortsIndex(uint8_t &index) {
+			index = (index+1) % validPortsIndex.size();
+		}
 
-			if (currentSCLPortIndex < validPortsIndex.size()) {
-				// SCL changed and in index
-				currentSCL = validPortsIndex[currentSCLPortIndex];
-	#ifdef ESP32
-				Wire.end();
-	#endif
-				Wire.begin((int)portArray[currentSDA], (int)portArray[currentSCL]); //NOLINT
-//				Serial.printf_P(PSTR("[INFO ] [I2CSCAN] Change I2C to SDA: %d, SCL: %d\r\n"), (int)portArray[currentSDA], (int)portArray[currentSCL]);
-				return true;
-			}
-
-			currentSCLPortIndex = 0;
-			currentSCL = validPortsIndex[currentSCLPortIndex];
-
-			currentSDAPortIndex++;
-
-			if (currentSDAPortIndex >= validPortsIndex.size()) {
+		bool incSDA(){
+			incvalidPortsIndex(currentSDAPortIndex);
+			if (currentSDAPortIndex == startSDAPortIndex) {
+				// scan finished
+				switchPort(startSDAPortIndex, startSCLPortIndex);
 				if (!found) {
 					Serial.println(F("[ERROR] [I2CSCAN] I2C: No I2C devices found")); //NOLINT
 				}
-	#ifdef ESP32
-				Wire.end();
-	#endif
-				Wire.begin(static_cast<int>(PIN_IMU_SDA), static_cast<int>(PIN_IMU_SCL));
 				scanState = ScanState::DONE;
 				return false;
 			}
-
-			currentSDA = validPortsIndex[currentSDAPortIndex];
-			Wire.begin((int)portArray[currentSDA], (int)portArray[currentSCL]);
 			return true;
 		}
+
+		bool selectNextPort(){
+			while (1) {
+				incvalidPortsIndex(currentSCLPortIndex);
+				if (currentSCLPortIndex == startSCLPortIndex) {
+					// Point to increase SDA reached
+					if (!incSDA()) {
+						return false;
+					}
+				}
+				if (currentSCLPortIndex != currentSDAPortIndex) {
+					currentSCL = validPortsIndex[currentSCLPortIndex];
+					currentSDA = validPortsIndex[currentSDAPortIndex];
+// Debug
+//					Serial.printf("CCCC currentSDAPortIndex: %d currentSCLPortIndex: %d validPortsIndex.size: %d\r\n",
+//						currentSDAPortIndex, currentSCLPortIndex, validPortsIndex.size());
+					switchPort(currentSDA, currentSCL);
+					return true;
+				}
+			}
+		}
+
 		template <uint8_t size1, uint8_t size2>
 		uint8_t countCommonElements(
 			const std::array<uint8_t, size1>& array1,
@@ -113,21 +126,50 @@ namespace I2CSCAN {
 		uint8_t excludes = countCommonElements<portArray.size(), portExclude.size()>(portArray, portExclude);
 		validPortsIndex.reserve(portArray.size() - excludes); // Reserve space to avoid reallocations
 
-		for (uint8_t i; i < portArray.size(); i++) {
-			if (std::find(portExclude.begin(), portExclude.end(), i) == portExclude.end()) {
+		for (uint8_t i=0; i < portArray.size(); i++) {
+			if (std::find(portExclude.begin(), portExclude.end(), portArray[i]) == portExclude.end()) {
 				validPortsIndex.push_back(i); // Port is valid, add it to the list
 			}
 		}
 
+		// Lets find out the configured Index for the Pins
+		for (uint8_t i=0; i < validPortsIndex.size(); i++) {
+			if (portArray[validPortsIndex[i]] == defaultSDAPin) {
+				startSDAPortIndex = i;
+			}
+			if (portArray[validPortsIndex[i]] == defaultSCLPin) {
+				startSCLPortIndex = i;
+			}
+		}
+
+//		Serial.printf_P(PSTR("[ERROR] [I2CSCAN] Default I2C Ports SDA: %d SCL: %d\r\n"), defaultSDAPin, defaultSCLPin);
+		if (startSDAPortIndex == 255 || startSCLPortIndex == 255) {
+			Serial.printf_P(PSTR("[ERROR] [I2CSCAN] I2C Ports SDA: %d SCL: %d not found in Array. Abort the I2C Scan\r\n"), defaultSDAPin, defaultSCLPin);
+			// What todo when the PIN is not in the Index? Abort the scan?
+			// The current behavior will then just set index 0 and 1 as default.
+			// This will lead to problematic behavior if the Arrays are not correctly defined.
+			// As it will not able to reset back to the previous configured pins
+			return;
+		}
+
+// Debug
+//		for (const auto& portsIndex : validPortsIndex) {
+//			Serial.printf("Pin Index: %2d PinNum: %2d PinName: %s\r\n", portsIndex, portArray[portsIndex], portMap[portsIndex].c_str());
+//		}
+//		Serial.printf("startSDAPortIndex: %2d startSCLPortIndex: %2d\r\n", startSDAPortIndex, startSCLPortIndex);
+
 		// Reset scan variables and start scanning
         found = false;
-		currentSDAPortIndex = 0;
-		currentSCLPortIndex = 1;
+		currentSDAPortIndex = startSDAPortIndex;
+		currentSCLPortIndex = startSCLPortIndex;
 		currentSDA = validPortsIndex[currentSDAPortIndex];
 		currentSCL = validPortsIndex[currentSCLPortIndex];
         currentAddress = 1;
 		txFails = 0;
         scanState = ScanState::SCANNING;
+// Debug
+//		Serial.printf("AAAA currentSDAPortIndex: %d currentSCLPortIndex: %d validPortsIndex.size: %d\r\n",
+//			currentSDAPortIndex, currentSCLPortIndex, validPortsIndex.size());
 	}
 
     void update() {


### PR DESCRIPTION
- Move Wire.end() to the correct position
- ESP32-C6 Pin 0 and 9 Report all addresses
- Fix wrong numbers/names in output