### PR TITLE
Add configurable shared SPI bus pins

### DIFF
--- a/board-defaults.json
+++ b/board-defaults.json
@@ -60,6 +60,11 @@
 						"sda": "4"
 					}
 				],
+				"SPI": {
+					"sck": "14",
+					"miso": "12",
+					"mosi": "13"
+				},
 				"BATTERY": {
 					"type": "BAT_EXTERNAL",
 					"r1": 10,

--- a/board-defaults.json
+++ b/board-defaults.json
@@ -4,22 +4,25 @@
 	"defaults": {
 		"BOARD_SLIMEVR": {
 			"values": {
-				"SENSORS": [
+				"BUSES": [
 					{
 						"protocol": "I2C",
-						"imu": "IMU_AUTO",
-						"int": "16",
-						"rotation": "DEG_270",
+						"sda": "14",
 						"scl": "12",
-						"sda": "14"
-					},
-					{
-						"protocol": "I2C",
-						"imu": "IMU_AUTO",
-						"int": "13",
-						"rotation": "DEG_270",
-						"scl": "12",
-						"sda": "14"
+						"imus": [
+							{
+								"protocol": "I2C",
+								"imu": "IMU_AUTO",
+								"int": "16",
+								"rotation": "DEG_270"
+							},
+							{
+								"protocol": "I2C",
+								"imu": "IMU_AUTO",
+								"int": "13",
+								"rotation": "DEG_270"
+							}
+						]
 					}
 				],
 				"BATTERY": {
@@ -43,28 +46,36 @@
 		},
 		"BOARD_SLIMEVR_V1_2": {
 			"values": {
-				"SENSORS": [
+				"BUSES": [
 					{
 						"protocol": "SPI",
-						"imu": "IMU_AUTO",
-						"int": "2",
-						"cs": "15",
-						"rotation": "DEG_270"
+						"sck": "14",
+						"miso": "12",
+						"mosi": "13",
+						"imus": [
+							{
+								"protocol": "SPI",
+								"imu": "IMU_AUTO",
+								"int": "2",
+								"cs": "15",
+								"rotation": "DEG_270"
+							}
+						]
 					},
 					{
 						"protocol": "I2C",
-						"imu": "IMU_AUTO",
-						"int": "16",
-						"rotation": "DEG_270",
+						"sda": "4",
 						"scl": "5",
-						"sda": "4"
+						"imus": [
+							{
+								"protocol": "I2C",
+								"imu": "IMU_AUTO",
+								"int": "16",
+								"rotation": "DEG_270"
+							}
+						]
 					}
 				],
-				"SPI": {
-					"sck": "14",
-					"miso": "12",
-					"mosi": "13"
-				},
 				"BATTERY": {
 					"type": "BAT_EXTERNAL",
 					"r1": 10,
@@ -86,22 +97,25 @@
 		},
 		"BOARD_SLIMEVR_DEV": {
 			"values": {
-				"SENSORS": [
+				"BUSES": [
 					{
 						"protocol": "I2C",
-						"imu": "IMU_AUTO",
-						"int": "10",
-						"rotation": "DEG_270",
+						"sda": "4",
 						"scl": "5",
-						"sda": "4"
-					},
-					{
-						"protocol": "I2C",
-						"imu": "IMU_AUTO",
-						"int": "13",
-						"rotation": "DEG_270",
-						"scl": "5",
-						"sda": "4"
+						"imus": [
+							{
+								"protocol": "I2C",
+								"imu": "IMU_AUTO",
+								"int": "10",
+								"rotation": "DEG_270"
+							},
+							{
+								"protocol": "I2C",
+								"imu": "IMU_AUTO",
+								"int": "13",
+								"rotation": "DEG_270"
+							}
+						]
 					}
 				],
 				"BATTERY": {
@@ -125,22 +139,25 @@
 		},
 		"BOARD_WEMOSD1MINI": {
 			"values": {
-				"SENSORS": [
+				"BUSES": [
 					{
 						"protocol": "I2C",
-						"imu": "IMU_AUTO",
-						"int": "D5",
-						"rotation": "DEG_270",
+						"sda": "D2",
 						"scl": "D1",
-						"sda": "D2"
-					},
-					{
-						"protocol": "I2C",
-						"imu": "IMU_AUTO",
-						"int": "D6",
-						"rotation": "DEG_270",
-						"scl": "D1",
-						"sda": "D2"
+						"imus": [
+							{
+								"protocol": "I2C",
+								"imu": "IMU_AUTO",
+								"int": "D5",
+								"rotation": "DEG_270"
+							},
+							{
+								"protocol": "I2C",
+								"imu": "IMU_AUTO",
+								"int": "D6",
+								"rotation": "DEG_270"
+							}
+						]
 					}
 				],
 				"BATTERY": {
@@ -164,22 +181,25 @@
 		},
 		"BOARD_NODEMCU": {
 			"values": {
-				"SENSORS": [
+				"BUSES": [
 					{
 						"protocol": "I2C",
-						"imu": "IMU_BNO085",
-						"int": "D5",
-						"rotation": "DEG_270",
+						"sda": "D2",
 						"scl": "D1",
-						"sda": "D2"
-					},
-					{
-						"protocol": "I2C",
-						"imu": "IMU_BNO085",
-						"int": "D6",
-						"rotation": "DEG_270",
-						"scl": "D1",
-						"sda": "D2"
+						"imus": [
+							{
+								"protocol": "I2C",
+								"imu": "IMU_BNO085",
+								"int": "D5",
+								"rotation": "DEG_270"
+							},
+							{
+								"protocol": "I2C",
+								"imu": "IMU_BNO085",
+								"int": "D6",
+								"rotation": "DEG_270"
+							}
+						]
 					}
 				],
 				"BATTERY": {
@@ -203,22 +223,25 @@
 		},
 		"BOARD_ESP01": {
 			"values": {
-				"SENSORS": [
+				"BUSES": [
 					{
 						"protocol": "I2C",
-						"imu": "IMU_BNO085",
-						"int": "255",
-						"rotation": "DEG_270",
+						"sda": "2",
 						"scl": "0",
-						"sda": "2"
-					},
-					{
-						"protocol": "I2C",
-						"imu": "IMU_BNO085",
-						"int": "255",
-						"rotation": "DEG_270",
-						"scl": "0",
-						"sda": "2"
+						"imus": [
+							{
+								"protocol": "I2C",
+								"imu": "IMU_BNO085",
+								"int": "255",
+								"rotation": "DEG_270"
+							},
+							{
+								"protocol": "I2C",
+								"imu": "IMU_BNO085",
+								"int": "255",
+								"rotation": "DEG_270"
+							}
+						]
 					}
 				],
 				"BATTERY": {
@@ -242,22 +265,25 @@
 		},
 		"BOARD_TTGO_TBASE": {
 			"values": {
-				"SENSORS": [
+				"BUSES": [
 					{
 						"protocol": "I2C",
-						"imu": "IMU_BNO085",
-						"int": "14",
-						"rotation": "DEG_270",
+						"sda": "5",
 						"scl": "4",
-						"sda": "5"
-					},
-					{
-						"protocol": "I2C",
-						"imu": "IMU_BNO085",
-						"int": "13",
-						"rotation": "DEG_270",
-						"scl": "4",
-						"sda": "5"
+						"imus": [
+							{
+								"protocol": "I2C",
+								"imu": "IMU_BNO085",
+								"int": "14",
+								"rotation": "DEG_270"
+							},
+							{
+								"protocol": "I2C",
+								"imu": "IMU_BNO085",
+								"int": "13",
+								"rotation": "DEG_270"
+							}
+						]
 					}
 				],
 				"BATTERY": {
@@ -281,22 +307,25 @@
 		},
 		"BOARD_WROOM32": {
 			"values": {
-				"SENSORS": [
+				"BUSES": [
 					{
 						"protocol": "I2C",
-						"imu": "IMU_BNO085",
-						"int": "23",
-						"rotation": "DEG_270",
+						"sda": "21",
 						"scl": "22",
-						"sda": "21"
-					},
-					{
-						"protocol": "I2C",
-						"imu": "IMU_BNO085",
-						"int": "25",
-						"rotation": "DEG_270",
-						"scl": "22",
-						"sda": "21"
+						"imus": [
+							{
+								"protocol": "I2C",
+								"imu": "IMU_BNO085",
+								"int": "23",
+								"rotation": "DEG_270"
+							},
+							{
+								"protocol": "I2C",
+								"imu": "IMU_BNO085",
+								"int": "25",
+								"rotation": "DEG_270"
+							}
+						]
 					}
 				],
 				"BATTERY": {
@@ -320,22 +349,25 @@
 		},
 		"BOARD_LOLIN_C3_MINI": {
 			"values": {
-				"SENSORS": [
+				"BUSES": [
 					{
 						"protocol": "I2C",
-						"imu": "IMU_ICM45686",
-						"int": "6",
-						"rotation": "DEG_270",
+						"sda": "5",
 						"scl": "4",
-						"sda": "5"
-					},
-					{
-						"protocol": "I2C",
-						"imu": "IMU_ICM45686",
-						"int": "8",
-						"rotation": "DEG_270",
-						"scl": "4",
-						"sda": "5"
+						"imus": [
+							{
+								"protocol": "I2C",
+								"imu": "IMU_ICM45686",
+								"int": "6",
+								"rotation": "DEG_270"
+							},
+							{
+								"protocol": "I2C",
+								"imu": "IMU_ICM45686",
+								"int": "8",
+								"rotation": "DEG_270"
+							}
+						]
 					}
 				],
 				"BATTERY": {
@@ -359,22 +391,25 @@
 		},
 		"BOARD_BEETLE32C3": {
 			"values": {
-				"SENSORS": [
+				"BUSES": [
 					{
 						"protocol": "I2C",
-						"imu": "IMU_ICM45686",
-						"int": "6",
-						"rotation": "DEG_270",
+						"sda": "8",
 						"scl": "9",
-						"sda": "8"
-					},
-					{
-						"protocol": "I2C",
-						"imu": "IMU_ICM45686",
-						"int": "7",
-						"rotation": "DEG_270",
-						"scl": "9",
-						"sda": "8"
+						"imus": [
+							{
+								"protocol": "I2C",
+								"imu": "IMU_ICM45686",
+								"int": "6",
+								"rotation": "DEG_270"
+							},
+							{
+								"protocol": "I2C",
+								"imu": "IMU_ICM45686",
+								"int": "7",
+								"rotation": "DEG_270"
+							}
+						]
 					}
 				],
 				"BATTERY": {
@@ -398,22 +433,25 @@
 		},
 		"BOARD_ESP32C3DEVKITM1": {
 			"values": {
-				"SENSORS": [
+				"BUSES": [
 					{
 						"protocol": "I2C",
-						"imu": "IMU_ICM45686",
-						"int": "6",
-						"rotation": "DEG_270",
+						"sda": "5",
 						"scl": "4",
-						"sda": "5"
-					},
-					{
-						"protocol": "I2C",
-						"imu": "IMU_ICM45686",
-						"int": "7",
-						"rotation": "DEG_270",
-						"scl": "4",
-						"sda": "5"
+						"imus": [
+							{
+								"protocol": "I2C",
+								"imu": "IMU_ICM45686",
+								"int": "6",
+								"rotation": "DEG_270"
+							},
+							{
+								"protocol": "I2C",
+								"imu": "IMU_ICM45686",
+								"int": "7",
+								"rotation": "DEG_270"
+							}
+						]
 					}
 				],
 				"BATTERY": {
@@ -437,22 +475,25 @@
 		},
 		"BOARD_ESP32C6DEVKITC1": {
 			"values": {
-				"SENSORS": [
+				"BUSES": [
 					{
 						"protocol": "I2C",
-						"imu": "IMU_ICM45686",
-						"int": "6",
-						"rotation": "DEG_270",
+						"sda": "5",
 						"scl": "4",
-						"sda": "5"
-					},
-					{
-						"protocol": "I2C",
-						"imu": "IMU_ICM45686",
-						"int": "7",
-						"rotation": "DEG_270",
-						"scl": "4",
-						"sda": "5"
+						"imus": [
+							{
+								"protocol": "I2C",
+								"imu": "IMU_ICM45686",
+								"int": "6",
+								"rotation": "DEG_270"
+							},
+							{
+								"protocol": "I2C",
+								"imu": "IMU_ICM45686",
+								"int": "7",
+								"rotation": "DEG_270"
+							}
+						]
 					}
 				],
 				"BATTERY": {
@@ -476,22 +517,25 @@
 		},
 		"BOARD_WEMOSWROOM02": {
 			"values": {
-				"SENSORS": [
+				"BUSES": [
 					{
 						"protocol": "I2C",
-						"imu": "IMU_ICM45686",
-						"int": "0",
-						"rotation": "DEG_270",
+						"sda": "2",
 						"scl": "14",
-						"sda": "2"
-					},
-					{
-						"protocol": "I2C",
-						"imu": "IMU_ICM45686",
-						"int": "4",
-						"rotation": "DEG_270",
-						"scl": "14",
-						"sda": "2"
+						"imus": [
+							{
+								"protocol": "I2C",
+								"imu": "IMU_ICM45686",
+								"int": "0",
+								"rotation": "DEG_270"
+							},
+							{
+								"protocol": "I2C",
+								"imu": "IMU_ICM45686",
+								"int": "4",
+								"rotation": "DEG_270"
+							}
+						]
 					}
 				],
 				"BATTERY": {
@@ -515,22 +559,25 @@
 		},
 		"BOARD_XIAO_ESP32C3": {
 			"values": {
-				"SENSORS": [
+				"BUSES": [
 					{
 						"protocol": "I2C",
-						"imu": "IMU_ICM45686",
-						"int": "5",
-						"rotation": "DEG_270",
+						"sda": "6",
 						"scl": "7",
-						"sda": "6"
-					},
-					{
-						"protocol": "I2C",
-						"imu": "IMU_ICM45686",
-						"int": "10",
-						"rotation": "DEG_270",
-						"scl": "7",
-						"sda": "6"
+						"imus": [
+							{
+								"protocol": "I2C",
+								"imu": "IMU_ICM45686",
+								"int": "5",
+								"rotation": "DEG_270"
+							},
+							{
+								"protocol": "I2C",
+								"imu": "IMU_ICM45686",
+								"int": "10",
+								"rotation": "DEG_270"
+							}
+						]
 					}
 				],
 				"BATTERY": {
@@ -554,22 +601,25 @@
 		},
 		"BOARD_ESP32S3_SUPERMINI": {
 			"values": {
-				"SENSORS": [
+				"BUSES": [
 					{
 						"protocol": "I2C",
-						"imu": "IMU_ICM45686",
-						"int": "5",
-						"rotation": "DEG_270",
+						"sda": "7",
 						"scl": "6",
-						"sda": "7"
-					},
-					{
-						"protocol": "I2C",
-						"imu": "IMU_ICM45686",
-						"int": "4",
-						"rotation": "DEG_270",
-						"scl": "6",
-						"sda": "7"
+						"imus": [
+							{
+								"protocol": "I2C",
+								"imu": "IMU_ICM45686",
+								"int": "5",
+								"rotation": "DEG_270"
+							},
+							{
+								"protocol": "I2C",
+								"imu": "IMU_ICM45686",
+								"int": "4",
+								"rotation": "DEG_270"
+							}
+						]
 					}
 				],
 				"BATTERY": {

--- a/board-defaults.schema.json
+++ b/board-defaults.schema.json
@@ -88,6 +88,17 @@
 			"required": ["protocol", "imu", "cs"]
 		},
 
+		"SPI_BUS": {
+			"type": "object",
+			"description": "Shared SPI bus pin settings",
+			"properties": {
+				"sck": { "$ref": "#/$defs/pin", "description": "SCK Pin" },
+				"miso": { "$ref": "#/$defs/pin", "description": "MISO Pin" },
+				"mosi": { "$ref": "#/$defs/pin", "description": "MOSI Pin" }
+			},
+			"required": ["sck", "miso", "mosi"]
+		},
+
 		"IMU": {
 			"type": "object",
 			"discriminator": {
@@ -192,6 +203,7 @@
 					},
 					"required": ["LED_PIN", "LED_INVERTED"]
 				},
+				"SPI": { "$ref": "#/$defs/SPI_BUS" },
 				"BATTERY": { "$ref": "#/$defs/BATTERY" }
 			},
 			"required": ["SENSORS", "LED", "BATTERY"]

--- a/board-defaults.schema.json
+++ b/board-defaults.schema.json
@@ -67,7 +67,7 @@
 					"description": "IMU Rotation"
 				}
 			},
-			"required": ["protocol", "imu", "sda", "scl"]
+			"required": ["protocol", "imu"]
 		},
 
 		"SPI_IMU": {
@@ -210,12 +210,11 @@
 		"BASIC_IMU_BOARD_CONFIG": {
 			"type": "object",
 			"properties": {
-				"SENSORS": {
+				"BUSES": {
 					"type": "array",
-					"items": { "$ref": "#/$defs/IMU" },
+					"items": { "$ref": "#/$defs/BUS" },
 					"minItems": 1,
-					"maxItems": 2,
-					"description": "Sensors List"
+					"description": "Bus List"
 				},
 				"LED": {
 					"type": "object",
@@ -232,10 +231,9 @@
 					},
 					"required": ["LED_PIN", "LED_INVERTED"]
 				},
-				"SPI": { "$ref": "#/$defs/SPI_BUS" },
 				"BATTERY": { "$ref": "#/$defs/BATTERY" }
 			},
-			"required": ["SENSORS", "LED", "BATTERY"]
+			"required": ["BUSES", "LED", "BATTERY"]
 		},
 
 		"BoardConfig": {

--- a/board-defaults.schema.json
+++ b/board-defaults.schema.json
@@ -67,7 +67,7 @@
 					"description": "IMU Rotation"
 				}
 			},
-			"required": ["protocol", "imu"]
+			"required": ["protocol", "imu", "rotation"]
 		},
 
 		"SPI_IMU": {
@@ -83,7 +83,7 @@
 				},
 				"cs": { "$ref": "#/$defs/pin", "description": "CS Pin" }
 			},
-			"required": ["protocol", "imu", "cs"]
+			"required": ["protocol", "imu", "cs", "rotation"]
 		},
 
 		"BUS": {
@@ -221,6 +221,7 @@
 					"type": "array",
 					"items": { "$ref": "#/$defs/BUS" },
 					"minItems": 1,
+					"maxItems": 2,
 					"description": "Bus List"
 				},
 				"LED": {

--- a/board-defaults.schema.json
+++ b/board-defaults.schema.json
@@ -106,8 +106,11 @@
 				"sda": { "$ref": "#/$defs/pin", "description": "SDA Pin" },
 				"scl": { "$ref": "#/$defs/pin", "description": "SCL Pin" },
 				"imus": {
+					"description": "I2C IMUs",
 					"type": "array",
-					"items": { "$ref": "#/$defs/I2C_IMU" }
+					"items": { "$ref": "#/$defs/I2C_IMU" },
+					"minItems": 1,
+					"maxItems": 2
 				}
 			},
 			"required": ["protocol", "sda", "scl", "imus"]
@@ -123,7 +126,10 @@
 				"mosi": { "$ref": "#/$defs/pin", "description": "MOSI Pin" },
 				"imus": {
 					"type": "array",
-					"items": { "$ref": "#/$defs/SPI_IMU" }
+					"description": "SPI IMUs",
+					"items": { "$ref": "#/$defs/SPI_IMU" },
+					"minItems": 1,
+					"maxItems": 2
 				}
 			},
 			"required": ["protocol", "sck", "miso", "mosi", "imus"]

--- a/board-defaults.schema.json
+++ b/board-defaults.schema.json
@@ -57,8 +57,6 @@
 			"properties": {
 				"protocol": { "const": "I2C" },
 				"imu": { "$ref": "#/$defs/IMU_TYPE" },
-				"sda": { "$ref": "#/$defs/pin", "description": "SDA Pin" },
-				"scl": { "$ref": "#/$defs/pin", "description": "SCL Pin" },
 				"int": { "$ref": "#/$defs/pin", "description": "INT Pin" },
 				"address": {
 					"type": "number",
@@ -88,13 +86,44 @@
 			"required": ["protocol", "imu", "cs"]
 		},
 
+		"BUS": {
+			"type": "object",
+			"discriminator": {
+				"propertyName": "protocol"
+			},
+			"oneOf": [
+				{ "$ref": "#/$defs/I2C_BUS" },
+				{ "$ref": "#/$defs/SPI_BUS" }
+			]
+		},
+
+		"I2C_BUS": {
+			"type": "object",
+			"description": "I2C bus pin settings",
+			"properties": {
+				"protocol": { "const": "I2C" },
+				"sda": { "$ref": "#/$defs/pin", "description": "SDA Pin"},
+				"scl": { "$ref": "#/$defs/pin", "description": "SCL Pin" },
+				"imus": {
+					"type": "array",
+					"items": { "$ref": "#/$defs/I2C_IMU" }
+				}
+			},
+			"required": ["sda", "scl"]
+		},
+
 		"SPI_BUS": {
 			"type": "object",
-			"description": "Shared SPI bus pin settings",
+			"description": "SPI bus pin settings",
 			"properties": {
+				"protocol": { "const": "SPI" },
 				"sck": { "$ref": "#/$defs/pin", "description": "SCK Pin" },
 				"miso": { "$ref": "#/$defs/pin", "description": "MISO Pin" },
-				"mosi": { "$ref": "#/$defs/pin", "description": "MOSI Pin" }
+				"mosi": { "$ref": "#/$defs/pin", "description": "MOSI Pin" },
+				"imus": {
+					"type": "array",
+					"items": { "$ref": "#/$defs/SPI_IMU" }
+				}
 			},
 			"required": ["sck", "miso", "mosi"]
 		},

--- a/board-defaults.schema.json
+++ b/board-defaults.schema.json
@@ -94,7 +94,8 @@
 			"oneOf": [
 				{ "$ref": "#/$defs/I2C_BUS" },
 				{ "$ref": "#/$defs/SPI_BUS" }
-			]
+			],
+			"required": ["protocol"]
 		},
 
 		"I2C_BUS": {
@@ -102,14 +103,14 @@
 			"description": "I2C bus pin settings",
 			"properties": {
 				"protocol": { "const": "I2C" },
-				"sda": { "$ref": "#/$defs/pin", "description": "SDA Pin"},
+				"sda": { "$ref": "#/$defs/pin", "description": "SDA Pin" },
 				"scl": { "$ref": "#/$defs/pin", "description": "SCL Pin" },
 				"imus": {
 					"type": "array",
 					"items": { "$ref": "#/$defs/I2C_IMU" }
 				}
 			},
-			"required": ["sda", "scl"]
+			"required": ["protocol", "sda", "scl", "imus"]
 		},
 
 		"SPI_BUS": {
@@ -125,7 +126,7 @@
 					"items": { "$ref": "#/$defs/SPI_IMU" }
 				}
 			},
-			"required": ["sck", "miso", "mosi"]
+			"required": ["protocol", "sck", "miso", "mosi", "imus"]
 		},
 
 		"IMU": {

--- a/scripts/preprocessor.py
+++ b/scripts/preprocessor.py
@@ -101,10 +101,20 @@ def _build_board_flags(defaults: dict, board_name: str) -> List[str]:
     sensors = values.get('SENSORS')
     if sensors:
         sensor_list = []
-
         add('PIN_IMU_SDA', 255, 'pin') # FIXME fix the I2C Scanner so it use the sensor list and not be called when no I2C sensor
         add('PIN_IMU_SCL', 255, 'pin')
         add('PIN_IMU_INT_2', 255, 'pin') # FIXME: fix the CONFIG serial command so it use the sensor list
+
+        # Use 255 as "not configured" so DirectSPIInterface falls back to default SPI pins.
+        add('PIN_IMU_SCK', 255, 'pin')
+        add('PIN_IMU_MISO', 255, 'pin')
+        add('PIN_IMU_MOSI', 255, 'pin')
+
+        spi_bus = values.get('SPI')
+        if spi_bus:
+            add('PIN_IMU_SCK', spi_bus.get('sck'), 'pin')
+            add('PIN_IMU_MISO', spi_bus.get('miso'), 'pin')
+            add('PIN_IMU_MOSI', spi_bus.get('mosi'), 'pin')
 
         for index, sensor in enumerate(sensors):
             if sensor.get('protocol') == 'I2C':
@@ -126,7 +136,7 @@ def _build_board_flags(defaults: dict, board_name: str) -> List[str]:
                     format_value(sensor.get('imu'), 'raw'),
                     f"DIRECT_PIN({format_value(sensor.get('cs'), 'pin')})",
                     format_value(sensor.get('rotation'), 'raw'),
-                    "DIRECT_SPI(24'000'000, MSBFIRST, SPI_MODE3)",
+                    "DIRECT_SPI(24'000'000, MSBFIRST, SPI_MODE3, PIN_IMU_SCK, PIN_IMU_MISO, PIN_IMU_MOSI)",
                     'false' if index == 0 else 'true',
                     f"DIRECT_PIN({format_value(sensor.get('int', 255), 'pin')})",
                     '0'

--- a/scripts/preprocessor.py
+++ b/scripts/preprocessor.py
@@ -98,56 +98,70 @@ def _build_board_flags(defaults: dict, board_name: str) -> List[str]:
     add('LED_PIN', values.get('LED').get('LED_PIN'), 'pin')
     add('LED_INVERTED', values.get('LED').get('LED_INVERTED'), 'raw')
 
-    sensors = values.get('SENSORS')
-    if sensors:
-        sensor_list = []
-        add('PIN_IMU_SDA', 255, 'pin') # FIXME fix the I2C Scanner so it use the sensor list and not be called when no I2C sensor
-        add('PIN_IMU_SCL', 255, 'pin')
-        add('PIN_IMU_INT_2', 255, 'pin') # FIXME: fix the CONFIG serial command so it use the sensor list
+    bus = values.get('BUS')
+    if not bus:
+        raise ValueError(f"Missing BUS config for {board_name}")
 
-        # Use 255 as "not configured" so DirectSPIInterface falls back to default SPI pins.
-        add('PIN_IMU_SCK', 255, 'pin')
-        add('PIN_IMU_MISO', 255, 'pin')
-        add('PIN_IMU_MOSI', 255, 'pin')
+    sensor_list = []
+    protocol = bus.get('protocol')
 
-        spi_bus = values.get('SPI')
-        if spi_bus:
-            add('PIN_IMU_SCK', spi_bus.get('sck'), 'pin')
-            add('PIN_IMU_MISO', spi_bus.get('miso'), 'pin')
-            add('PIN_IMU_MOSI', spi_bus.get('mosi'), 'pin')
+    add('PIN_IMU_SDA', 255, 'pin') # FIXME fix the I2C Scanner so it use the sensor list and not be called when no I2C sensor
+    add('PIN_IMU_SCL', 255, 'pin')
+    add('PIN_IMU_INT_2', 255, 'pin') # FIXME: fix the CONFIG serial command so it use the sensor list
 
-        for index, sensor in enumerate(sensors):
-            if sensor.get('protocol') == 'I2C':
-                params = [
-                    format_value(sensor.get('imu'), 'raw'),
-                    format_value(sensor.get('address', 'PRIMARY_IMU_ADDRESS_ONE' if index == 0 else 'SECONDARY_IMU_ADDRESS_TWO'), 'number'),
-                    format_value(sensor.get('rotation'), 'raw'),
-                    f"DIRECT_WIRE({format_value(sensor.get('scl'), 'pin')}, {format_value(sensor.get('sda'), 'pin')})",
-                    'false' if index == 0 else 'true',
-                    f"DIRECT_PIN({format_value(sensor.get('int', 255), 'pin')})",
-                    '0'
-                ]
-                sensor_list.append(f"SENSOR_DESC_ENTRY({','.join(params)})")
-                add('PIN_IMU_SDA', sensor.get('sda'), 'pin')
-                add('PIN_IMU_SCL', sensor.get('scl'), 'pin')
+    # Use 255 as "not configured" so DirectSPIInterface falls back to default SPI pins.
+    add('PIN_IMU_SCK', 255, 'pin')
+    add('PIN_IMU_MISO', 255, 'pin')
+    add('PIN_IMU_MOSI', 255, 'pin')
 
-            if sensor.get('protocol') == 'SPI':
-                params = [
-                    format_value(sensor.get('imu'), 'raw'),
-                    f"DIRECT_PIN({format_value(sensor.get('cs'), 'pin')})",
-                    format_value(sensor.get('rotation'), 'raw'),
-                    "DIRECT_SPI(24'000'000, MSBFIRST, SPI_MODE3, PIN_IMU_SCK, PIN_IMU_MISO, PIN_IMU_MOSI)",
-                    'false' if index == 0 else 'true',
-                    f"DIRECT_PIN({format_value(sensor.get('int', 255), 'pin')})",
-                    '0'
-                ]
-                sensor_list.append(f"SENSOR_DESC_ENTRY({','.join(params)})")
+    if protocol == 'I2C':
+        add('PIN_IMU_SDA', bus.get('sda'), 'pin')
+        add('PIN_IMU_SCL', bus.get('scl'), 'pin')
 
-            if index == 0: # FIXME: fix the CONFIG serial command so it use the sensor list
-                add('PIN_IMU_INT', sensor.get('int'), 'pin')
-            elif index == 1:
-                add('PIN_IMU_INT_2', sensor.get('int'), 'pin')
-        add('SENSOR_DESC_LIST', f"'{' '.join(sensor_list)}'", 'raw')
+    elif protocol == 'SPI':
+        add('PIN_IMU_SCK', bus.get('sck'), 'pin')
+        add('PIN_IMU_MISO', bus.get('miso'), 'pin')
+        add('PIN_IMU_MOSI', bus.get('mosi'), 'pin')
+
+    else:
+        raise ValueError(f"Unsupported bus protocol: {protocol}")
+
+    for index, sensor in enumerate(bus.get('imus', [])):
+        if sensor.get('protocol') != protocol:
+            raise ValueError(f"Sensor protocol does not match bus protocol on {board_name}")
+
+        secondary = 'false' if index == 0 else 'true'
+
+        if protocol == 'I2C':
+            params = [
+                format_value(sensor.get('imu'), 'raw'),
+                format_value(sensor.get('address', 'PRIMARY_IMU_ADDRESS_ONE' if index == 0 else 'SECONDARY_IMU_ADDRESS_TWO'), 'number'),
+                format_value(sensor.get('rotation'), 'raw'),
+                f"DIRECT_WIRE({format_value(bus.get('scl'), 'pin')}, {format_value(bus.get('sda'), 'pin')})",
+                secondary,
+                f"DIRECT_PIN({format_value(sensor.get('int', 255), 'pin')})",
+                '0'
+            ]
+
+        else:
+            params = [
+                format_value(sensor.get('imu'), 'raw'),
+                f"DIRECT_PIN({format_value(sensor.get('cs'), 'pin')})",
+                format_value(sensor.get('rotation'), 'raw'),
+                "DIRECT_SPI(24'000'000, MSBFIRST, SPI_MODE3, PIN_IMU_SCK, PIN_IMU_MISO, PIN_IMU_MOSI)",
+                secondary,
+                f"DIRECT_PIN({format_value(sensor.get('int', 255), 'pin')})",
+                '0'
+            ]
+
+        sensor_list.append(f"SENSOR_DESC_ENTRY({','.join(params)})")
+
+        if index == 0: # FIXME: fix the CONFIG serial command so it use the sensor list
+            add('PIN_IMU_INT', sensor.get('int'), 'pin')
+        elif index == 1:
+            add('PIN_IMU_INT_2', sensor.get('int'), 'pin')
+
+    add('SENSOR_DESC_LIST', f"'{' '.join(sensor_list)}'", 'raw')
 
 
     battery = values.get('BATTERY')

--- a/scripts/preprocessor.py
+++ b/scripts/preprocessor.py
@@ -98,12 +98,12 @@ def _build_board_flags(defaults: dict, board_name: str) -> List[str]:
     add('LED_PIN', values.get('LED').get('LED_PIN'), 'pin')
     add('LED_INVERTED', values.get('LED').get('LED_INVERTED'), 'raw')
 
-    bus = values.get('BUS')
-    if not bus:
-        raise ValueError(f"Missing BUS config for {board_name}")
+    buses = values.get('BUSES')
+    if not buses:
+        raise ValueError(f"Missing BUSES config for {board_name}")
 
     sensor_list = []
-    protocol = bus.get('protocol')
+    sensor_index = 0
 
     add('PIN_IMU_SDA', 255, 'pin') # FIXME fix the I2C Scanner so it use the sensor list and not be called when no I2C sensor
     add('PIN_IMU_SCL', 255, 'pin')
@@ -114,52 +114,57 @@ def _build_board_flags(defaults: dict, board_name: str) -> List[str]:
     add('PIN_IMU_MISO', 255, 'pin')
     add('PIN_IMU_MOSI', 255, 'pin')
 
-    if protocol == 'I2C':
-        add('PIN_IMU_SDA', bus.get('sda'), 'pin')
-        add('PIN_IMU_SCL', bus.get('scl'), 'pin')
-
-    elif protocol == 'SPI':
-        add('PIN_IMU_SCK', bus.get('sck'), 'pin')
-        add('PIN_IMU_MISO', bus.get('miso'), 'pin')
-        add('PIN_IMU_MOSI', bus.get('mosi'), 'pin')
-
-    else:
-        raise ValueError(f"Unsupported bus protocol: {protocol}")
-
-    for index, sensor in enumerate(bus.get('imus', [])):
-        if sensor.get('protocol') != protocol:
-            raise ValueError(f"Sensor protocol does not match bus protocol on {board_name}")
-
-        secondary = 'false' if index == 0 else 'true'
+    for bus in buses:
+        protocol = bus.get('protocol')
 
         if protocol == 'I2C':
-            params = [
-                format_value(sensor.get('imu'), 'raw'),
-                format_value(sensor.get('address', 'PRIMARY_IMU_ADDRESS_ONE' if index == 0 else 'SECONDARY_IMU_ADDRESS_TWO'), 'number'),
-                format_value(sensor.get('rotation'), 'raw'),
-                f"DIRECT_WIRE({format_value(bus.get('scl'), 'pin')}, {format_value(bus.get('sda'), 'pin')})",
-                secondary,
-                f"DIRECT_PIN({format_value(sensor.get('int', 255), 'pin')})",
-                '0'
-            ]
+            add('PIN_IMU_SDA', bus.get('sda'), 'pin')
+            add('PIN_IMU_SCL', bus.get('scl'), 'pin')
+
+        elif protocol == 'SPI':
+            add('PIN_IMU_SCK', bus.get('sck'), 'pin')
+            add('PIN_IMU_MISO', bus.get('miso'), 'pin')
+            add('PIN_IMU_MOSI', bus.get('mosi'), 'pin')
 
         else:
-            params = [
-                format_value(sensor.get('imu'), 'raw'),
-                f"DIRECT_PIN({format_value(sensor.get('cs'), 'pin')})",
-                format_value(sensor.get('rotation'), 'raw'),
-                "DIRECT_SPI(24'000'000, MSBFIRST, SPI_MODE3, PIN_IMU_SCK, PIN_IMU_MISO, PIN_IMU_MOSI)",
-                secondary,
-                f"DIRECT_PIN({format_value(sensor.get('int', 255), 'pin')})",
-                '0'
-            ]
+            raise ValueError(f"Unsupported bus protocol: {protocol}")
 
-        sensor_list.append(f"SENSOR_DESC_ENTRY({','.join(params)})")
+        for sensor in bus.get('imus', []):
+            if sensor.get('protocol') != protocol:
+                raise ValueError(f"Sensor protocol does not match bus protocol on {board_name}")
 
-        if index == 0: # FIXME: fix the CONFIG serial command so it use the sensor list
-            add('PIN_IMU_INT', sensor.get('int'), 'pin')
-        elif index == 1:
-            add('PIN_IMU_INT_2', sensor.get('int'), 'pin')
+            secondary = 'false' if sensor_index == 0 else 'true'
+
+            if protocol == 'I2C':
+                params = [
+                    format_value(sensor.get('imu'), 'raw'),
+                    format_value(sensor.get('address', 'PRIMARY_IMU_ADDRESS_ONE' if sensor_index == 0 else 'SECONDARY_IMU_ADDRESS_TWO'), 'number'),
+                    format_value(sensor.get('rotation'), 'raw'),
+                    f"DIRECT_WIRE({format_value(bus.get('scl'), 'pin')}, {format_value(bus.get('sda'), 'pin')})",
+                    secondary,
+                    f"DIRECT_PIN({format_value(sensor.get('int', 255), 'pin')})",
+                    '0'
+                ]
+
+            else:
+                params = [
+                    format_value(sensor.get('imu'), 'raw'),
+                    f"DIRECT_PIN({format_value(sensor.get('cs'), 'pin')})",
+                    format_value(sensor.get('rotation'), 'raw'),
+                    "DIRECT_SPI(24'000'000, MSBFIRST, SPI_MODE3, PIN_IMU_SCK, PIN_IMU_MISO, PIN_IMU_MOSI)",
+                    secondary,
+                    f"DIRECT_PIN({format_value(sensor.get('int', 255), 'pin')})",
+                    '0'
+                ]
+
+            sensor_list.append(f"SENSOR_DESC_ENTRY({','.join(params)})")
+
+            if sensor_index == 0: # FIXME: fix the CONFIG serial command so it use the sensor list
+                add('PIN_IMU_INT', sensor.get('int'), 'pin')
+            elif sensor_index == 1:
+                add('PIN_IMU_INT_2', sensor.get('int'), 'pin')
+
+            sensor_index += 1
 
     add('SENSOR_DESC_LIST', f"'{' '.join(sensor_list)}'", 'raw')
 

--- a/src/boards/defines_helpers.h
+++ b/src/boards/defines_helpers.h
@@ -39,6 +39,24 @@
 #define SCL(pin)
 #endif
 
+#ifndef PIN_IMU_SCK
+#define SCK(pin) constexpr uint8_t PIN_IMU_SCK = pin;
+#else
+#define SCK(pin)
+#endif
+
+#ifndef PIN_IMU_MISO
+#define MISO(pin) constexpr uint8_t PIN_IMU_MISO = pin;
+#else
+#define MISO(pin)
+#endif
+
+#ifndef PIN_IMU_MOSI
+#define MOSI(pin) constexpr uint8_t PIN_IMU_MOSI = pin;
+#else
+#define MOSI(pin)
+#endif
+
 #ifndef PIN_IMU_INT
 #define INT(pin) constexpr uint8_t PIN_IMU_INT = pin;
 #else

--- a/src/defines.h
+++ b/src/defines.h
@@ -66,6 +66,9 @@
 
 // #define PIN_IMU_SDA 14
 // #define PIN_IMU_SCL 12
+// #define PIN_IMU_SCK 4
+// #define PIN_IMU_MISO 5
+// #define PIN_IMU_MOSI 6
 // #define PIN_IMU_INT 16
 // #define PIN_IMU_INT_2 13
 // #define PIN_BATTERY_LEVEL 17

--- a/src/sensorinterface/DirectSPIInterface.cpp
+++ b/src/sensorinterface/DirectSPIInterface.cpp
@@ -42,8 +42,11 @@ DirectSPIInterface::DirectSPIInterface(
 	, m_mosi{mosi} {}
 
 bool DirectSPIInterface::init() {
+	const bool customPinsConfigured
+		= m_sck != 255 && m_miso != 255 && m_mosi != 255;
+#if defined(ESP32)
 	// To make sure SCK, MISO, MOSI pins have already defined
-	if (m_sck != 255 && m_miso != 255 && m_mosi != 255) {
+	if (customPinsConfigured) {
 		// SPIClass::begin() requires int8_t
 		// for kepping uint_8 style, doing transform here
 		m_spiClass->begin(
@@ -55,6 +58,36 @@ bool DirectSPIInterface::init() {
 		// or use the default pin defines
 		m_spiClass->begin();
 	}
+
+#elif defined(ESP8266)
+	if (customPinsConfigured) {
+		const bool overlapPins
+			= m_sck == 6 && m_miso == 7 && m_mosi == 8;
+		// SPIClass::pins() requires an SS argument even though SlimeVR manages CS
+		// separately for each sensor through PinInterface. ESP8266 overlap mode
+		// specifically requires GPIO0, while the standard HSPI pin set uses the
+		// core-defined SS pin (GPIO15).
+		const int8_t hardwareSs
+			= overlapPins ? 0 : static_cast<int8_t>(SS);
+
+		if (!m_spiClass->pins(
+				static_cast<int8_t>(m_sck),
+				static_cast<int8_t>(m_miso),
+				static_cast<int8_t>(m_mosi),
+				hardwareSs
+			)) {
+			return false;
+		}
+	}
+
+	m_spiClass->begin();
+
+	// controls each sensor's CS through PinInterface,
+	// turn off the Hardware cs control
+	m_spiClass->setHwCs(false);
+#else
+	m_spiClass->begin();
+#endif
 	return true;
 }
 

--- a/src/sensorinterface/DirectSPIInterface.cpp
+++ b/src/sensorinterface/DirectSPIInterface.cpp
@@ -28,25 +28,46 @@
 
 namespace SlimeVR {
 
-DirectSPIInterface::DirectSPIInterface(SPIClass& spiClass, SPISettings spiSettings)
+DirectSPIInterface::DirectSPIInterface(
+	SPIClass* spiClass,
+	SPISettings spiSettings,
+	uint8_t sck,
+	uint8_t miso,
+	uint8_t mosi
+)
 	: m_spiClass{spiClass}
-	, m_spiSettings{spiSettings} {}
+	, m_spiSettings{spiSettings}
+	, m_sck{sck}
+	, m_miso{miso}
+	, m_mosi{mosi} {}
 
 bool DirectSPIInterface::init() {
-	m_spiClass.begin();
+	// To make sure SCK, MISO, MOSI pins have already defined
+	if (m_sck != 255 && m_miso != 255 && m_mosi != 255) {
+		// SPIClass::begin() requires int8_t
+		// for kepping uint_8 style, doing transform here
+		m_spiClass->begin(
+			(int8_t)m_sck,
+			(int8_t)m_miso,
+			(int8_t)m_mosi
+		);
+	} else {
+		// or use the default pin defines
+		m_spiClass->begin();
+	}
 	return true;
 }
 
 void DirectSPIInterface::swapIn() {}
 
 void DirectSPIInterface::beginTransaction(PinInterface* csPin) {
-	m_spiClass.beginTransaction(m_spiSettings);
+	m_spiClass->beginTransaction(m_spiSettings);
 	csPin->digitalWrite(LOW);
 }
 
 void DirectSPIInterface::endTransaction(PinInterface* csPin) {
 	csPin->digitalWrite(HIGH);
-	m_spiClass.endTransaction();
+	m_spiClass->endTransaction();
 }
 
 const SPISettings& DirectSPIInterface::getSpiSettings() { return m_spiSettings; }

--- a/src/sensorinterface/DirectSPIInterface.cpp
+++ b/src/sensorinterface/DirectSPIInterface.cpp
@@ -42,18 +42,13 @@ DirectSPIInterface::DirectSPIInterface(
 	, m_mosi{mosi} {}
 
 bool DirectSPIInterface::init() {
-	const bool customPinsConfigured
-		= m_sck != 255 && m_miso != 255 && m_mosi != 255;
+	const bool customPinsConfigured = m_sck != 255 && m_miso != 255 && m_mosi != 255;
 #if defined(ESP32)
 	// To make sure SCK, MISO, MOSI pins have already defined
 	if (customPinsConfigured) {
 		// SPIClass::begin() requires int8_t
 		// for kepping uint_8 style, doing transform here
-		m_spiClass->begin(
-			(int8_t)m_sck,
-			(int8_t)m_miso,
-			(int8_t)m_mosi
-		);
+		m_spiClass->begin((int8_t)m_sck, (int8_t)m_miso, (int8_t)m_mosi);
 	} else {
 		// or use the default pin defines
 		m_spiClass->begin();
@@ -61,14 +56,12 @@ bool DirectSPIInterface::init() {
 
 #elif defined(ESP8266)
 	if (customPinsConfigured) {
-		const bool overlapPins
-			= m_sck == 6 && m_miso == 7 && m_mosi == 8;
+		const bool overlapPins = m_sck == 6 && m_miso == 7 && m_mosi == 8;
 		// SPIClass::pins() requires an SS argument even though SlimeVR manages CS
 		// separately for each sensor through PinInterface. ESP8266 overlap mode
 		// specifically requires GPIO0, while the standard HSPI pin set uses the
 		// core-defined SS pin (GPIO15).
-		const int8_t hardwareSs
-			= overlapPins ? 0 : static_cast<int8_t>(SS);
+		const int8_t hardwareSs = overlapPins ? 0 : static_cast<int8_t>(SS);
 
 		if (!m_spiClass->pins(
 				static_cast<int8_t>(m_sck),

--- a/src/sensorinterface/DirectSPIInterface.h
+++ b/src/sensorinterface/DirectSPIInterface.h
@@ -32,7 +32,17 @@ namespace SlimeVR {
 
 class DirectSPIInterface : public SensorInterface {
 public:
-	DirectSPIInterface(SPIClass& spiClass, SPISettings spiSettings);
+	// Store the SPIClass instance by pointer instead of by value/reference-like cache
+	// copies. On ESP32-C3, copying the global SPI object through the interface cache
+	// can lead to duplicated ownership of internal SPI resources and a heap
+	// double-free during teardown/reinitialization. This class does not own the SPIClass.
+	DirectSPIInterface(
+		SPIClass* spiClass,
+		SPISettings spiSettings,
+		uint8_t sck = 255,
+		uint8_t miso = 255,
+		uint8_t mosi = 255
+	);
 	bool init() final;
 	void swapIn() final;
 
@@ -43,14 +53,17 @@ public:
 
 	template <typename... Args>
 	auto transfer(Args... args) {
-		return m_spiClass.transfer(args...);
+		return m_spiClass->transfer(args...);
 	}
 
 	const SPISettings& getSpiSettings();
 
 private:
-	SPIClass& m_spiClass;
+	SPIClass* m_spiClass;
 	SPISettings m_spiSettings;
+	uint8_t m_sck;
+	uint8_t m_miso;
+	uint8_t m_mosi;
 };
 
 }  // namespace SlimeVR

--- a/src/sensorinterface/DirectSPIInterface.h
+++ b/src/sensorinterface/DirectSPIInterface.h
@@ -35,7 +35,8 @@ public:
 	// Store the SPIClass instance by pointer instead of by value/reference-like cache
 	// copies. On ESP32-C3, copying the global SPI object through the interface cache
 	// can lead to duplicated ownership of internal SPI resources and a heap
-	// double-free during teardown/reinitialization. This class does not own the SPIClass.
+	// double-free during teardown/reinitialization. This class does not own the
+	// SPIClass.
 	DirectSPIInterface(
 		SPIClass* spiClass,
 		SPISettings spiSettings,

--- a/src/sensorinterface/SensorInterfaceManager.h
+++ b/src/sensorinterface/SensorInterfaceManager.h
@@ -106,7 +106,8 @@ private:
 	SensorInterface<I2CWireSensorInterface, int, int> i2cWireInterfaces;
 	SensorInterface<I2CPCASensorInterface, int, int, int, int> pcaWireInterfaces;
 	SensorInterface<Sensors::I2CImpl, uint8_t> i2cImpls;
-	SensorInterface<DirectSPIInterface, SPIClass, SPISettings> directSPIInterfaces;
+	SensorInterface<DirectSPIInterface, SPIClass*, SPISettings, uint8_t, uint8_t, uint8_t>
+		directSPIInterfaces;
 	SensorInterface<Sensors::SPIImpl, DirectSPIInterface*, PinInterface*> spiImpls;
 };
 

--- a/src/sensorinterface/SensorInterfaceManager.h
+++ b/src/sensorinterface/SensorInterfaceManager.h
@@ -106,7 +106,13 @@ private:
 	SensorInterface<I2CWireSensorInterface, int, int> i2cWireInterfaces;
 	SensorInterface<I2CPCASensorInterface, int, int, int, int> pcaWireInterfaces;
 	SensorInterface<Sensors::I2CImpl, uint8_t> i2cImpls;
-	SensorInterface<DirectSPIInterface, SPIClass*, SPISettings, uint8_t, uint8_t, uint8_t>
+	SensorInterface<
+		DirectSPIInterface,
+		SPIClass*,
+		SPISettings,
+		uint8_t,
+		uint8_t,
+		uint8_t>
 		directSPIInterfaces;
 	SensorInterface<Sensors::SPIImpl, DirectSPIInterface*, PinInterface*> spiImpls;
 };

--- a/src/sensors/SensorBuilder.cpp
+++ b/src/sensors/SensorBuilder.cpp
@@ -54,10 +54,20 @@ uint8_t SensorBuilder::buildAllSensors() {
 			  return interfaceManager.pcaWireInterface().get(scl, sda, addr, ch);
 		  };
 	[[maybe_unused]] const auto DIRECT_SPI
-		= [&](uint32_t clockFreq, uint8_t bitOrder, uint8_t dataMode) {
+		= [&](uint32_t clockFreq,
+			  uint8_t bitOrder,
+			  uint8_t dataMode,
+			  // Default to 255 to allow DIRECT_SPI() to be called without
+			  // explicit pins, making DirectSPIInterface use the board defaults.
+			  uint8_t sck = 255,
+			  uint8_t miso = 255,
+			  uint8_t mosi = 255) {
 			  return interfaceManager.directSPIInterface().get(
-				  SPI,
-				  SPISettings(clockFreq, bitOrder, dataMode)
+				  &SPI,
+				  SPISettings(clockFreq, bitOrder, dataMode),
+				  sck,
+				  miso,
+				  mosi
 			  );
 		  };
 

--- a/src/sensors/SensorBuilder.cpp
+++ b/src/sensors/SensorBuilder.cpp
@@ -53,23 +53,18 @@ uint8_t SensorBuilder::buildAllSensors() {
 		= [&](uint8_t scl, uint8_t sda, uint8_t addr, uint8_t ch) {
 			  return interfaceManager.pcaWireInterface().get(scl, sda, addr, ch);
 		  };
-	[[maybe_unused]] const auto DIRECT_SPI
-		= [&](uint32_t clockFreq,
-			  uint8_t bitOrder,
-			  uint8_t dataMode,
-			  // Default to 255 to allow DIRECT_SPI() to be called without
-			  // explicit pins, making DirectSPIInterface use the board defaults.
-			  uint8_t sck = 255,
-			  uint8_t miso = 255,
-			  uint8_t mosi = 255) {
-			  return interfaceManager.directSPIInterface().get(
-				  &SPI,
-				  SPISettings(clockFreq, bitOrder, dataMode),
-				  sck,
-				  miso,
-				  mosi
-			  );
-		  };
+	[[maybe_unused]] const auto DIRECT_SPI =
+		[&](uint32_t clockFreq,
+			uint8_t bitOrder,
+			uint8_t dataMode,
+			// Default to 255 to allow DIRECT_SPI() to be called without
+			// explicit pins, making DirectSPIInterface use the board defaults.
+			uint8_t sck = 255,
+			uint8_t miso = 255,
+			uint8_t mosi = 255) {
+			return interfaceManager.directSPIInterface()
+				.get(&SPI, SPISettings(clockFreq, bitOrder, dataMode), sck, miso, mosi);
+		};
 
 	// Apply descriptor list and expand to entries
 	SENSOR_DESC_LIST


### PR DESCRIPTION
# PR Summary
This PR adds configurable pins for the shared SPI bus:

- `PIN_IMU_SCK`
- `PIN_IMU_MISO`
- `PIN_IMU_MOSI`

The shared SPI bus configuration is integrated into:

- `board-defaults.schema.json`
- `board-defaults.json`
- `scripts/preprocessor.py`
- `DirectSPIInterface`

Chip select remains configured separately for each sensor through `PinInterface`.

## Platform behavior

- On ESP32, configured pins are passed to `SPIClass::begin(sck, miso, mosi)`.
- On ESP8266, the supported pin set is selected through `SPIClass::pins()`.
- If SPI bus pins are not configured, the existing parameterless `SPI.begin()` behavior is preserved.
- ESP8266 hardware CS is disabled after initialization because CS is managed separately for each sensor.

## Testing

Tested locally with:

- ESP32-C3 and LSM6DSV over SPI
- Custom SCK, MISO and MOSI pins
- ESP8266 build compatibility (Not tested on real chips)

## LLM usage

DeepSeek and ChatGPT were used only for debugging assistance and translating commit messages.

Related to #537