### PR TITLE
Feat rebootrecovery

### DIFF
--- a/src/configuration/Configuration.cpp
+++ b/src/configuration/Configuration.cpp
@@ -29,9 +29,14 @@
 #include <cstring>
 
 #include "../FSHelper.h"
+#include "GlobalVars.h"
 #include "consts.h"
 #include "sensors/SensorToggles.h"
 #include "utils.h"
+
+#ifdef ESP32
+#include "nvs_flash.h"
+#endif
 
 #define DIR_CALIBRATIONS "/calibrations"
 #define DIR_TEMPERATURE_CALIBRATIONS "/tempcalibrations"
@@ -104,6 +109,33 @@ void Configuration::setup() {
 
 #ifdef DEBUG_CONFIGURATION
 	print();
+#endif
+}
+
+void Configuration::factoryReset() {
+	this->reset();
+	this->wifiReset();
+	this->m_Logger.info("Rebooting...");
+	delay(3000);
+	ESP.restart();
+}
+
+void Configuration::wifiReset() {
+	WiFi.disconnect(true);  // Clear WiFi credentials
+#if ESP8266
+	ESP.eraseConfig();  // Clear ESP config
+#elif defined(ESP32)
+	nvs_flash_erase();
+#else
+#warning SERIAL COMMAND FACTORY RESET NOT SUPPORTED
+	this->m_Logger.info(PSTR("FACTORY RESET NOT SUPPORTED"));
+	return;
+#endif
+#if defined(WIFI_CREDS_SSID) && defined(WIFI_CREDS_PASSWD)
+#warning FACTORY RESET does not clear your hardcoded WiFi credentials!
+	this->m_Logger.warn(
+		PSTR("FACTORY RESET does not clear your hardcoded WiFi credentials!")
+	);
 #endif
 }
 

--- a/src/configuration/Configuration.cpp
+++ b/src/configuration/Configuration.cpp
@@ -43,10 +43,25 @@
 #define DIR_TOGGLES_OLD "/toggles"
 #define DIR_TOGGLES "/sensortoggles"
 
+extern bool initFullreset;
+
 namespace SlimeVR::Configuration {
 void Configuration::setup() {
 	if (m_Loaded) {
 		return;
+	}
+
+	if (initFullreset) {
+		this->m_Logger.info(
+			PSTR("Request for Factory reset from Recovery Mode received.")
+		);
+		if (LittleFS.begin()) {
+			this->factoryReset();
+		} else {
+			this->m_Logger.error(PSTR("Could not mount LittleFS try to format it"));
+			LittleFS.format();
+			this->factoryReset();
+		}
 	}
 
 	bool status = LittleFS.begin();

--- a/src/configuration/Configuration.h
+++ b/src/configuration/Configuration.h
@@ -35,6 +35,8 @@ namespace SlimeVR::Configuration {
 class Configuration {
 public:
 	void setup();
+	void factoryReset();
+	void wifiReset();
 
 	void save();
 	void reset();

--- a/src/consts.h
+++ b/src/consts.h
@@ -102,6 +102,37 @@ enum class SensorTypeID : uint8_t {
 #define BOARD_ESP32C6_SUPERMINI 27
 #define BOARD_DEV_RESERVED 250  // Reserved, should not be used in any release firmware
 
+#define BOARD_N0 "BOARD_UNKNOWN"
+#define BOARD_N1 "BOARD_SLIMEVR_LEGACY"  // More ancient development version of SlimeVR
+#define BOARD_N2 "BOARD_SLIMEVR_DEV"  // Ancient development version of SlimeVR
+#define BOARD_N3 "BOARD_NODEMCU"
+#define BOARD_N4 "BOARD_CUSTOM"
+#define BOARD_N5 "BOARD_WROOM32"
+#define BOARD_N6 "BOARD_WEMOSD1MINI"
+#define BOARD_N7 "BOARD_TTGO_TBASE"
+#define BOARD_N8 "BOARD_ESP01"
+#define BOARD_N9 "BOARD_SLIMEVR"  // SlimeVR v1.0 & v1.1
+#define BOARD_N10 "BOARD_LOLIN_C3_MINI"
+#define BOARD_N11 "BOARD_BEETLE32C3"
+#define BOARD_N12 "BOARD_ESP32C3DEVKITM1"
+#define BOARD_N13 "BOARD_OWOTRACK"  // Only used by owoTrack mobile app
+#define BOARD_N14 "BOARD_WRANGLER"  // Only used by wrangler app
+#define BOARD_N15 "BOARD_MOCOPI"  // Used by mocopi/moslime
+#define BOARD_N16 "BOARD_WEMOSWROOM02"
+#define BOARD_N17 "BOARD_XIAO_ESP32C3"
+#define BOARD_N18 "BOARD_HARITORA"  // Used by Haritora/SlimeTora
+#define BOARD_N19 "BOARD_ESP32C6DEVKITC1"
+#define BOARD_N20 "BOARD_GLOVE_IMU_SLIMEVR_DEV"  // IMU Glove
+#define BOARD_N21 "BOARD_GESTURES"  // Used by Gestures
+#define BOARD_N22 "BOARD_SLIMEVR_V1_2"  // SlimeVR v1.2
+#define BOARD_N23 "BOARD_ESP32S3_SUPERMINI"
+#define BOARD_N24 "BOARD_GENERIC_NRF"
+#define BOARD_N25 "BOARD_SLIMEVR_BUTTERFLY_DEV"
+#define BOARD_N26 "BOARD_SLIMEVR_BUTTERFLY"
+#define BOARD_N27 "BOARD_ESP32C6_SUPERMINI"
+#define BOARD_N250 \
+	"BOARD_DEV_RESERVED"  // Reserved, should not be used in any release firmware
+
 #define BAT_EXTERNAL 1
 #define BAT_INTERNAL 2
 #define BAT_MCP3021 3

--- a/src/globals.h
+++ b/src/globals.h
@@ -76,3 +76,39 @@
 #ifndef UPDATE_NAME
 #define UPDATE_NAME ""
 #endif
+
+// Some Compiler magic to expand the define and the escpae it
+#define STRINGIFY(s) #s
+#define TOSTRING(s) STRINGIFY(s)
+
+// Some Compiler magic to combine defines together
+// Target is to from BOARD -> 6 to BOARD_N6 to resolve the boardname
+#define BOARD_CONSTRING(a, b) a##b
+#define BOARD_TOSTRING(a, b) BOARD_CONSTRING(a, b)
+#define BOARDNTOSTR(a) BOARD_TOSTRING(BOARD_N, a)
+
+// Formating does wired stuff here so disabled
+// clang-format off
+static const char sSlVRPrInfo[] PROGMEM
+	= "============= Product Info =============\r\n"
+	  "PRODUCT_NAME: " PRODUCT_NAME "\r\n"
+	  "VENDOR_NAME: " VENDOR_NAME "\r\n"
+	  "VENDOR_URL: " VENDOR_URL "\r\n"
+	  "Firmware update URL: " UPDATE_ADDRESS "\r\n"
+	  "Firmware update Name: " UPDATE_NAME "\r\n"
+	  "BOARD: " TOSTRING(BOARD) "\r\n"
+	  "BOARD NAME: " BOARDNTOSTR(BOARD) "\r\n"
+	  "HARDWARE_MCU: " TOSTRING(HARDWARE_MCU) "\r\n"
+	  "PROTOCOL_VERSION: " TOSTRING(PROTOCOL_VERSION) "\r\n"
+	  "FIRMWARE_VERSION: " TOSTRING(FIRMWARE_VERSION) "\r\n"
+	  "LED_PIN: " TOSTRING(LED_PIN) "\r\n"
+	  "LED_INVERTED: " TOSTRING(LED_INVERTED) "\r\n"
+	  "PIN_BATTERY_LEVEL: " TOSTRING(PIN_BATTERY_LEVEL) "\r\n"
+	  "BATTERY_MONITOR: " TOSTRING(BATTERY_MONITOR) "\r\n"
+	  "BATTERY_SHIELD_RESISTANCE: " TOSTRING(BATTERY_SHIELD_RESISTANCE) "\r\n"
+	  "BATTERY_SHIELD_R1: " TOSTRING(BATTERY_SHIELD_R1) "\r\n"
+	  "BATTERY_SHIELD_R2: " TOSTRING(BATTERY_SHIELD_R2) "\r\n"
+	  "SENSOR_DESC_LIST:\r\n"
+	  TOSTRING(SENSOR_DESC_LIST) "\r\n"
+	  "========================================\r\n";
+// clang-format on

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -32,6 +32,7 @@
 #include "logging/Logger.h"
 #include "logging/SerialBuffer.h"
 #include "ota.h"
+#include "preinit.h"
 #include "serial/serialcommands.h"
 #include "status/TPSCounter.h"
 

--- a/src/preinit.h
+++ b/src/preinit.h
@@ -1,0 +1,340 @@
+/*
+	SlimeVR Code is placed under the MIT license
+	Copyright (c) 2026 unlogisch04 & SlimeVR contributors
+
+	Permission is hereby granted, free of charge, to any person obtaining a copy
+	of this software and associated documentation files (the "Software"), to deal
+	in the Software without restriction, including without limitation the rights
+	to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+	copies of the Software, and to permit persons to whom the Software is
+	furnished to do so, subject to the following conditions:
+
+	The above copyright notice and this permission notice shall be included in
+	all copies or substantial portions of the Software.
+
+	THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+	IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+	FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+	AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+	LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+	OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+	THE SOFTWARE.
+*/
+
+// #include "globals.h"
+#include <Arduino.h>
+
+#if defined(CONFIG_IDF_TARGET_ESP32C3)
+#include "soc/rtc_cntl_reg.h"
+#endif
+
+#define PREINIT_CONSOLEMAXLENGTH 30
+
+static const char conshelptxt[] PROGMEM
+	= "Avaiable Commands\r\n"
+	  "HELP          - Prints this dialog\r\n"
+	  "SET FLASHMODE - Sets the tracker into flashmode\r\n"
+	  "FRST          - Factory reset\r\n"
+	  "REBOOT        - Reboots the tracker into normal mode\r\n"
+	  "CONTINUE      - Continue to normal mode\r\n";
+
+static const char consinittxt[] PROGMEM
+	= "\r\n===== Recovery Console =====\r\n"
+	  "The tracker rebootet due to a crash\r\n"
+	  "With the recovery console you're able to do some basic recovery operations.\r\n";
+
+static const char consflashmode[] PROGMEM
+	= "Entering flashing mode.\r\n"
+	  "You can now close the serial monitor\r\n"
+	  "and go to the firmware flasher to flash\r\n"
+	  "your tracker over USB.\r\n"
+	  "If you entered the flashing mode by accident,\r\n"
+	  "turn your tracker off and on.";
+
+static const char consfrst[] PROGMEM = "Init Factory Reset\r\n";
+
+static const char consnormal[] PROGMEM = "Continue to normal mode\r\n";
+
+static const char consna[] PROGMEM = "Error: Unknown command";
+
+static const char consnimpl[] PROGMEM = "Error: Command is not implemented";
+
+static const char constrlong[] PROGMEM = "Error: Too long input string";
+
+bool initFullreset = false;
+
+// Functions that need to be writen to the HW Layer
+#if ESP8266
+bool preinit_detectconsole() {
+	rst_info* rstreason = ESP.getResetInfoPtr();
+	// false: continue boot true: recovery console
+	return (
+		rstreason->reason == REASON_WDT_RST || rstreason->reason == REASON_EXCEPTION_RST
+		|| rstreason->reason == REASON_SOFT_WDT_RST
+	);
+}
+
+int8_t preinit_reboot() {
+	// ESP.restart()) is asynchronous, this does not work at this point for ESP8266
+	ESP.reset();
+	return 1;
+}
+
+int8_t preinit_frst() { return 3; }
+
+int8_t preinit_flashmode() {
+	ESP.rebootIntoUartDownloadMode();
+	return 1;
+}
+#else
+bool preinit_detectconsole() {
+	esp_reset_reason_t rstreason = esp_reset_reason();
+	// false: continue boot true: recovery console
+	return (
+		rstreason == ESP_RST_PANIC || rstreason == ESP_RST_INT_WDT
+		|| rstreason == ESP_RST_TASK_WDT || rstreason == ESP_RST_WDT
+		|| rstreason == ESP_RST_CPU_LOCKUP
+	);
+}
+
+int8_t preinit_reboot() {
+	ESP.restart();
+	return 1;
+}
+
+int8_t preinit_frst() { return 3; }
+
+int8_t preinit_flashmode() {
+	// It seems that the different ESP Chips have differnt Registerf if they even
+	// avaliable.
+	// On ESP Chip with a direct USB Interface the Flashmode is not as importandt, only
+	// that it is not rebooting all the time and makes it hard to set it into download
+	// mode over USB
+#ifdef CONFIG_IDF_TARGET_ESP32C3
+	// from https://esp32.com/viewtopic.php?t=33180
+	REG_WRITE(RTC_CNTL_OPTION1_REG, RTC_CNTL_FORCE_DOWNLOAD_BOOT);
+	esp_restart();
+	return 1;
+#else
+	return -2;
+#endif
+}
+
+#endif
+
+void printSlimeVRConfig(Stream& Serial) { Serial.printf(sSlVRPrInfo); }
+
+// not HW depending functions
+int8_t preinit_select(String& cmd, Stream& Serial) {
+	int8_t ret = -1;
+	cmd.toUpperCase();
+	Serial.printf("Command: %s\r\n", cmd.c_str());
+	if (cmd.startsWith(F("HELP"))) {
+		Serial.println(conshelptxt);
+		ret = 1;
+	} else if (cmd.startsWith("SET FLASHMODE")) {
+		Serial.println(consflashmode);
+		ret = preinit_flashmode();
+	} else if (cmd.startsWith("FRST")) {
+		Serial.println(consfrst);
+		ret = preinit_frst();
+	} else if (cmd.startsWith("REBOOT")) {
+		ret = preinit_reboot();
+	} else if (cmd.startsWith("CONTINUE")) {
+		ret = 2;
+	}
+	return ret;
+}
+
+void preinit_console(Stream& Serial) {
+	Serial.println(consinittxt);
+	Serial.println(conshelptxt);
+
+	String cmdbuffer;
+
+	while (1) {
+		if (Serial.available()) {
+			int ichr = Serial.read();
+			if (ichr < 0 || ichr > 255) {
+				// not valid char
+				continue;
+			}
+			char chr = (char)ichr;
+			if (chr == '\r') {
+				continue;
+			}
+			if (chr == '\n') {
+				int8_t i = preinit_select(cmdbuffer, Serial);
+				switch (i) {
+					case -2:
+						// Command not implemented (valid command but it does not exist)
+						Serial.println(consnimpl);
+						break;
+					case -1:
+						// Command not found
+						Serial.println(consna);
+						Serial.println(conshelptxt);
+						break;
+					case 2:
+						// Command requets to go to normal mode
+						Serial.println(consnormal);
+						return;
+					case 3:
+						// Command requests a factory reset
+						initFullreset = true;
+						return;
+					default:
+						// No action
+						break;
+				}
+				cmdbuffer = "";
+			} else {
+				cmdbuffer += chr;
+				if (cmdbuffer.length() > PREINIT_CONSOLEMAXLENGTH) {
+					cmdbuffer = "";
+					Serial.println(constrlong);
+					Serial.println(conshelptxt);
+				}
+			}
+		}
+#ifdef ESP8266
+		ESP.wdtFeed();
+#endif
+		delay(1);
+	}
+}
+
+// Register the Framework functions call that are called before
+// the c++ constructor
+#ifdef ESP8266
+#include <user_interface.h>
+extern "C" void preinit(void) {
+	rst_info* rstreason = ESP.getResetInfoPtr();
+	if (rstreason->reason == REASON_DEEP_SLEEP_AWAKE) {
+		// Even if currently there is no deep sleep implemented skip for faster wakeup
+		return;
+	}
+	HardwareSerial Serial(0);
+
+	Serial.begin(115200);
+	Serial.println();
+	Serial.println();
+	Serial.println(F("==== SlimeVR Tracker ESP Booting ===="));
+	Serial.printf_P(PSTR("getBootVersion(): %d"), ESP.getBootVersion());
+	Serial.println();
+	Serial.printf_P(PSTR("Arduino Core Version: %s"), ESP.getCoreVersion().c_str());
+	Serial.println();
+	Serial.printf_P(PSTR("FullVersion: %s"), ESP.getFullVersion().c_str());
+	Serial.println();
+	Serial.printf_P(PSTR("Core Frequency: %d MHz"), ESP.getCpuFreqMHz());
+	Serial.println();
+	Serial.printf_P(
+		PSTR("Checking FlashCRC: %s"),
+		ESP.checkFlashCRC() ? F("OK") : F("Failed")
+	);
+	Serial.println();
+	// MD5 takes quit a while to calculate maybe not make it?
+	Serial.printf_P(PSTR("Sketch MD5: %s"), ESP.getSketchMD5().c_str());
+	Serial.println();
+	Serial.printf_P(PSTR("Reset reason: %s"), ESP.getResetInfo().c_str());
+	Serial.println();
+	Serial.printf_P(PSTR("Flash VendorId: %d"), ESP.getFlashChipVendorId());
+	Serial.println();
+	Serial.printf_P(PSTR("Flash size: %d"), ESP.getFlashChipSize());
+	Serial.println();
+	Serial.printf_P(PSTR("Flash size real: %d"), ESP.getFlashChipRealSize());
+	Serial.println();
+	Serial.printf_P(PSTR("Flash size by ChipId: %d"), ESP.getFlashChipSizeByChipId());
+	Serial.println();
+	Serial.println();
+
+	printSlimeVRConfig(Serial);
+	delay(1);
+
+	if (preinit_detectconsole()) {
+		preinit_console(Serial);
+	}
+
+	Serial.flush();
+	Serial.end();
+}
+#elif defined(ESP32)
+// On ESP32 the best place to inject code seems to be init() as it is not used and
+// defined as weak
+// it runs before initVariant(void) wich is a place for board variant code to initialize
+
+const char* init_resetreason(esp_reset_reason_t rstreason) {
+	switch (rstreason) {
+		case ESP_RST_UNKNOWN:
+			return "ESP_RST_UNKNOWN";
+		case ESP_RST_POWERON:
+			return "ESP_RST_POWERON";
+		case ESP_RST_EXT:
+			return "ESP_RST_EXT";
+		case ESP_RST_SW:
+			return "ESP_RST_SW";
+		case ESP_RST_PANIC:
+			return "ESP_RST_PANIC";
+		case ESP_RST_INT_WDT:
+			return "ESP_RST_INT_WDT";
+		case ESP_RST_TASK_WDT:
+			return "ESP_RST_TASK_WDT";
+		case ESP_RST_WDT:
+			return "ESP_RST_WDT";
+		case ESP_RST_DEEPSLEEP:
+			return "ESP_RST_DEEPSLEEP";
+		case ESP_RST_BROWNOUT:
+			return "ESP_RST_BROWNOUT";
+		case ESP_RST_SDIO:
+			return "ESP_RST_SDIO";
+		case ESP_RST_USB:
+			return "ESP_RST_USB";
+		case ESP_RST_JTAG:
+			return "ESP_RST_JTAG";
+		case ESP_RST_EFUSE:
+			return "ESP_RST_EFUSE";
+		case ESP_RST_PWR_GLITCH:
+			return "ESP_RST_PWR_GLITCH";
+		case ESP_RST_CPU_LOCKUP:
+			return "ESP_RST_CPU_LOCKUP";
+		default:
+			return "UNKNOWN";
+	}
+}
+
+extern "C" void init(void) {
+	esp_reset_reason_t rstreason = esp_reset_reason();
+	if (rstreason == ESP_RST_DEEPSLEEP) {
+		// Even if currently there is no deep sleep implemented skip for faster wakeup
+		return;
+	}
+
+	Serial.begin(115200);
+	Serial.println();
+	Serial.println();
+	Serial.println(F("==== SlimeVR Tracker ESP Booting ===="));
+	Serial.printf_P(PSTR("Arduino Core Version: %s"), ESP.getCoreVersion());
+	Serial.println();
+	Serial.printf_P(PSTR("MCU: %s"), ESP.getChipModel());
+	Serial.println();
+	Serial.printf_P(PSTR("Core Frequency: %d MHz"), ESP.getCpuFreqMHz());
+	Serial.println();
+	// MD5 takes quit a while to calculate maybe not make it?
+	Serial.printf_P(PSTR("Sketch MD5: %s"), ESP.getSketchMD5().c_str());
+	Serial.println();
+	Serial.printf_P(PSTR("Reset reason: %s"), init_resetreason(rstreason));
+	Serial.println();
+	Serial.printf_P(PSTR("Flash VendorId: %d"), ESP.getChipModel());
+	Serial.println();
+	Serial.printf_P(PSTR("Flash size: %d"), ESP.getFlashChipSize());
+	Serial.println();
+	Serial.println();
+
+	printSlimeVRConfig(Serial);
+	delay(1);
+
+	if (preinit_detectconsole()) {
+		preinit_console(Serial);
+	}
+}
+#endif

--- a/src/serial/serialcommands.cpp
+++ b/src/serial/serialcommands.cpp
@@ -374,27 +374,8 @@ void cmdReboot(CmdParser* parser) {
 
 void cmdFactoryReset(CmdParser* parser) {
 	logger.info("FACTORY RESET");
-
-	configuration.reset();
-
-	WiFi.disconnect(true);  // Clear WiFi credentials
-#if ESP8266
-	ESP.eraseConfig();  // Clear ESP config
-#elif defined(ESP32)
-	nvs_flash_erase();
-#else
-#warning SERIAL COMMAND FACTORY RESET NOT SUPPORTED
-	logger.info("FACTORY RESET NOT SUPPORTED");
-	return;
-#endif
-
-#if defined(WIFI_CREDS_SSID) && defined(WIFI_CREDS_PASSWD)
-#warning FACTORY RESET does not clear your hardcoded WiFi credentials!
-	logger.warn("FACTORY RESET does not clear your hardcoded WiFi credentials!");
-#endif
-
-	delay(3000);
-	ESP.restart();
+	configuration.factoryReset();
+	// No return here factoryReset will reboot the tracker.
 }
 
 void cmdTemperatureCalibration(CmdParser* parser) {

--- a/src/serial/serialcommands.cpp
+++ b/src/serial/serialcommands.cpp
@@ -31,8 +31,8 @@
 #include "logging/Logger.h"
 #include "utils.h"
 
-#ifdef ESP32
-#include "nvs_flash.h"
+#if defined(CONFIG_IDF_TARGET_ESP32C3)
+#include "soc/rtc_cntl_reg.h"
 #endif
 
 #ifdef EXT_SERIAL_COMMANDS
@@ -58,6 +58,14 @@ constexpr const char* FULL_VENDOR_STR
 #else
 constexpr const char* FULL_VENDOR_STR = "Vendor: Unknown, product: Unknown";
 #endif
+
+static const char sCMDFlashmdoe[] PROGMEM
+	= "Entering flashing mode.\r\n"
+	  "You can now close the serial monitor\r\n"
+	  "and go to the firmware flasher to flash\r\n"
+	  "your tracker over USB.\r\n"
+	  "If you entered the flashing mode by accident,\r\n"
+	  "turn your tracker off and on.";
 
 namespace SerialCommands {
 SlimeVR::Logging::Logger logger("SerialCommands");
@@ -158,6 +166,20 @@ void cmdSet(CmdParser* parser) {
 				wifiNetwork.setWiFiCredentials(ssid, ppass);
 				logger.info("CMD SET BWIFI OK: New wifi credentials set, reconnecting");
 			}
+		} else if (parser->equalCmdParam(1, "FLASHMODE")) {
+#if ESP8266
+			logger.info(sCMDFlashmdoe);
+			delay(1000);
+			ESP.rebootIntoUartDownloadMode();
+#elif defined(CONFIG_IDF_TARGET_ESP32C3)
+			logger.info(sCMDFlashmdoe);
+			delay(1000);
+			// from https://esp32.com/viewtopic.php?t=33180
+			REG_WRITE(RTC_CNTL_OPTION1_REG, RTC_CNTL_FORCE_DOWNLOAD_BOOT);
+			esp_restart();
+#else
+			logger.error(PSTR("Flashmode is not supported on this device"));
+#endif
 #if EXT_SERIAL_COMMANDS
 		} else if (parser->equalCmdParam(1, "CRASH")) {
 			// well target of this function is to crash the tracker

--- a/src/serial/serialcommands.cpp
+++ b/src/serial/serialcommands.cpp
@@ -258,43 +258,7 @@ void cmdGet(CmdParser* parser) {
 	}
 
 	if (parser->equalCmdParam(1, "CONFIG")) {
-		String str
-			= "BOARD=%d\n"
-			  "IMU=%d\n"
-			  "SECOND_IMU=%d\n"
-			  "IMU_ROTATION=%f\n"
-			  "SECOND_IMU_ROTATION=%f\n"
-			  "BATTERY_MONITOR=%d\n"
-			  "BATTERY_SHIELD_RESISTANCE=%d\n"
-			  "BATTERY_SHIELD_R1=%d\n"
-			  "BATTERY_SHIELD_R2=%d\n"
-			  "PIN_IMU_SDA=%d\n"
-			  "PIN_IMU_SCL=%d\n"
-			  "PIN_IMU_INT=%d\n"
-			  "PIN_IMU_INT_2=%d\n"
-			  "PIN_BATTERY_LEVEL=%d\n"
-			  "LED_PIN=%d\n"
-			  "LED_INVERTED=%d\n";
-
-		Serial.printf(
-			str.c_str(),
-			BOARD,
-			static_cast<int>(sensorManager.getSensorType(0)),
-			static_cast<int>(sensorManager.getSensorType(1)),
-			IMU_ROTATION,
-			SECOND_IMU_ROTATION,
-			BATTERY_MONITOR,
-			BATTERY_SHIELD_RESISTANCE,
-			BATTERY_SHIELD_R1,
-			BATTERY_SHIELD_R2,
-			PIN_IMU_SDA,
-			PIN_IMU_SCL,
-			PIN_IMU_INT,
-			PIN_IMU_INT_2,
-			PIN_BATTERY_LEVEL,
-			LED_PIN,
-			LED_INVERTED
-		);
+		Serial.printf(sSlVRPrInfo);
 	}
 
 	if (parser->equalCmdParam(1, "TEST")) {

--- a/src/serial/serialcommands.cpp
+++ b/src/serial/serialcommands.cpp
@@ -158,6 +158,15 @@ void cmdSet(CmdParser* parser) {
 				wifiNetwork.setWiFiCredentials(ssid, ppass);
 				logger.info("CMD SET BWIFI OK: New wifi credentials set, reconnecting");
 			}
+#if EXT_SERIAL_COMMANDS
+		} else if (parser->equalCmdParam(1, "CRASH")) {
+			// well target of this function is to crash the tracker
+			// used for debuging/testing
+			while (true) {
+				int* ptr = NULL;
+				*ptr = 0;
+			}
+#endif
 		} else {
 			logger.error("CMD SET ERROR: Unrecognized variable to set");
 		}


### PR DESCRIPTION
This adds a early detection if the firmware did crash.
If it is it presents a serial console with some recovery options.
Target is, if the firmware crashes for some reason like config file errors,...
the use is still able to reset the config over the Serial Console or to set it into UART Flash mode (ESP8266 and ESP32-C3)
While on ESP8266 DevBoards this has no use. On the Official Slime HW it can help to reduce the need to open trackers.

pls dont squash this one